### PR TITLE
Fix fragile optional imports hiding logic (#214)

### DIFF
--- a/ergodic_insurance/claim_generator.py
+++ b/ergodic_insurance/claim_generator.py
@@ -44,9 +44,12 @@ Since:
 """
 
 from dataclasses import dataclass
+import logging
 from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 # Import trend classes for frequency and severity adjustments
 from .trends import NoTrend, Trend
@@ -58,7 +61,17 @@ try:
     from .loss_distributions import ManufacturingLossGenerator
 
     ENHANCED_DISTRIBUTIONS_AVAILABLE = True
-except ImportError:
+except ModuleNotFoundError:
+    # Module doesn't exist - this is expected in minimal installations
+    ENHANCED_DISTRIBUTIONS_AVAILABLE = False
+    LossData = None  # type: ignore
+except ImportError as e:
+    # Module exists but has issues (syntax error, missing dependency, etc.)
+    logger.warning(
+        "loss_distributions module exists but failed to import: %s. "
+        "Falling back to standard distributions.",
+        e,
+    )
     ENHANCED_DISTRIBUTIONS_AVAILABLE = False
     LossData = None  # type: ignore
 
@@ -67,7 +80,17 @@ try:
     from .exposure_base import ExposureBase
 
     EXPOSURE_BASE_AVAILABLE = True
-except ImportError:
+except ModuleNotFoundError:
+    # Module doesn't exist - this is expected in minimal installations
+    EXPOSURE_BASE_AVAILABLE = False
+    ExposureBase = None  # type: ignore
+except ImportError as e:
+    # Module exists but has issues (syntax error, missing dependency, etc.)
+    logger.warning(
+        "exposure_base module exists but failed to import: %s. "
+        "Dynamic exposure scaling will be unavailable.",
+        e,
+    )
     EXPOSURE_BASE_AVAILABLE = False
     ExposureBase = None  # type: ignore
 


### PR DESCRIPTION
## Summary

Closes #214

This PR fixes the fragile optional import handling in `claim_generator.py` that was silently hiding real errors.

## Changes

- Changed from catching generic `ImportError` to `ModuleNotFoundError` specifically for missing module detection
- Added separate `ImportError` handler that logs warnings for other import failures (syntax errors, missing dependencies in the module)
- Added module-level logger (`logging.getLogger(__name__)`) for warning messages

## Why

Previously, the `try...except ImportError` pattern would catch not only missing modules (expected) but also:
- Syntax errors in the module
- Missing dependencies within the module
- Other import-time failures

This made debugging "why is my enhanced simulation not running?" very difficult since the system silently fell back to legacy logic.

## Test plan

- [x] All 38 existing tests in `test_claim_generator.py` pass
- [x] Module imports successfully with enhanced distributions available
- [x] Pre-commit hooks pass (black, isort, mypy)