### PR TITLE
fix: Correct prepaid insurance tracking using insurance accounting module

### DIFF
--- a/ergodic_insurance/manufacturer.py
+++ b/ergodic_insurance/manufacturer.py
@@ -1374,10 +1374,13 @@ class WidgetManufacturer:
                 # Will amortize at $100K/month over 12 months
         """
         if annual_premium > 0:
-            self.prepaid_insurance += annual_premium
-            self.cash -= annual_premium
-            # Track original premium for proper amortization calculation
-            self._original_prepaid_premium = annual_premium
+            # Use insurance accounting module to properly track prepaid insurance
+            result = self.insurance_accounting.pay_annual_premium(annual_premium)
+
+            # Update balance sheet
+            self.prepaid_insurance = result["prepaid_asset"]
+            self.cash -= result["cash_outflow"]
+
             logger.info(f"Recorded prepaid insurance: ${annual_premium:,.2f}")
 
     def amortize_prepaid_insurance(self, months: int = 1) -> float:

--- a/ergodic_insurance/tests/test_depreciation_tracking.py
+++ b/ergodic_insurance/tests/test_depreciation_tracking.py
@@ -181,8 +181,8 @@ class TestDepreciationTracking:
         # Try to amortize for 24 months at once (should stop at balance)
         total_amortized = manufacturer.amortize_prepaid_insurance(months=24)
 
-        assert total_amortized == premium
-        assert manufacturer.prepaid_insurance == 0
+        assert total_amortized == pytest.approx(premium, rel=1e-9)
+        assert manufacturer.prepaid_insurance == pytest.approx(0, abs=1e-9)
 
         # Further amortization should return 0
         additional_amortization = manufacturer.amortize_prepaid_insurance(months=1)


### PR DESCRIPTION
## Summary
- Fixed failing prepaid insurance tracking tests by properly synchronizing the manufacturer with the insurance accounting module
- Updated `record_prepaid_insurance` to use the insurance accounting module's `pay_annual_premium()` method
- Added floating-point precision tolerance in test assertions to handle minor arithmetic differences

## Test plan
- [x] Run `pytest ergodic_insurance/tests/test_balance_sheet_classification.py::TestBalanceSheetClassification::test_prepaid_insurance_tracking` - PASSED
- [x] Run `pytest ergodic_insurance/tests/test_depreciation_tracking.py -k "prepaid_insurance"` - 5 tests PASSED
- [x] All prepaid insurance related tests now pass

## Changes made
1. **manufacturer.py**: Modified `record_prepaid_insurance()` to properly use `insurance_accounting.pay_annual_premium()` instead of directly setting `self.prepaid_insurance`
2. **test_depreciation_tracking.py**: Updated test assertions to use `pytest.approx()` for floating-point comparisons

This ensures the insurance accounting module properly tracks the prepaid balance for amortization.

🤖 Generated with [Claude Code](https://claude.ai/code)