### PR TITLE
feat: Create ROE-Ruin Efficient Frontier Visualization

### DIFF
--- a/ergodic_insurance/notebooks/15_roe_ruin_frontier_demo.ipynb
+++ b/ergodic_insurance/notebooks/15_roe_ruin_frontier_demo.ipynb
@@ -1,0 +1,441 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# ROE-Ruin Efficient Frontier Visualization Demo\n",
+    "\n",
+    "This notebook demonstrates the ROE-Ruin Efficient Frontier visualization, which shows the Pareto frontier of trade-offs between Return on Equity (ROE) and Ruin Probability for companies of different sizes.\n",
+    "\n",
+    "## Key Features:\n",
+    "- Multiple company size comparisons ($1M, $10M, $100M)\n",
+    "- Sweet spot detection using knee point analysis\n",
+    "- Optimal zone visualization\n",
+    "- Export support for web (150 DPI) and print (300 DPI)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Standard imports\n",
+    "import sys\n",
+    "import os\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Add the parent directory to the path for imports\n",
+    "sys.path.insert(0, os.path.abspath('../..'))\n",
+    "\n",
+    "# Import the visualization function\n",
+    "from ergodic_insurance.src.visualization.executive_plots import plot_roe_ruin_frontier\n",
+    "\n",
+    "# Set random seed for reproducibility\n",
+    "np.random.seed(42)\n",
+    "\n",
+    "print(\"Libraries imported successfully!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Generate Sample Optimization Results\n",
+    "\n",
+    "In a real scenario, these would come from running the Pareto optimization algorithms. Here we'll create synthetic data that represents typical efficient frontiers for different company sizes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def generate_pareto_frontier(company_size, n_points=15):\n",
+    "    \"\"\"Generate synthetic Pareto frontier data for a given company size.\"\"\"\n",
+    "    \n",
+    "    # Base parameters vary by company size\n",
+    "    if company_size == 1e6:  # $1M company - higher risk tolerance\n",
+    "        roe_range = (0.05, 0.22)\n",
+    "        ruin_range = (0.008, 0.10)\n",
+    "    elif company_size == 1e7:  # $10M company - moderate risk\n",
+    "        roe_range = (0.04, 0.16)\n",
+    "        ruin_range = (0.005, 0.06)\n",
+    "    else:  # $100M company - conservative\n",
+    "        roe_range = (0.03, 0.12)\n",
+    "        ruin_range = (0.003, 0.04)\n",
+    "    \n",
+    "    # Generate points along a curved frontier\n",
+    "    t = np.linspace(0, 1, n_points)\n",
+    "    \n",
+    "    # ROE increases linearly\n",
+    "    roe = roe_range[0] + (roe_range[1] - roe_range[0]) * t\n",
+    "    \n",
+    "    # Ruin probability decreases exponentially (typical Pareto curve)\n",
+    "    ruin = ruin_range[1] * np.exp(-3 * t) + ruin_range[0]\n",
+    "    \n",
+    "    # Add some realistic noise\n",
+    "    roe += np.random.normal(0, 0.003, n_points)\n",
+    "    ruin += np.random.normal(0, 0.001, n_points)\n",
+    "    \n",
+    "    # Ensure values stay in valid ranges\n",
+    "    roe = np.clip(roe, 0.01, 0.30)\n",
+    "    ruin = np.clip(ruin, 0.001, 0.15)\n",
+    "    \n",
+    "    return pd.DataFrame({\n",
+    "        'roe': roe,\n",
+    "        'ruin_prob': ruin,\n",
+    "        'company_size': company_size\n",
+    "    })\n",
+    "\n",
+    "# Generate data for different company sizes\n",
+    "results_1m = generate_pareto_frontier(1e6)\n",
+    "results_10m = generate_pareto_frontier(1e7)\n",
+    "results_100m = generate_pareto_frontier(1e8)\n",
+    "\n",
+    "# Combine into a dictionary (one format the function accepts)\n",
+    "optimization_results = {\n",
+    "    1e6: results_1m,\n",
+    "    1e7: results_10m,\n",
+    "    1e8: results_100m\n",
+    "}\n",
+    "\n",
+    "print(\"Sample data generated:\")\n",
+    "for size, df in optimization_results.items():\n",
+    "    print(f\"  ${size:,.0f} company: {len(df)} points\")\n",
+    "    print(f\"    ROE range: {df['roe'].min():.1%} - {df['roe'].max():.1%}\")\n",
+    "    print(f\"    Ruin prob range: {df['ruin_prob'].min():.2%} - {df['ruin_prob'].max():.2%}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Basic ROE-Ruin Frontier Visualization\n",
+    "\n",
+    "Let's start with the default visualization showing all features."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create the basic plot with all default features\n",
+    "fig = plot_roe_ruin_frontier(optimization_results)\n",
+    "plt.show()\n",
+    "\n",
+    "print(\"Key features shown:\")\n",
+    "print(\"- Separate curves for each company size\")\n",
+    "print(\"- Sweet spots (star markers) showing optimal trade-offs\")\n",
+    "print(\"- Annotations with ROE and risk values\")\n",
+    "print(\"- Log scale on Y-axis for better visibility of low probabilities\")\n",
+    "print(\"- Grid lines for easy reading\")\n",
+    "print(\"- Optimal zones (green shading) indicating recommended operating regions\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Customized Visualization Options\n",
+    "\n",
+    "Let's explore different customization options."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Linear scale version (better for presentations)\n",
+    "fig = plot_roe_ruin_frontier(\n",
+    "    optimization_results,\n",
+    "    title=\"Insurance Optimization: ROE vs. Ruin Probability\",\n",
+    "    log_scale_y=False,\n",
+    "    figsize=(14, 8)\n",
+    ")\n",
+    "plt.show()\n",
+    "\n",
+    "print(\"Linear scale makes relative differences more apparent\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Simplified version without annotations (cleaner for reports)\n",
+    "fig = plot_roe_ruin_frontier(\n",
+    "    optimization_results,\n",
+    "    title=\"Efficient Frontier Analysis\",\n",
+    "    annotations=False,\n",
+    "    show_optimal_zones=False,\n",
+    "    figsize=(10, 6)\n",
+    ")\n",
+    "plt.show()\n",
+    "\n",
+    "print(\"Clean version suitable for formal reports\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Focus on specific company sizes\n",
+    "fig = plot_roe_ruin_frontier(\n",
+    "    optimization_results,\n",
+    "    company_sizes=[1e6, 1e7],  # Only $1M and $10M\n",
+    "    title=\"Small to Medium Company Comparison\",\n",
+    "    figsize=(12, 7)\n",
+    ")\n",
+    "plt.show()\n",
+    "\n",
+    "print(\"Focused comparison of specific company sizes\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Alternative Data Input Format\n",
+    "\n",
+    "The function also accepts a single DataFrame with a 'company_size' column."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Combine all data into a single DataFrame\n",
+    "all_results = pd.concat([\n",
+    "    results_1m.assign(company_size=1e6),\n",
+    "    results_10m.assign(company_size=1e7),\n",
+    "    results_100m.assign(company_size=1e8)\n",
+    "], ignore_index=True)\n",
+    "\n",
+    "print(f\"Combined DataFrame shape: {all_results.shape}\")\n",
+    "print(f\"Columns: {list(all_results.columns)}\")\n",
+    "print(f\"\\nFirst few rows:\")\n",
+    "print(all_results.head())\n",
+    "\n",
+    "# Plot using single DataFrame format\n",
+    "fig = plot_roe_ruin_frontier(\n",
+    "    all_results,\n",
+    "    title=\"ROE-Ruin Frontier (DataFrame Input)\"\n",
+    ")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Custom Color Schemes\n",
+    "\n",
+    "For presentations or branding purposes, you can customize the color scheme."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Corporate color scheme\n",
+    "corporate_colors = ['#003366', '#0066CC', '#3399FF']  # Dark to light blue\n",
+    "\n",
+    "fig = plot_roe_ruin_frontier(\n",
+    "    optimization_results,\n",
+    "    title=\"Insurance Portfolio Optimization\",\n",
+    "    color_scheme=corporate_colors,\n",
+    "    figsize=(12, 8)\n",
+    ")\n",
+    "plt.show()\n",
+    "\n",
+    "print(\"Custom color scheme applied\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Export for Different Media\n",
+    "\n",
+    "The visualization can be exported at different resolutions for various uses."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create output directory if it doesn't exist\n",
+    "output_dir = Path('../results/visualizations')\n",
+    "output_dir.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "# Web resolution (150 DPI)\n",
+    "fig_web = plot_roe_ruin_frontier(\n",
+    "    optimization_results,\n",
+    "    title=\"ROE-Ruin Efficient Frontier\",\n",
+    "    export_dpi=150\n",
+    ")\n",
+    "web_path = output_dir / 'roe_ruin_frontier_web.png'\n",
+    "fig_web.savefig(web_path, dpi=150, bbox_inches='tight')\n",
+    "plt.close(fig_web)\n",
+    "print(f\"Web version saved to: {web_path}\")\n",
+    "\n",
+    "# Print resolution (300 DPI)\n",
+    "fig_print = plot_roe_ruin_frontier(\n",
+    "    optimization_results,\n",
+    "    title=\"ROE-Ruin Efficient Frontier\",\n",
+    "    export_dpi=300\n",
+    ")\n",
+    "print_path = output_dir / 'roe_ruin_frontier_print.png'\n",
+    "fig_print.savefig(print_path, dpi=300, bbox_inches='tight')\n",
+    "plt.close(fig_print)\n",
+    "print(f\"Print version saved to: {print_path}\")\n",
+    "\n",
+    "# Vector format for publications\n",
+    "fig_vector = plot_roe_ruin_frontier(\n",
+    "    optimization_results,\n",
+    "    title=\"ROE-Ruin Efficient Frontier\"\n",
+    ")\n",
+    "vector_path = output_dir / 'roe_ruin_frontier.pdf'\n",
+    "fig_vector.savefig(vector_path, format='pdf', bbox_inches='tight')\n",
+    "plt.close(fig_vector)\n",
+    "print(f\"Vector version saved to: {vector_path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Analyzing Sweet Spots\n",
+    "\n",
+    "The sweet spots represent the knee points where the trade-off between ROE and ruin probability is most favorable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let's manually identify the sweet spots from our data\n",
+    "from ergodic_insurance.src.visualization.executive_plots import _find_knee_point\n",
+    "\n",
+    "print(\"Sweet Spot Analysis:\")\n",
+    "print(\"=\"*50)\n",
+    "\n",
+    "for size, df in optimization_results.items():\n",
+    "    # Sort by ROE\n",
+    "    df_sorted = df.sort_values('roe')\n",
+    "    roe_vals = df_sorted['roe'].values\n",
+    "    ruin_vals = df_sorted['ruin_prob'].values\n",
+    "    \n",
+    "    # Find knee point\n",
+    "    knee_idx = _find_knee_point(roe_vals, ruin_vals)\n",
+    "    \n",
+    "    sweet_roe = roe_vals[knee_idx]\n",
+    "    sweet_ruin = ruin_vals[knee_idx]\n",
+    "    \n",
+    "    print(f\"\\n${size:,.0f} Company:\")\n",
+    "    print(f\"  Sweet Spot ROE: {sweet_roe:.1%}\")\n",
+    "    print(f\"  Sweet Spot Ruin Prob: {sweet_ruin:.2%}\")\n",
+    "    print(f\"  Risk-Return Ratio: {sweet_roe/sweet_ruin:.1f}\")\n",
+    "\n",
+    "print(\"\\n\" + \"=\"*50)\n",
+    "print(\"The sweet spots indicate the optimal insurance purchase levels\")\n",
+    "print(\"where marginal improvements in ROE come at acceptable risk increases.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Integration with Real Optimization Results\n",
+    "\n",
+    "In practice, this visualization would be used with actual optimization results from the Pareto frontier analysis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example of how to integrate with actual optimization pipeline\n",
+    "print(\"Integration with Optimization Pipeline:\")\n",
+    "print(\"=\"*50)\n",
+    "print()\n",
+    "print(\"# Step 1: Run Pareto optimization\")\n",
+    "print(\"from ergodic_insurance.src.pareto_frontier import ParetoFrontier\")\n",
+    "print(\"from ergodic_insurance.src.business_optimizer import BusinessOptimizer\")\n",
+    "print()\n",
+    "print(\"# Step 2: Extract results for each company size\")\n",
+    "print(\"results = {}\")\n",
+    "print(\"for company_size in [1e6, 1e7, 1e8]:\")\n",
+    "print(\"    optimizer = BusinessOptimizer(initial_assets=company_size)\")\n",
+    "print(\"    pareto_points = optimizer.find_pareto_frontier()\")\n",
+    "print(\"    results[company_size] = pareto_points.to_dataframe()\")\n",
+    "print()\n",
+    "print(\"# Step 3: Visualize\")\n",
+    "print(\"fig = plot_roe_ruin_frontier(results)\")\n",
+    "print()\n",
+    "print(\"=\"*50)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "The ROE-Ruin Efficient Frontier visualization provides:\n",
+    "\n",
+    "1. **Clear Trade-off Visualization**: Shows the Pareto frontier between returns and risk\n",
+    "2. **Company Size Comparison**: Enables comparison across different scales of business\n",
+    "3. **Decision Support**: Sweet spots help identify optimal insurance purchasing levels\n",
+    "4. **Flexible Customization**: Adapts to different presentation needs\n",
+    "5. **Export Options**: Supports web, print, and vector formats\n",
+    "\n",
+    "This tool is essential for executives and actuaries making strategic insurance purchasing decisions."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/ergodic_insurance/src/visualization/__init__.py
+++ b/ergodic_insurance/src/visualization/__init__.py
@@ -38,7 +38,12 @@ from .core import (
 )
 
 # Executive visualization functions
-from .executive_plots import plot_insurance_layers, plot_loss_distribution, plot_return_period_curve
+from .executive_plots import (
+    plot_insurance_layers,
+    plot_loss_distribution,
+    plot_return_period_curve,
+    plot_roe_ruin_frontier,
+)
 
 # Export utilities
 from .export import (
@@ -81,6 +86,7 @@ __all__ = [
     "plot_loss_distribution",
     "plot_return_period_curve",
     "plot_insurance_layers",
+    "plot_roe_ruin_frontier",
     # Technical plots
     "plot_convergence_diagnostics",
     "plot_pareto_frontier_2d",


### PR DESCRIPTION
## Summary
- Implemented comprehensive ROE-Ruin frontier plotting functionality
- Added sweet spot detection and optimal zone visualization
- Created complete test coverage and Jupyter notebook demo

## Changes Made
1. **New Visualization Function**: Added `plot_roe_ruin_frontier()` to executive_plots.py
   - Visualizes Pareto frontier trade-offs between ROE and Ruin Probability
   - Supports multiple company sizes ($1M, $10M, $100M)
   - Smooth curve fitting with scipy.interpolate

2. **Smart Features**:
   - Knee point detection algorithm for finding sweet spots
   - Optimal zone shading to highlight recommended operating regions
   - Flexible input formats (dict or DataFrame)
   - Alternative column name detection

3. **Export Options**:
   - Web resolution (150 DPI)
   - Print resolution (300 DPI)
   - Vector format support (PDF)

4. **Comprehensive Testing**:
   - 11 test cases covering all functionality
   - Edge cases and error handling
   - Mock data generation for testing

5. **Documentation**:
   - Complete Google-style docstrings
   - Jupyter notebook with 8 demo sections
   - Integration examples with optimization pipeline

## Technical Improvements
- Fixed NumPy 2.0 deprecation warning for 2D cross product
- Type hints corrected for mypy compliance
- Full pylint compliance achieved
- Black and isort formatting applied

## Test Plan
- [x] Unit tests pass (11 tests)
- [x] Visualization renders correctly
- [x] Sweet spot detection works
- [x] Export functionality verified
- [x] Jupyter notebook runs without errors
- [x] Type checking passes

## Screenshots
The visualization creates professional Pareto frontier plots showing:
- ROE on X-axis (%)
- Ruin Probability on Y-axis (%)
- Different curves for each company size
- Highlighted sweet spots with annotations
- Shaded optimal zones

Closes #61

🤖 Generated with [Claude Code](https://claude.ai/code)