### PR TITLE
Fix: Math domain error in time-weighted ROE (#211)

### DIFF
--- a/ergodic_insurance/simulation.py
+++ b/ergodic_insurance/simulation.py
@@ -176,8 +176,12 @@ class SimulationResults:
             return 0.0
 
         # For time-weighted average, we use geometric mean for compounding returns
+        # Guard against total loss scenarios where ROE <= -1 would cause log domain errors
+        # Clip to -0.99 (99% loss) to maintain valid growth factors >= 0.01
+        clipped_roe = np.clip(valid_roe, -0.99, None)
+
         # Convert ROE to growth factors (1 + roe)
-        growth_factors = 1 + valid_roe
+        growth_factors = 1 + clipped_roe
 
         # Geometric mean minus 1 to get average return
         time_weighted_roe = np.exp(np.mean(np.log(growth_factors))) - 1


### PR DESCRIPTION
## Summary

Closes #211

Fixes math domain error in `calculate_time_weighted_roe()` when ROE values of -100% or worse occur during bankruptcy/total loss scenarios.

## Changes Made

- **ergodic_insurance/simulation.py**: Added guard clause to clip ROE values to -0.99 minimum before computing logarithm. This ensures `1 + roe >= 0.01`, preventing `np.log()` from failing with domain errors or returning `-inf`.

- **ergodic_insurance/tests/test_simulation.py**: Added regression test `test_time_weighted_roe_total_loss` covering:
  - ROE of -100% (total loss)
  - ROE worse than -100% (edge case)
  - Verification that results are valid finite floats

## Rationale

The fix follows the existing pattern used in `risk_metrics.py:897` which clips ROE to -0.99 for the same reason. A 99% loss floor is appropriate because:
1. It represents near-total ruin while maintaining mathematical validity
2. It's consistent with how the codebase handles extreme losses elsewhere
3. It preserves the spirit of geometric averaging while avoiding numerical issues

## Test Plan

- [x] Existing `test_time_weighted_roe` passes (normal scenarios)
- [x] New `test_time_weighted_roe_total_loss` passes (edge cases)
- [x] All 15 simulation tests pass
- [x] Pre-commit hooks pass (black, isort, mypy, pylint)