### PR TITLE
Fix: Move fiscal_year_end default to central Config object

### DIFF
--- a/ergodic_insurance/config.py
+++ b/ergodic_insurance/config.py
@@ -382,6 +382,9 @@ class SimulationConfig(BaseModel):
         max_horizon_years: Maximum supported horizon to prevent excessive
             memory usage.
         random_seed: Random seed for reproducibility. None for random.
+        fiscal_year_end: Month of fiscal year end (1-12). Default is 12
+            (December) for calendar year alignment. Set to 6 for June,
+            3 for March, etc. to match different fiscal calendars.
 
     Examples:
         Quick test simulation::
@@ -401,6 +404,14 @@ class SimulationConfig(BaseModel):
                 random_seed=None  # Random each run
             )
 
+        Non-calendar fiscal year::
+
+            sim = SimulationConfig(
+                time_resolution='annual',
+                time_horizon_years=50,
+                fiscal_year_end=6  # June fiscal year end
+            )
+
     Note:
         For ergodic analysis, horizons of 100+ years are recommended
         to observe long-term time averages.
@@ -415,6 +426,12 @@ class SimulationConfig(BaseModel):
     )
     random_seed: Optional[int] = Field(
         default=None, ge=0, description="Random seed for reproducibility"
+    )
+    fiscal_year_end: int = Field(
+        default=12,
+        ge=1,
+        le=12,
+        description="Month of fiscal year end (1-12). Default is 12 (December) for calendar year.",
     )
 
     @model_validator(mode="after")

--- a/ergodic_insurance/tests/test_financial_statements.py
+++ b/ergodic_insurance/tests/test_financial_statements.py
@@ -31,7 +31,9 @@ class TestFinancialStatementConfig:
         assert config.decimal_places == 0
         assert config.include_yoy_change is True
         assert config.include_percentages is True
-        assert config.fiscal_year_end == 12
+        # fiscal_year_end defaults to None, allowing inheritance from central config
+        # It gets resolved to 12 when used with a generator without central config
+        assert config.fiscal_year_end is None
         assert config.consolidate_monthly is True
 
     def test_custom_config(self):


### PR DESCRIPTION
## Summary
Closes #228

This PR moves the hardcoded `fiscal_year_end` default from `FinancialStatementConfig` to the central `Config` object (`SimulationConfig`), allowing it to be globally controlled for the entire simulation context.

## Changes Made

- **`ergodic_insurance/config.py`**: Added `fiscal_year_end` field to `SimulationConfig` with:
  - Default value of 12 (December - calendar year)
  - Validation to ensure value is between 1-12
  - Updated docstring with examples

- **`ergodic_insurance/financial_statements.py`**:
  - Changed `FinancialStatementConfig.fiscal_year_end` from `int = 12` to `Optional[int] = None`
  - Updated docstring to explain inheritance from central config
  - `FinancialStatementGenerator.__init__` now resolves fiscal_year_end from central config when None
  - `MonteCarloStatementAggregator.__init__` defaults to 12 when no central config is available

- **`ergodic_insurance/tests/test_financial_statements.py`**: Updated test to expect None as default

## Testing Performed

- All 55 tests pass (financial_statements + config tests)
- Verified SimulationConfig accepts fiscal_year_end 1-12 and rejects invalid values
- Verified FinancialStatementGenerator inherits from central config when fiscal_year_end is None
- Verified backward compatibility: explicit values still work

## Edge Cases Considered

- When no central config is available, defaults to 12 (December)
- When explicit fiscal_year_end is passed to FinancialStatementConfig, it takes precedence
- MonteCarloStatementAggregator doesn't have access to central config, defaults to 12