### PR TITLE
feat: Implement per-occurrence and aggregate limit types for insurance layers

### DIFF
--- a/ergodic_insurance/insurance_program.py
+++ b/ergodic_insurance/insurance_program.py
@@ -69,13 +69,15 @@ class EnhancedInsuranceLayer:
     """
 
     attachment_point: float  # Where coverage starts
-    limit: float  # Maximum coverage amount per occurrence
+    limit: float  # Maximum coverage amount (interpretation depends on limit_type)
     premium_rate: float  # % of limit as base premium
     reinstatements: int = 0  # Number of reinstatements available
     reinstatement_premium: float = 1.0  # % of original premium per reinstatement
     reinstatement_type: ReinstatementType = ReinstatementType.PRO_RATA
-    aggregate_limit: Optional[float] = None  # Annual aggregate limit if applicable
+    aggregate_limit: Optional[float] = None  # Annual aggregate limit (for aggregate/hybrid types)
     participation_rate: float = 1.0  # % of loss covered by this layer (default 100%)
+    limit_type: str = "per-occurrence"  # Type of limit: "per-occurrence", "aggregate", or "hybrid"
+    per_occurrence_limit: Optional[float] = None  # Per-occurrence limit (for hybrid type)
 
     def __post_init__(self):
         """Validate layer parameters."""
@@ -93,6 +95,48 @@ class EnhancedInsuranceLayer:
             raise ValueError(
                 f"Reinstatement premium must be non-negative, got {self.reinstatement_premium}"
             )
+
+        # Validate limit type
+        valid_limit_types = ["per-occurrence", "aggregate", "hybrid"]
+        if self.limit_type not in valid_limit_types:
+            raise ValueError(
+                f"Invalid limit_type: {self.limit_type}. Must be one of {valid_limit_types}"
+            )
+
+        # Handle different limit type configurations
+        if self.limit_type == "per-occurrence":
+            # For per-occurrence, the limit field is the per-occurrence limit
+            # No aggregate limit should be set (will be ignored if set)
+            if self.reinstatements > 0:
+                import warnings
+
+                warnings.warn(
+                    f"Reinstatements parameter ({self.reinstatements}) is not used for per-occurrence limits.",
+                    UserWarning,
+                )
+        elif self.limit_type == "aggregate":
+            # For aggregate, the limit field is the aggregate limit
+            # Set aggregate_limit to match limit if not already set
+            if self.aggregate_limit is None:
+                self.aggregate_limit = self.limit
+        elif self.limit_type == "hybrid":
+            # For hybrid, need both per-occurrence and aggregate limits
+            if self.per_occurrence_limit is None:
+                # If not specified, use limit as per-occurrence limit
+                self.per_occurrence_limit = self.limit
+            if self.aggregate_limit is None:
+                # If aggregate not specified, error
+                raise ValueError(
+                    "Hybrid limit type requires both per_occurrence_limit and aggregate_limit"
+                )
+            if self.per_occurrence_limit <= 0:
+                raise ValueError(
+                    f"Per-occurrence limit must be positive, got {self.per_occurrence_limit}"
+                )
+            if self.aggregate_limit <= 0:
+                raise ValueError(f"Aggregate limit must be positive, got {self.aggregate_limit}")
+
+        # Validate aggregate limit if specified
         if self.aggregate_limit is not None and self.aggregate_limit <= 0:
             raise ValueError(f"Aggregate limit must be positive if set, got {self.aggregate_limit}")
 
@@ -147,7 +191,21 @@ class EnhancedInsuranceLayer:
             return 0.0
 
         excess_loss = total_loss - self.attachment_point
-        return min(excess_loss, self.limit)
+
+        # Apply the appropriate limit based on limit_type
+        if self.limit_type == "per-occurrence":
+            # For per-occurrence, limit each individual loss
+            return min(excess_loss, self.limit)
+        elif self.limit_type == "aggregate":
+            # For aggregate, limit is handled in process_claim via aggregate tracking
+            # Here we just return the excess without limiting
+            return min(excess_loss, self.limit)
+        elif self.limit_type == "hybrid":
+            # For hybrid, apply per-occurrence limit first
+            # Aggregate limit is handled in process_claim
+            return min(excess_loss, self.per_occurrence_limit or self.limit)
+        else:
+            return min(excess_loss, self.limit)
 
 
 @dataclass
@@ -181,6 +239,160 @@ class LayerState:
         Returns:
             Tuple of (amount_paid, reinstatement_premium).
         """
+        if claim_amount <= 0:
+            return 0.0, 0.0
+
+        # Handle different limit types
+        if self.layer.limit_type == "per-occurrence":
+            # Per-occurrence: each claim limited but no exhaustion
+            payment = min(claim_amount, self.layer.limit)
+            self.total_claims_paid += payment
+            return payment, 0.0  # No reinstatement premiums for per-occurrence
+
+        elif self.layer.limit_type == "aggregate":
+            # Aggregate: track total usage and exhaust when limit reached
+            if self.is_exhausted:
+                return 0.0, 0.0
+
+            total_payment = 0.0
+            total_reinstatement_premium = 0.0
+            remaining_claim = claim_amount
+
+            # Process claim with current limit (may trigger reinstatements)
+            while remaining_claim > 0 and not self.is_exhausted:
+                # Calculate available limit
+                available_limit = self.current_limit
+
+                # Check aggregate limit if it exists
+                if self.layer.aggregate_limit is not None:
+                    remaining_aggregate = self.layer.aggregate_limit - self.aggregate_used
+                    if remaining_aggregate <= 0:
+                        self.is_exhausted = True
+                        break
+                    available_limit = min(available_limit, remaining_aggregate)
+
+                # Calculate payment from available limit
+                payment = min(remaining_claim, available_limit)
+                if payment > 0:
+                    self.used_limit += payment
+                    self.current_limit -= payment
+                    self.total_claims_paid += payment
+                    self.aggregate_used += payment
+                    total_payment += payment
+                    remaining_claim -= payment
+
+                    # Check if aggregate exhausted
+                    if (
+                        self.layer.aggregate_limit is not None
+                        and self.aggregate_used >= self.layer.aggregate_limit
+                    ):
+                        # Check if this is a single aggregate that can be reinstated
+                        # (aggregate_limit == limit means single aggregate with reinstatements)
+                        # (aggregate_limit > limit means overall cap across reinstatements)
+                        if (
+                            self.layer.aggregate_limit == self.layer.limit
+                            and self.reinstatements_used < self.layer.reinstatements
+                        ):
+                            # Single aggregate with reinstatements - can reinstate
+                            self.reinstatements_used += 1
+                            self.current_limit = self.layer.limit
+                            self.aggregate_used = 0  # Reset aggregate tracking
+                            reinstatement_premium = self.layer.calculate_reinstatement_premium(
+                                timing_factor
+                            )
+                            self.reinstatement_premiums_paid += reinstatement_premium
+                            total_reinstatement_premium += reinstatement_premium
+                            # Continue processing if there's remaining claim
+                            if remaining_claim > 0:
+                                continue
+                        else:
+                            # Overall cap reached - cannot be reinstated
+                            self.is_exhausted = True
+                            self.current_limit = 0
+                            break
+
+                # Check if limit exhausted and can reinstate
+                if self.current_limit == 0 and not self.is_exhausted:
+                    if self.reinstatements_used < self.layer.reinstatements:
+                        # Trigger reinstatement
+                        self.reinstatements_used += 1
+                        self.current_limit = self.layer.limit
+                        reinstatement_premium = self.layer.calculate_reinstatement_premium(
+                            timing_factor
+                        )
+                        self.reinstatement_premiums_paid += reinstatement_premium
+                        total_reinstatement_premium += reinstatement_premium
+                        # Continue processing if there's remaining claim
+                        if remaining_claim == 0:
+                            break
+                    else:
+                        # No more reinstatements available
+                        self.is_exhausted = True
+                        break
+                elif remaining_claim == 0:
+                    # Claim fully processed - check if we need reinstatement
+                    if (
+                        self.current_limit == 0
+                        and self.reinstatements_used < self.layer.reinstatements
+                        and not self.is_exhausted
+                    ):
+                        # Trigger reinstatement for future use
+                        self.reinstatements_used += 1
+                        self.current_limit = self.layer.limit
+                        reinstatement_premium = self.layer.calculate_reinstatement_premium(
+                            timing_factor
+                        )
+                        self.reinstatement_premiums_paid += reinstatement_premium
+                        total_reinstatement_premium += reinstatement_premium
+                    break
+
+            return total_payment, total_reinstatement_premium
+
+        elif self.layer.limit_type == "hybrid":
+            # Hybrid: apply both per-occurrence and aggregate constraints
+            if self.is_exhausted:
+                return 0.0, 0.0
+
+            # First apply per-occurrence limit
+            per_occurrence_limit = self.layer.per_occurrence_limit or self.layer.limit
+            max_payment = min(claim_amount, per_occurrence_limit)
+
+            # Then check against remaining aggregate
+            if self.layer.aggregate_limit is not None:
+                remaining_aggregate = self.layer.aggregate_limit - self.aggregate_used
+                if remaining_aggregate <= 0:
+                    self.is_exhausted = True
+                    return 0.0, 0.0
+                max_payment = min(max_payment, remaining_aggregate)
+
+            # Make the payment
+            if max_payment > 0:
+                self.total_claims_paid += max_payment
+                self.aggregate_used += max_payment
+
+                # Check if aggregate is now exhausted
+                if self.aggregate_used >= self.layer.aggregate_limit:
+                    self.is_exhausted = True
+
+            # Calculate reinstatement premium if aggregate portion exhausted
+            reinstatement_premium = 0.0
+            if self.is_exhausted and self.reinstatements_used < self.layer.reinstatements:
+                self.reinstatements_used += 1
+                self.aggregate_used = 0  # Reset aggregate tracking
+                self.is_exhausted = False
+                reinstatement_premium = self.layer.calculate_reinstatement_premium(timing_factor)
+                self.reinstatement_premiums_paid += reinstatement_premium
+
+            return max_payment, reinstatement_premium
+
+        else:
+            # Fallback to aggregate behavior
+            return self._process_claim_aggregate(claim_amount, timing_factor)
+
+    def _process_claim_aggregate(
+        self, claim_amount: float, timing_factor: float = 1.0
+    ) -> Tuple[float, float]:
+        """Original aggregate claim processing logic (for backward compatibility)."""
         if self.is_exhausted or claim_amount <= 0:
             return 0.0, 0.0
 

--- a/ergodic_insurance/tests/test_config_v2.py
+++ b/ergodic_insurance/tests/test_config_v2.py
@@ -117,17 +117,17 @@ class TestInsuranceLayerConfig:
         assert layer.reinstatements == 2
 
     def test_invalid_aggregate_limit(self):
-        """Test validation of aggregate limit < per-occurrence limit."""
-        with pytest.raises(ValidationError) as exc_info:
-            InsuranceLayerConfig(
-                name="Invalid",
-                limit=1000000,
-                attachment=0,
-                premium_rate=0.015,
-                aggregate_limit=500000,  # Less than limit
-            )
-        assert "Aggregate limit" in str(exc_info.value)
-        assert "cannot be less than" in str(exc_info.value)
+        """Test that aggregate limit < limit is now allowed (for overall cap scenarios)."""
+        # This is now valid as aggregate can be an overall cap across reinstatements
+        layer = InsuranceLayerConfig(
+            name="Valid",
+            limit=1000000,
+            attachment=0,
+            premium_rate=0.015,
+            aggregate_limit=500000,  # Less than limit is now allowed
+        )
+        assert layer.limit == 1000000
+        assert layer.aggregate_limit == 500000
 
     def test_valid_aggregate_limit(self):
         """Test valid aggregate limit >= per-occurrence limit."""

--- a/ergodic_insurance/tests/test_insurance_program.py
+++ b/ergodic_insurance/tests/test_insurance_program.py
@@ -152,7 +152,9 @@ class TestLayerState:
 
     def test_process_claim_simple(self):
         """Test simple claim processing."""
-        layer = EnhancedInsuranceLayer(attachment_point=0, limit=5_000_000, premium_rate=0.01)
+        layer = EnhancedInsuranceLayer(
+            attachment_point=0, limit=5_000_000, premium_rate=0.01, limit_type="aggregate"
+        )
         state = LayerState(layer)
 
         payment, reinstatement_premium = state.process_claim(2_000_000)
@@ -169,6 +171,7 @@ class TestLayerState:
             limit=5_000_000,
             premium_rate=0.01,
             reinstatements=0,  # No reinstatements
+            limit_type="aggregate",
         )
         state = LayerState(layer)
 
@@ -191,6 +194,7 @@ class TestLayerState:
             reinstatements=1,
             reinstatement_premium=1.0,
             reinstatement_type=ReinstatementType.FULL,
+            limit_type="aggregate",
         )
         state = LayerState(layer)
 
@@ -212,6 +216,7 @@ class TestLayerState:
             reinstatements=2,
             reinstatement_premium=0.5,
             reinstatement_type=ReinstatementType.PRO_RATA,
+            limit_type="aggregate",
         )
         state = LayerState(layer)
 
@@ -239,6 +244,7 @@ class TestLayerState:
             premium_rate=0.01,
             reinstatements=10,  # Many reinstatements
             aggregate_limit=5_000_000,  # But aggregate cap
+            limit_type="aggregate",
         )
         state = LayerState(layer)
 
@@ -259,7 +265,11 @@ class TestLayerState:
     def test_reset(self):
         """Test state reset functionality."""
         layer = EnhancedInsuranceLayer(
-            attachment_point=0, limit=5_000_000, premium_rate=0.01, reinstatements=1
+            attachment_point=0,
+            limit=5_000_000,
+            premium_rate=0.01,
+            reinstatements=1,
+            limit_type="aggregate",
         )
         state = LayerState(layer)
 
@@ -379,6 +389,7 @@ class TestInsuranceProgram:
                 reinstatements=1,
                 reinstatement_premium=1.0,
                 reinstatement_type=ReinstatementType.FULL,
+                limit_type="aggregate",
             )
         ]
         program = InsuranceProgram(layers)
@@ -399,6 +410,7 @@ class TestInsuranceProgram:
                 reinstatements=2,
                 reinstatement_premium=0.5,
                 reinstatement_type=ReinstatementType.PRO_RATA,
+                limit_type="aggregate",
             )
         ]
         program = InsuranceProgram(layers)
@@ -427,7 +439,11 @@ class TestInsuranceProgram:
 
     def test_reset_annual(self):
         """Test annual reset functionality."""
-        layers = [EnhancedInsuranceLayer(attachment_point=0, limit=5_000_000, premium_rate=0.01)]
+        layers = [
+            EnhancedInsuranceLayer(
+                attachment_point=0, limit=5_000_000, premium_rate=0.01, limit_type="aggregate"
+            )
+        ]
         program = InsuranceProgram(layers)
 
         # Process claim

--- a/ergodic_insurance/tests/test_limit_types.py
+++ b/ergodic_insurance/tests/test_limit_types.py
@@ -1,0 +1,393 @@
+"""Tests for per-occurrence, aggregate, and hybrid insurance limit types.
+
+This module tests the new functionality for different limit types in insurance layers,
+ensuring proper behavior for per-occurrence (default), aggregate, and hybrid configurations.
+"""
+
+import warnings
+
+import numpy as np
+import pytest
+
+from ergodic_insurance.insurance_program import (
+    EnhancedInsuranceLayer,
+    InsuranceProgram,
+    LayerState,
+    ReinstatementType,
+)
+
+
+class TestPerOccurrenceLimits:
+    """Test per-occurrence limit functionality."""
+
+    def test_per_occurrence_default(self):
+        """Test that per-occurrence is the default limit type."""
+        layer = EnhancedInsuranceLayer(limit=1_000_000, attachment_point=100_000, premium_rate=0.02)
+        assert layer.limit_type == "per-occurrence"
+
+        # Process multiple large losses
+        state = LayerState(layer)
+        for _ in range(5):
+            payment, _ = state.process_claim(2_000_000)
+            assert payment == 1_000_000  # Each claim gets full limit
+
+    def test_per_occurrence_no_exhaustion(self):
+        """Test that per-occurrence limits never exhaust."""
+        layer = EnhancedInsuranceLayer(
+            limit=500_000, attachment_point=0, premium_rate=0.01, limit_type="per-occurrence"
+        )
+
+        state = LayerState(layer)
+
+        # Process many claims
+        total_paid = 0
+        for i in range(10):
+            payment, reinstatement_premium = state.process_claim(1_000_000)
+            assert payment == 500_000  # Each claim limited to 500K
+            assert reinstatement_premium == 0  # No reinstatement premiums
+            total_paid += payment
+
+        assert total_paid == 5_000_000  # 10 claims * 500K each
+        assert not state.is_exhausted  # Never exhausts
+
+    def test_per_occurrence_reinstatement_warning(self):
+        """Test that reinstatements generate warning for per-occurrence limits."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            layer = EnhancedInsuranceLayer(
+                limit=1_000_000,
+                attachment_point=100_000,
+                premium_rate=0.02,
+                limit_type="per-occurrence",
+                reinstatements=2,  # Should trigger warning
+            )
+
+            # Check that a warning was raised
+            assert len(w) == 1
+            assert "not used for per-occurrence limits" in str(w[0].message)
+
+
+class TestAggregateLimits:
+    """Test aggregate limit functionality."""
+
+    def test_aggregate_limit_exhaustion(self):
+        """Test that aggregate limits exhaust after cumulative claims."""
+        layer = EnhancedInsuranceLayer(
+            limit=5_000_000, attachment_point=100_000, premium_rate=0.02, limit_type="aggregate"
+        )
+
+        state = LayerState(layer)
+        payments = []
+        for _ in range(3):
+            payment, _ = state.process_claim(2_000_000)
+            payments.append(payment)
+
+        assert sum(payments) == 5_000_000  # Total limited to aggregate
+        assert payments[2] == 1_000_000  # Last payment partial
+
+        # Additional claims should not be paid
+        payment, _ = state.process_claim(1_000_000)
+        assert payment == 0
+        assert state.is_exhausted
+
+    def test_aggregate_with_reinstatements(self):
+        """Test aggregate limits with reinstatements."""
+        layer = EnhancedInsuranceLayer(
+            limit=1_000_000,
+            attachment_point=0,
+            premium_rate=0.02,
+            limit_type="aggregate",
+            reinstatements=2,
+            reinstatement_type=ReinstatementType.FULL,
+        )
+
+        state = LayerState(layer)
+
+        # First claim exhausts the limit
+        payment1, premium1 = state.process_claim(1_000_000)
+        assert payment1 == 1_000_000
+        assert premium1 == 20_000  # Full reinstatement premium (1M * 0.02)
+        assert state.reinstatements_used == 1
+
+        # Second claim uses reinstated limit
+        payment2, premium2 = state.process_claim(1_000_000)
+        assert payment2 == 1_000_000
+        assert premium2 == 20_000  # Another reinstatement
+        assert state.reinstatements_used == 2
+
+        # Third claim uses last reinstated limit
+        payment3, premium3 = state.process_claim(1_000_000)
+        assert payment3 == 1_000_000
+        assert premium3 == 0  # No more reinstatements
+        assert state.is_exhausted
+
+
+class TestHybridLimits:
+    """Test hybrid limit functionality."""
+
+    def test_hybrid_limits(self):
+        """Test that hybrid limits apply both constraints."""
+        layer = EnhancedInsuranceLayer(
+            limit_type="hybrid",
+            per_occurrence_limit=1_000_000,
+            aggregate_limit=3_000_000,
+            attachment_point=100_000,
+            premium_rate=0.02,
+            limit=1_000_000,  # Required field, used as per-occurrence if not specified
+        )
+
+        state = LayerState(layer)
+
+        # First loss: 2M claim, limited to 1M per-occurrence
+        payment1, _ = state.process_claim(2_000_000)
+        assert payment1 == 1_000_000
+
+        # Second loss: Another 2M claim, limited to 1M
+        payment2, _ = state.process_claim(2_000_000)
+        assert payment2 == 1_000_000
+
+        # Third loss: 2M claim, but aggregate is nearly exhausted
+        payment3, _ = state.process_claim(2_000_000)
+        assert payment3 == 1_000_000
+
+        # Fourth loss: Aggregate exhausted
+        payment4, _ = state.process_claim(2_000_000)
+        assert payment4 == 0
+        assert state.is_exhausted
+
+    def test_hybrid_partial_aggregate_exhaustion(self):
+        """Test hybrid limits when aggregate partially exhausts."""
+        layer = EnhancedInsuranceLayer(
+            limit_type="hybrid",
+            per_occurrence_limit=1_000_000,
+            aggregate_limit=2_500_000,
+            attachment_point=0,
+            premium_rate=0.02,
+            limit=1_000_000,
+        )
+
+        state = LayerState(layer)
+
+        # First two claims: 1M each
+        payment1, _ = state.process_claim(1_000_000)
+        payment2, _ = state.process_claim(1_000_000)
+        assert payment1 == 1_000_000
+        assert payment2 == 1_000_000
+
+        # Third claim: Only 500K remaining in aggregate
+        payment3, _ = state.process_claim(1_000_000)
+        assert payment3 == 500_000  # Limited by remaining aggregate
+        assert state.is_exhausted
+
+    def test_hybrid_with_reinstatements(self):
+        """Test hybrid limits with reinstatements on aggregate portion."""
+        layer = EnhancedInsuranceLayer(
+            limit_type="hybrid",
+            per_occurrence_limit=500_000,
+            aggregate_limit=1_000_000,
+            attachment_point=0,
+            premium_rate=0.02,
+            reinstatements=1,
+            reinstatement_type=ReinstatementType.FULL,
+            limit=500_000,
+        )
+
+        state = LayerState(layer)
+
+        # First two claims exhaust aggregate
+        payment1, premium1 = state.process_claim(600_000)  # Limited to 500K per-occurrence
+        payment2, premium2 = state.process_claim(600_000)  # Limited to 500K per-occurrence
+
+        assert payment1 == 500_000
+        assert payment2 == 500_000
+        assert premium1 == 0  # No reinstatement yet
+        assert premium2 == 10_000  # Reinstatement triggered (500K * 0.02)
+
+        # Aggregate is reinstated
+        assert not state.is_exhausted
+
+        # Third claim uses reinstated aggregate
+        payment3, _ = state.process_claim(600_000)
+        assert payment3 == 500_000
+
+
+class TestReinstatementBehavior:
+    """Test reinstatement behavior for different limit types."""
+
+    def test_reinstatements_with_limit_types(self):
+        """Test reinstatement behavior for different limit types."""
+        # Per-occurrence: reinstatements ignored with warning
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            layer_po = EnhancedInsuranceLayer(
+                limit=1_000_000,
+                attachment_point=100_000,
+                premium_rate=0.02,
+                limit_type="per-occurrence",
+                reinstatements=2,  # Should be ignored with a warning
+            )
+            assert len(w) == 1
+            assert "not used for per-occurrence limits" in str(w[0].message)
+
+        # Aggregate: reinstatements work
+        layer_agg = EnhancedInsuranceLayer(
+            limit=1_000_000,
+            attachment_point=100_000,
+            premium_rate=0.02,
+            limit_type="aggregate",
+            reinstatements=2,
+        )
+
+        state_agg = LayerState(layer_agg)
+
+        # Exhaust and reinstate
+        payment1, premium1 = state_agg.process_claim(1_000_000)
+        assert payment1 == 1_000_000
+        assert premium1 > 0  # Reinstatement premium charged
+
+        # Can still claim after reinstatement
+        payment2, _ = state_agg.process_claim(500_000)
+        assert payment2 == 500_000
+
+
+class TestConfigurationMigration:
+    """Test configuration migration and backward compatibility."""
+
+    def test_configuration_migration(self):
+        """Test that existing configs default to per-occurrence limits."""
+        old_config = {
+            "limit": 5_000_000,
+            "attachment_point": 100_000,
+            "premium_rate": 0.02
+            # No limit_type specified
+        }
+
+        layer = EnhancedInsuranceLayer(**old_config)
+        # Should default to per-occurrence for new behavior
+        assert layer.limit_type == "per-occurrence"
+
+    def test_explicit_aggregate_configuration(self):
+        """Test explicit aggregate configuration."""
+        config = {
+            "limit": 5_000_000,
+            "attachment_point": 100_000,
+            "premium_rate": 0.02,
+            "limit_type": "aggregate",
+        }
+
+        layer = EnhancedInsuranceLayer(**config)
+        assert layer.limit_type == "aggregate"
+        assert layer.aggregate_limit == 5_000_000  # Set automatically
+
+    def test_hybrid_configuration_validation(self):
+        """Test hybrid configuration validation."""
+        # Valid hybrid config
+        valid_config = {
+            "limit": 1_000_000,
+            "attachment_point": 100_000,
+            "premium_rate": 0.02,
+            "limit_type": "hybrid",
+            "per_occurrence_limit": 1_000_000,
+            "aggregate_limit": 5_000_000,
+        }
+
+        layer = EnhancedInsuranceLayer(**valid_config)
+        assert layer.limit_type == "hybrid"
+        assert layer.per_occurrence_limit == 1_000_000
+        assert layer.aggregate_limit == 5_000_000
+
+        # Invalid hybrid config (missing aggregate)
+        invalid_config = {
+            "limit": 1_000_000,
+            "attachment_point": 100_000,
+            "premium_rate": 0.02,
+            "limit_type": "hybrid",
+            "per_occurrence_limit": 1_000_000
+            # Missing aggregate_limit
+        }
+
+        with pytest.raises(ValueError, match="Hybrid limit type requires"):
+            EnhancedInsuranceLayer(**invalid_config)
+
+
+class TestIntegrationScenarios:
+    """Test integration scenarios with insurance programs."""
+
+    def test_crisis_scenario_with_per_occurrence(self):
+        """Test that crisis scenario improves with per-occurrence limits."""
+        # Create program with per-occurrence limits
+        layers_po = [
+            EnhancedInsuranceLayer(
+                attachment_point=100_000,
+                limit=1_000_000,
+                premium_rate=0.02,
+                limit_type="per-occurrence",
+            ),
+            EnhancedInsuranceLayer(
+                attachment_point=1_100_000,
+                limit=5_000_000,
+                premium_rate=0.01,
+                limit_type="per-occurrence",
+            ),
+        ]
+
+        program_po = InsuranceProgram(layers=layers_po, deductible=100_000)
+
+        # Simulate crisis with multiple large losses
+        crisis_losses = [2_000_000, 3_000_000, 2_500_000, 4_000_000]
+
+        result_po = program_po.process_annual_claims(crisis_losses)
+
+        # All losses should be covered up to per-occurrence limits
+        assert result_po["total_recovery"] > 0
+
+        # Compare with aggregate limits
+        layers_agg = [
+            EnhancedInsuranceLayer(
+                attachment_point=100_000, limit=1_000_000, premium_rate=0.02, limit_type="aggregate"
+            ),
+            EnhancedInsuranceLayer(
+                attachment_point=1_100_000,
+                limit=5_000_000,
+                premium_rate=0.01,
+                limit_type="aggregate",
+            ),
+        ]
+
+        program_agg = InsuranceProgram(layers=layers_agg, deductible=100_000)
+        result_agg = program_agg.process_annual_claims(crisis_losses)
+
+        # Per-occurrence should provide better coverage in crisis
+        assert result_po["total_recovery"] > result_agg["total_recovery"]
+
+    def test_premium_calculation_consistency(self):
+        """Test that premiums calculate correctly for all limit types."""
+        premium_rate = 0.02
+        limit = 5_000_000
+        expected_premium = limit * premium_rate
+
+        # Per-occurrence
+        layer_po = EnhancedInsuranceLayer(
+            attachment_point=100_000,
+            limit=limit,
+            premium_rate=premium_rate,
+            limit_type="per-occurrence",
+        )
+        assert layer_po.calculate_base_premium() == expected_premium
+
+        # Aggregate
+        layer_agg = EnhancedInsuranceLayer(
+            attachment_point=100_000, limit=limit, premium_rate=premium_rate, limit_type="aggregate"
+        )
+        assert layer_agg.calculate_base_premium() == expected_premium
+
+        # Hybrid
+        layer_hybrid = EnhancedInsuranceLayer(
+            attachment_point=100_000,
+            limit=limit,
+            premium_rate=premium_rate,
+            limit_type="hybrid",
+            per_occurrence_limit=limit,
+            aggregate_limit=limit * 3,
+        )
+        assert layer_hybrid.calculate_base_premium() == expected_premium


### PR DESCRIPTION
## Summary
- Implements support for three distinct insurance limit types: per-occurrence (default), aggregate, and hybrid
- Provides accurate modeling of real-world insurance structures where limits can apply per-claim or across all claims
- Enhances the insurance simulation framework to support more realistic crisis scenarios

## Changes
- Added `limit_type` field to `EnhancedInsuranceLayer` with three options: "per-occurrence", "aggregate", "hybrid"
- Modified `LayerState.process_claim()` to handle each limit type appropriately:
  - **Per-occurrence**: Each claim limited individually, never exhausts
  - **Aggregate**: Track cumulative usage, exhausts after total claims reach limit
  - **Hybrid**: Apply both per-occurrence and aggregate constraints
- Updated config validation to support new limit type configurations
- Added comprehensive test suite (`test_limit_types.py`) with 14 test cases
- Updated existing tests to explicitly use aggregate limits for backward compatibility

## Test plan
- [x] All new test cases pass (14/14 in test_limit_types.py)
- [x] Existing insurance program tests updated and passing
- [x] Config validation tests updated to reflect new behavior
- [x] Integration tested with multiple claim scenarios

Closes #167

🤖 Generated with [Claude Code](https://claude.ai/code)