### PR TITLE
Fix: Double counting of insurance premiums in cash flow statement

### DIFF
--- a/ergodic_insurance/financial_statements.py
+++ b/ergodic_insurance/financial_statements.py
@@ -248,10 +248,12 @@ class CashFlowStatement:
     def _calculate_financing_cash_flow(
         self, current: Dict[str, float], prior: Dict[str, float], period: str
     ) -> Dict[str, float]:
-        """Calculate financing cash flow (dividends, equity changes, and insurance premiums).
+        """Calculate financing cash flow (dividends and equity changes).
 
-        Insurance premium payments are included in financing activities as they
-        represent pre-funding of risk management activities, similar to debt service.
+        Note: Insurance premiums are NOT included here because they are already
+        reflected in Net Income (which flows into Operating Activities). Including
+        them here would result in double counting. Insurance premiums are deducted
+        as an operating expense when calculating Net Income in the manufacturer.
 
         Args:
             current: Current period metrics
@@ -266,15 +268,9 @@ class CashFlowStatement:
         if period == "monthly":
             dividends = dividends / 12
 
-        # Get insurance premium payments
-        insurance_premiums = current.get("insurance_premiums_paid", 0)
-        if period == "monthly":
-            insurance_premiums = insurance_premiums / 12
-
         financing_items = {
             "dividends_paid": -dividends,  # Cash outflow
-            "insurance_premiums": -insurance_premiums,  # Cash outflow
-            "total": -(dividends + insurance_premiums),
+            "total": -dividends,
         }
 
         return financing_items


### PR DESCRIPTION
## Summary

Closes #212

- Removed insurance premiums from `_calculate_financing_cash_flow` method in `financial_statements.py`
- Insurance premiums are already reflected in Net Income (Operating Activities), so including them in Financing Activities caused double counting
- This fix corrects the understated ending cash position

## Changes Made

1. **`ergodic_insurance/financial_statements.py`**:
   - Removed `insurance_premiums` retrieval and calculation from `_calculate_financing_cash_flow`
   - Updated docstring to clarify why insurance premiums are NOT included in financing section
   - Financing section now only includes dividends paid

2. **`ergodic_insurance/tests/test_cash_flow_statement.py`**:
   - Added `test_insurance_premiums_not_in_financing` regression test
   - Test verifies insurance premiums are NOT in financing section even when `insurance_premiums_paid` exists in metrics
   - Test confirms financing total only includes dividends

## Testing Performed

- All 15 cash flow statement tests pass
- All 26 financial statement tests pass
- New regression test validates the fix

## Technical Details

The issue was that insurance premiums were counted twice:
1. **Implicitly** in Operating Activities via Net Income (premiums are deducted when calculating Net Income in `manufacturer.py`)
2. **Explicitly** in Financing Activities (the now-removed code)

This double counting understated the company's ending cash position.