### PR TITLE
Fix: Remove legacy accrued_expenses field to prevent double-counting

### DIFF
--- a/ergodic_insurance/tests/test_accrual_integration.py
+++ b/ergodic_insurance/tests/test_accrual_integration.py
@@ -56,8 +56,8 @@ class TestAccrualIntegration:
         # Record wage accrual
         manufacturer.record_wage_accrual(wage_amount, PaymentSchedule.IMMEDIATE)
 
-        # Check accrual was recorded
-        assert manufacturer.accrued_expenses == wage_amount
+        # Check accrual was recorded in AccrualManager (single source of truth - issue #238)
+        assert manufacturer.accrual_manager.get_total_accrued_expenses() == wage_amount
 
         # Process payment in same period
         initial_cash = manufacturer.cash
@@ -134,9 +134,8 @@ class TestAccrualIntegration:
         # Reset manufacturer
         manufacturer.reset()
 
-        # Verify accruals cleared
+        # Verify accruals cleared (AccrualManager is single source of truth - issue #238)
         assert manufacturer.accrual_manager.get_total_accrued_expenses() == 0
-        assert manufacturer.accrued_expenses == 0
 
     def test_monthly_resolution_accrual_sync(self, manufacturer):
         """Test accrual manager syncs with monthly resolution."""


### PR DESCRIPTION
## Summary

Closes #238

This PR fixes the double-counting of liabilities bug caused by the `max()` logic between the legacy `accrued_expenses` float and `AccrualManager`.

**The Problem:** The code maintained two parallel systems for tracking accrued expenses:
1. `self.accrued_expenses` - a legacy float
2. `AccrualManager` - detailed per-item accrual tracking

The `total_liabilities` property used `max(self.accrued_expenses, adjusted_accrued_expenses)` assuming both tracked the same underlying value. However, if they drifted out of sync, the higher (inflated) value was selected, leading to:
- Overstated liabilities
- Understated equity/solvency
- Potential premature bankruptcy triggers

**The Fix:** Completely deprecate and remove the legacy `accrued_expenses` field. `AccrualManager` is now the single source of truth.

## Changes Made

- **manufacturer.py**:
  - Removed `self.accrued_expenses` field initialization
  - Updated `total_liabilities` to use only AccrualManager data
  - Updated `get_financial_metrics` to use only AccrualManager data
  - Removed legacy float updates from `_process_accrual_payments`
  - Removed legacy float increment from `record_wage_accrual`
  - Removed reset of legacy field in `reset()` method

- **tests/test_accrual_integration.py**:
  - Updated `test_wage_accrual_immediate_payment` to verify AccrualManager
  - Updated `test_accrual_reset` to remove assertion on removed field

## Testing

- All 9 accrual integration tests pass
- All 53 related manufacturer/balance sheet tests pass
- All 25 cash flow and financial integration tests pass

## Impact

- Net removal of 24 lines of code
- Eliminates all possibility of accrued expenses drift
- Single source of truth for balance sheet reporting