### PR TITLE
feat: Enable periodic ruin probability tracking in MonteCarloEngine

### DIFF
--- a/ergodic_insurance/strategy_backtester.py
+++ b/ergodic_insurance/strategy_backtester.py
@@ -353,7 +353,12 @@ class OptimizedStaticStrategy(InsuranceStrategy):
             results = mc_engine.run()
 
             # Constraint: ruin_prob <= max_ruin_prob
-            return self.max_ruin_prob - results.ruin_probability
+            # Extract ruin probability for the final year
+            ruin_prob_value = results.ruin_probability.get(
+                str(mc_config.n_years),
+                list(results.ruin_probability.values())[-1] if results.ruin_probability else 0.0,
+            )
+            return self.max_ruin_prob - ruin_prob_value
 
         # Run optimization using scipy minimize
         from scipy.optimize import minimize
@@ -746,7 +751,13 @@ class StrategyBacktester:
         )
 
         # Add ruin probability from MC results
-        metrics.ruin_probability = simulation_results.ruin_probability
+        # Extract ruin probability for the final year from the dict
+        metrics.ruin_probability = simulation_results.ruin_probability.get(
+            str(n_years),
+            list(simulation_results.ruin_probability.values())[-1]
+            if simulation_results.ruin_probability
+            else 0.0,
+        )
 
         return metrics
 

--- a/ergodic_insurance/tests/test_periodic_ruin_tracking.py
+++ b/ergodic_insurance/tests/test_periodic_ruin_tracking.py
@@ -1,0 +1,262 @@
+"""Tests for periodic ruin probability tracking in Monte Carlo simulations."""
+
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+
+from ergodic_insurance.config import ManufacturerConfig
+from ergodic_insurance.insurance_program import EnhancedInsuranceLayer, InsuranceProgram
+from ergodic_insurance.loss_distributions import ManufacturingLossGenerator
+from ergodic_insurance.manufacturer import WidgetManufacturer
+from ergodic_insurance.monte_carlo import MonteCarloEngine, SimulationConfig, SimulationResults
+
+
+class TestPeriodicRuinTracking:
+    """Test periodic ruin probability evaluation functionality."""
+
+    @pytest.fixture
+    def setup_engine(self):
+        """Set up a test Monte Carlo engine."""
+        # Create mock loss generator
+        loss_generator = Mock(spec=ManufacturingLossGenerator)
+        loss_generator.generate_losses = Mock(return_value=([], None))
+
+        # Create insurance program
+        layer = EnhancedInsuranceLayer(
+            attachment_point=0,
+            limit=1_000_000,
+            base_premium_rate=0.02,
+        )
+        insurance_program = InsuranceProgram(layers=[layer])
+
+        # Create manufacturer
+        manufacturer_config = ManufacturerConfig(
+            initial_assets=10_000_000,
+            asset_turnover_ratio=0.5,
+            base_operating_margin=0.1,
+            tax_rate=0.25,
+            retention_ratio=0.8,
+        )
+        manufacturer = WidgetManufacturer(manufacturer_config)
+
+        return loss_generator, insurance_program, manufacturer
+
+    def test_basic_periodic_evaluation(self, setup_engine):
+        """Test basic periodic ruin probability evaluation."""
+        loss_generator, insurance_program, manufacturer = setup_engine
+
+        config = SimulationConfig(
+            n_simulations=1000,
+            n_years=20,
+            ruin_evaluation=[5, 10, 15],
+            parallel=False,  # Use sequential for deterministic testing
+            seed=42,
+        )
+
+        engine = MonteCarloEngine(
+            loss_generator=loss_generator,
+            insurance_program=insurance_program,
+            manufacturer=manufacturer,
+            config=config,
+        )
+
+        results = engine.run()
+
+        # Check that ruin_probability is now a dictionary
+        assert isinstance(results.ruin_probability, dict)
+        assert "5" in results.ruin_probability
+        assert "10" in results.ruin_probability
+        assert "15" in results.ruin_probability
+        assert "20" in results.ruin_probability  # Max runtime
+
+        # Ruin probability should be monotonically increasing
+        assert results.ruin_probability["5"] <= results.ruin_probability["10"]
+        assert results.ruin_probability["10"] <= results.ruin_probability["15"]
+        assert results.ruin_probability["15"] <= results.ruin_probability["20"]
+
+        # All probabilities should be between 0 and 1
+        for prob in results.ruin_probability.values():
+            assert 0 <= prob <= 1
+
+    def test_no_ruin_evaluation_specified(self, setup_engine):
+        """Test behavior when no ruin_evaluation is specified."""
+        loss_generator, insurance_program, manufacturer = setup_engine
+
+        sim_years = 10
+        config = SimulationConfig(
+            n_simulations=1000,
+            n_years=sim_years,
+            ruin_evaluation=None,  # No periodic evaluation
+            parallel=False,
+            seed=42,
+        )
+
+        engine = MonteCarloEngine(
+            loss_generator=loss_generator,
+            insurance_program=insurance_program,
+            manufacturer=manufacturer,
+            config=config,
+        )
+
+        results = engine.run()
+
+        # Should still return a dict with only the final year
+        assert isinstance(results.ruin_probability, dict)
+        assert str(sim_years) in results.ruin_probability
+        assert len(results.ruin_probability) == 1
+        assert 0 <= results.ruin_probability[str(sim_years)] <= 1
+
+    def test_parallel_execution(self, setup_engine):
+        """Test periodic ruin evaluation with parallel execution."""
+        loss_generator, insurance_program, manufacturer = setup_engine
+
+        config = SimulationConfig(
+            n_simulations=10000,
+            n_years=20,
+            ruin_evaluation=[5, 10, 15],
+            parallel=True,
+            n_workers=4,
+            seed=42,
+        )
+
+        engine = MonteCarloEngine(
+            loss_generator=loss_generator,
+            insurance_program=insurance_program,
+            manufacturer=manufacturer,
+            config=config,
+        )
+
+        results = engine.run()
+
+        # Results should be consistent across parallel execution
+        assert isinstance(results.ruin_probability, dict)
+        assert all(0 <= p <= 1 for p in results.ruin_probability.values())
+
+        # Check all expected evaluation points are present
+        assert "5" in results.ruin_probability
+        assert "10" in results.ruin_probability
+        assert "15" in results.ruin_probability
+        assert "20" in results.ruin_probability
+
+    def test_edge_cases(self, setup_engine):
+        """Test edge cases for ruin evaluation."""
+        loss_generator, insurance_program, manufacturer = setup_engine
+
+        # Test evaluation beyond simulation years
+        config = SimulationConfig(
+            n_simulations=100,
+            n_years=10,
+            ruin_evaluation=[5, 10, 20],  # 20 > n_years
+            parallel=False,
+            seed=42,
+        )
+
+        engine = MonteCarloEngine(
+            loss_generator=loss_generator,
+            insurance_program=insurance_program,
+            manufacturer=manufacturer,
+            config=config,
+        )
+
+        results = engine.run()
+
+        # Should handle gracefully, only evaluate up to n_years
+        assert "5" in results.ruin_probability
+        assert "10" in results.ruin_probability
+        assert "20" not in results.ruin_probability  # Beyond simulation period
+        assert "10" in results.ruin_probability  # Max runtime is 10
+
+    def test_single_year_evaluation(self, setup_engine):
+        """Test evaluation at a single year."""
+        loss_generator, insurance_program, manufacturer = setup_engine
+
+        config = SimulationConfig(
+            n_simulations=500,
+            n_years=10,
+            ruin_evaluation=[5],  # Single evaluation point
+            parallel=False,
+            seed=42,
+        )
+
+        engine = MonteCarloEngine(
+            loss_generator=loss_generator,
+            insurance_program=insurance_program,
+            manufacturer=manufacturer,
+            config=config,
+        )
+
+        results = engine.run()
+
+        assert isinstance(results.ruin_probability, dict)
+        assert "5" in results.ruin_probability
+        assert "10" in results.ruin_probability  # Final year always included
+        assert len(results.ruin_probability) == 2
+
+    def test_empty_evaluation_list(self, setup_engine):
+        """Test with empty evaluation list."""
+        loss_generator, insurance_program, manufacturer = setup_engine
+
+        config = SimulationConfig(
+            n_simulations=100,
+            n_years=10,
+            ruin_evaluation=[],  # Empty list
+            parallel=False,
+            seed=42,
+        )
+
+        engine = MonteCarloEngine(
+            loss_generator=loss_generator,
+            insurance_program=insurance_program,
+            manufacturer=manufacturer,
+            config=config,
+        )
+
+        results = engine.run()
+
+        # Should only have final year
+        assert isinstance(results.ruin_probability, dict)
+        assert "10" in results.ruin_probability
+        assert len(results.ruin_probability) == 1
+
+    def test_ruin_probability_consistency(self, setup_engine):
+        """Test that ruin probabilities are consistent and logical."""
+        loss_generator, insurance_program, manufacturer = setup_engine
+
+        # Create a scenario with higher loss probability
+        loss_generator.generate_losses = Mock(
+            side_effect=lambda duration, revenue: (
+                [Mock(amount=2_000_000)] if np.random.random() < 0.3 else [],
+                None,
+            )
+        )
+
+        config = SimulationConfig(
+            n_simulations=1000,
+            n_years=15,
+            ruin_evaluation=[3, 6, 9, 12],
+            parallel=False,
+            seed=42,
+        )
+
+        engine = MonteCarloEngine(
+            loss_generator=loss_generator,
+            insurance_program=insurance_program,
+            manufacturer=manufacturer,
+            config=config,
+        )
+
+        results = engine.run()
+
+        # Check monotonicity
+        prev_prob = 0.0
+        for year in [3, 6, 9, 12, 15]:
+            year_str = str(year)
+            assert year_str in results.ruin_probability
+            current_prob = results.ruin_probability[year_str]
+
+            # Probability should not decrease over time
+            assert (
+                current_prob >= prev_prob
+            ), f"Ruin probability decreased from {prev_prob} to {current_prob} at year {year}"
+            prev_prob = current_prob


### PR DESCRIPTION
## Summary

Closes #191

This PR implements periodic ruin probability tracking in the MonteCarloEngine, allowing users to track ruin probability at multiple time horizons during simulation runtime.

## Changes Made

- ✅ Added `ruin_evaluation` parameter to `SimulationConfig` to specify evaluation time points
- ✅ Changed `SimulationResults.ruin_probability` from `float` to `Dict[str, float]`
- ✅ Updated `_run_single_simulation` to track ruin at specified evaluation points
- ✅ Modified all execution paths (sequential, parallel, enhanced) to support periodic tracking
- ✅ Updated result aggregation methods to handle periodic ruin data
- ✅ Enhanced `summary()` method to display periodic ruin probabilities clearly
- ✅ Added comprehensive test suite for the new functionality

## Breaking Changes

⚠️ **Breaking Change**: `SimulationResults.ruin_probability` is now a `Dict[str, float]` instead of `float`. 

- The dictionary keys are string representations of years (e.g., "5", "10", "20")
- The final simulation year is always included
- Code that accesses `ruin_probability` directly will need updates

## Test Plan

- [x] Unit tests for basic periodic evaluation
- [x] Test with no evaluation points specified (defaults to final year only)
- [x] Test parallel execution compatibility
- [x] Test edge cases (evaluation beyond simulation years, empty lists)
- [x] Test monotonicity of ruin probabilities over time

## Notes

- Some existing code in other modules (e.g., `strategy_backtester.py`, `batch_processor.py`) will need updates to work with the new `Dict[str, float]` format
- As per issue requirements, no backward compatibility was maintained
- Parallel test may fail on Windows due to known pickling issues

🤖 Generated with [Claude Code](https://claude.ai/code)