### PR TITLE
Bug Fix: Remove Depreciation Fallback Logic from Reporting Layer

### DIFF
--- a/ergodic_insurance/financial_statements.py
+++ b/ergodic_insurance/financial_statements.py
@@ -124,11 +124,13 @@ class CashFlowStatement:
             net_income = net_income / 12
 
         # Add back non-cash items
-        depreciation = current.get("depreciation_expense", 0)
-        if depreciation == 0:
-            # Estimate if not available
-            gross_ppe = current.get("gross_ppe", current.get("assets", 0) * 0.7)
-            depreciation = gross_ppe * 0.1
+        # Depreciation expense MUST be provided by the Manufacturer class
+        if "depreciation_expense" not in current:
+            raise ValueError(
+                "depreciation_expense missing from metrics. "
+                "The Manufacturer class must calculate and provide depreciation_expense explicitly."
+            )
+        depreciation = current["depreciation_expense"]
         if period == "monthly":
             depreciation = depreciation / 12
 
@@ -233,10 +235,13 @@ class CashFlowStatement:
         prior_ppe = prior.get("gross_ppe", 0) if prior else 0
 
         # Get depreciation for the period
-        depreciation = current.get("depreciation_expense", 0)
-        if depreciation == 0:
-            # Estimate if not available
-            depreciation = current_ppe * 0.1
+        # Depreciation expense MUST be provided by the Manufacturer class
+        if "depreciation_expense" not in current:
+            raise ValueError(
+                "depreciation_expense missing from metrics. "
+                "The Manufacturer class must calculate and provide depreciation_expense explicitly."
+            )
+        depreciation = current["depreciation_expense"]
 
         # Capex = Change in PP&E + Depreciation
         # (Since depreciation reduces net PP&E, we add it back)
@@ -826,12 +831,13 @@ class FinancialStatementGenerator:
             admin_depreciation_alloc = 0.3  # 30% to SG&A
 
         # Calculate total depreciation
-        # Get from metrics or estimate from assets
-        total_depreciation = metrics.get("depreciation_expense", 0)
-        if total_depreciation == 0:
-            # Estimate depreciation if not available (10% of gross PP&E)
-            gross_ppe = metrics.get("gross_ppe", metrics.get("assets", 0) * 0.7)
-            total_depreciation = gross_ppe * 0.1
+        # Depreciation expense MUST be provided by the Manufacturer class
+        if "depreciation_expense" not in metrics:
+            raise ValueError(
+                "depreciation_expense missing from metrics. "
+                "The Manufacturer class must calculate and provide depreciation_expense explicitly."
+            )
+        total_depreciation = metrics["depreciation_expense"]
 
         if monthly:
             total_depreciation = total_depreciation / 12

--- a/ergodic_insurance/tests/test_financial_statements.py
+++ b/ergodic_insurance/tests/test_financial_statements.py
@@ -64,6 +64,8 @@ class TestFinancialStatementGenerator:
         )
 
         # Create sample metrics history
+        # Note: Balance sheet calculates total_assets = current_assets + net_ppe + restricted_assets
+        # Where net_ppe = gross_ppe - accumulated_depreciation
         manufacturer.metrics_history = [
             {
                 "year": 0,
@@ -81,6 +83,10 @@ class TestFinancialStatementGenerator:
                 "roe": 0.03,
                 "roa": 0.03,
                 "asset_turnover": 0.5,
+                "gross_ppe": 7_000_000,
+                "accumulated_depreciation": 0,
+                "depreciation_expense": 700_000,  # 10-year useful life
+                "cash": 3_000_000,  # Current assets to make total = 10M
             },
             {
                 "year": 1,
@@ -98,6 +104,10 @@ class TestFinancialStatementGenerator:
                 "roe": 0.03,
                 "roa": 0.03,
                 "asset_turnover": 0.5,
+                "gross_ppe": 7_200_000,
+                "accumulated_depreciation": 700_000,
+                "depreciation_expense": 720_000,
+                "cash": 3_300_000,  # Year 1: 3.3M cash + 6.5M net_ppe + 0.5M restricted = 10.3M
             },
             {
                 "year": 2,
@@ -115,6 +125,10 @@ class TestFinancialStatementGenerator:
                 "roe": 0.03,
                 "roa": 0.03,
                 "asset_turnover": 0.5,
+                "gross_ppe": 7_400_000,
+                "accumulated_depreciation": 1_420_000,
+                "depreciation_expense": 740_000,
+                "cash": 4_429_000,  # Year 2: 4.429M cash + 5.98M net_ppe + 0.2M restricted = 10.609M
             },
         ]
 


### PR DESCRIPTION
## Summary

Closes #222

This PR removes the problematic fallback logic from the financial statements reporting layer that was inventing data when `depreciation_expense` was missing or zero.

## Problem

The `CashFlowStatement` class contained fallback logic in three methods that assumed a 10-year useful life for assets (10% depreciation rate) when `depreciation_expense` was not provided:

```python
if depreciation == 0:
    depreciation = gross_ppe * 0.1
```

This hardcoded business logic in the view/reporting layer, creating discrepancies between the simulated cash balance and reported cash flow statements.

## Solution

1. **Removed fallback logic** from three methods:
   - `_calculate_operating_cash_flow()` (lines 128-131)
   - `_calculate_capex()` (lines 236-239)
   - `_build_gaap_expenses_section()` (lines 830-834)

2. **Added proper error handling** to raise descriptive `ValueError` if `depreciation_expense` is missing from metrics, with clear guidance that the Manufacturer class must provide this data explicitly.

3. **Updated test fixtures** to include `depreciation_expense` data, ensuring tests properly reflect production usage.

## Verification

- The `Manufacturer` class already calculates and provides `depreciation_expense` in its metrics dictionary (manufacturer.py:2704)
- All existing tests pass (58 tests across cash flow, financial statements, and depreciation tracking modules)
- The reporting layer no longer invents assumptions - it now fails fast with a clear error message if data is missing

## Testing Performed

```bash
pytest ergodic_insurance/tests/test_cash_flow_statement.py -v          # 15 passed
pytest ergodic_insurance/tests/test_financial_statements.py -v         # 26 passed
pytest ergodic_insurance/tests/test_depreciation_tracking.py -v        # 17 passed
```

All tests pass. No edge cases were found where the fallback logic was actually needed - the Manufacturer always provides depreciation_expense when running simulations.

## Files Modified

- `ergodic_insurance/financial_statements.py`: Removed fallback logic, added error handling
- `ergodic_insurance/tests/test_financial_statements.py`: Updated test fixtures with depreciation data

## Impact

- **Breaking Change**: If any code attempts to generate financial statements with metrics that don't include `depreciation_expense`, it will now raise a clear error instead of silently estimating.
- **Expected Impact**: None for normal usage, as the Manufacturer class always provides this data.
- **Benefit**: Eliminates discrepancies between simulated cash balance and reported cash flow statements.