### PR TITLE
Fix: Dividend phantom payments - track actual dividends with cash constraints (#239)

### DIFF
--- a/ergodic_insurance/financial_statements.py
+++ b/ergodic_insurance/financial_statements.py
@@ -283,14 +283,24 @@ class CashFlowStatement:
         return financing_items
 
     def _calculate_dividends(self, current: Dict[str, float]) -> float:
-        """Calculate dividends paid based on retention ratio.
+        """Get dividends paid from metrics or calculate as fallback.
+
+        Issue #239: The WidgetManufacturer now tracks actual dividends_paid
+        considering cash constraints. This method should read that value
+        instead of calculating it, which may report phantom payments.
 
         Args:
             current: Current period metrics
 
         Returns:
-            Dividends paid amount
+            Dividends paid amount (actual from metrics if available)
         """
+        # Prefer actual dividends_paid from metrics (tracks cash constraints)
+        if "dividends_paid" in current:
+            return current["dividends_paid"]
+
+        # Fallback: Calculate from net income (backward compatibility)
+        # This path is used when metrics don't have dividends_paid
         net_income = current.get("net_income", 0)
 
         # Only pay dividends on positive income

--- a/ergodic_insurance/tests/test_dividend_phantom_payments.py
+++ b/ergodic_insurance/tests/test_dividend_phantom_payments.py
@@ -1,0 +1,350 @@
+"""Unit tests for Issue #239: Fix Dividend "Phantom" Payments.
+
+Tests verify that:
+1. Dividends are not paid when cash is insufficient (cash-constrained)
+2. Dividends are reduced when cash is partially sufficient
+3. The WidgetManufacturer correctly tracks actual dividends paid
+4. The CashFlowStatement reads dividends_paid from metrics
+5. Cash flow reconciliation works correctly with constrained dividends
+"""
+
+import pytest
+
+from ergodic_insurance.config import ManufacturerConfig
+from ergodic_insurance.financial_statements import CashFlowStatement
+from ergodic_insurance.manufacturer import WidgetManufacturer
+
+
+class TestDividendPhantomPayments:
+    """Test suite for dividend phantom payment fixes."""
+
+    config: ManufacturerConfig  # Set in setup_method
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        # Create a base configuration with 30% dividend payout (70% retention)
+        self.config = ManufacturerConfig(
+            initial_assets=1_000_000,
+            base_operating_margin=0.10,  # 10% margin
+            tax_rate=0.25,
+            retention_ratio=0.7,  # 70% retained, 30% dividends
+            asset_turnover_ratio=0.8,
+            insolvency_tolerance=100,
+        )
+
+    def test_full_dividends_when_cash_sufficient(self):
+        """Test that full dividends are paid when cash is sufficient."""
+        manufacturer = WidgetManufacturer(self.config)
+
+        # Run a step to generate income
+        metrics = manufacturer.step()
+
+        # With sufficient cash, dividends should be paid based on retention ratio
+        net_income = metrics.get("net_income", 0)
+        if net_income > 0:
+            expected_dividends = net_income * (1 - manufacturer.retention_ratio)
+            actual_dividends = metrics.get("dividends_paid", 0)
+            # Should be close to expected (may be less if cash constrained)
+            assert actual_dividends <= expected_dividends + 0.01
+            assert actual_dividends >= 0
+
+    def test_no_dividends_when_net_loss(self):
+        """Test that no dividends are paid when there's a net loss."""
+        # Create a config with low margin that might lead to losses
+        manufacturer = WidgetManufacturer(self.config)
+
+        # Simulate a loss scenario by setting up conditions
+        # The _last_dividends_paid should be 0 for loss scenarios
+        manufacturer._last_dividends_paid = 0  # Reset
+
+        # Call update_balance_sheet with a loss
+        initial_cash = manufacturer.cash
+        manufacturer.update_balance_sheet(-100_000)  # Net loss
+
+        # No dividends should be paid on a loss
+        assert manufacturer._last_dividends_paid == 0
+
+    def test_dividends_constrained_by_cash(self):
+        """Test that dividends are constrained when cash is insufficient."""
+        manufacturer = WidgetManufacturer(self.config)
+
+        # Set up a scenario with low cash but positive income
+        # This simulates timing differences (recognized revenue not yet collected)
+        manufacturer.cash = 10  # Very low cash
+        initial_equity = manufacturer.equity
+
+        # Positive net income but not enough cash to pay full dividends
+        net_income = 1000  # $1000 net income
+        theoretical_dividends = net_income * (1 - manufacturer.retention_ratio)  # $300
+        retained_earnings = net_income * manufacturer.retention_ratio  # $700
+
+        # After adding retained earnings, cash would be $10 + $700 = $710
+        # This is more than theoretical dividends ($300), so full dividends can be paid
+        manufacturer.update_balance_sheet(net_income)
+
+        # In this case, full dividends can be paid
+        assert manufacturer._last_dividends_paid <= theoretical_dividends + 0.01
+
+    def test_no_dividends_when_projected_cash_negative(self):
+        """Test no dividends when projected cash after operations is negative."""
+        manufacturer = WidgetManufacturer(self.config)
+
+        # Set up extreme scenario: very negative cash
+        manufacturer.cash = -1000  # Negative cash (possible due to timing)
+
+        # Positive net income
+        net_income = 500  # $500 net income
+        retained_earnings = net_income * manufacturer.retention_ratio  # $350
+
+        # Projected cash = -1000 + 350 = -650 (still negative)
+        # No dividends can be paid
+        manufacturer.update_balance_sheet(net_income)
+
+        # Dividends should be 0 since projected cash <= 0
+        assert manufacturer._last_dividends_paid == 0
+
+        # All earnings should be retained to improve cash position
+        # Cash should be: -1000 + 500 = -500 (all income retained, no dividends)
+        expected_cash = -1000 + net_income  # Full income retained
+        assert abs(manufacturer.cash - expected_cash) < 0.01
+
+    def test_partial_dividends_when_cash_partially_sufficient(self):
+        """Test partial dividends when cash is partially sufficient."""
+        manufacturer = WidgetManufacturer(self.config)
+
+        # Set up scenario where only partial dividends can be paid
+        manufacturer.cash = -500  # Negative cash
+
+        net_income = 1000  # $1000 net income
+        retained_earnings = net_income * manufacturer.retention_ratio  # $700
+        theoretical_dividends = net_income * (1 - manufacturer.retention_ratio)  # $300
+
+        # Projected cash = -500 + 700 = 200
+        # Can only pay $200 in dividends (what's projected available)
+        manufacturer.update_balance_sheet(net_income)
+
+        # Partial dividends should be paid
+        assert manufacturer._last_dividends_paid == pytest.approx(200, abs=0.01)
+
+        # Cash accounting:
+        # Beginning: -500
+        # Add net income: +1000
+        # Pay dividends: -200
+        # Ending: 300
+        # Which equals: -500 + retained_earnings(700) + additional_retained(100) = 300
+        assert manufacturer.cash == pytest.approx(300, abs=0.01)
+
+    def test_metrics_use_actual_dividends_paid(self):
+        """Test that calculate_metrics uses the tracked _last_dividends_paid."""
+        manufacturer = WidgetManufacturer(self.config)
+
+        # Set a specific value for _last_dividends_paid
+        manufacturer._last_dividends_paid = 12345.67
+
+        # Calculate metrics
+        metrics = manufacturer.calculate_metrics()
+
+        # Metrics should use the tracked value, not recalculate
+        assert metrics["dividends_paid"] == 12345.67
+
+    def test_cash_flow_statement_reads_from_metrics(self):
+        """Test that CashFlowStatement reads dividends_paid from metrics."""
+        # Create metrics with explicit dividends_paid
+        # Use float literals for type consistency
+        metrics_history: list[dict[str, float]] = [
+            {
+                "net_income": 1000000.0,
+                "depreciation_expense": 100000.0,
+                "cash": 500000.0,
+                "accounts_receivable": 0.0,
+                "inventory": 0.0,
+                "prepaid_insurance": 0.0,
+                "accounts_payable": 0.0,
+                "accrued_expenses": 0.0,
+                "claim_liabilities": 0.0,
+                "gross_ppe": 1000000.0,
+                "dividends_paid": 123456.0,  # Explicit value
+            },
+        ]
+
+        cash_flow = CashFlowStatement(metrics_history)
+        financing_cf = cash_flow._calculate_financing_cash_flow(metrics_history[0], {}, "annual")
+
+        # Should read from metrics, not calculate
+        assert financing_cf["dividends_paid"] == pytest.approx(-123456)
+
+    def test_cash_flow_statement_fallback_without_metrics(self):
+        """Test CashFlowStatement falls back to calculation when no dividends_paid."""
+        # Create metrics WITHOUT dividends_paid
+        # Use float literals for type consistency
+        metrics_history: list[dict[str, float]] = [
+            {
+                "net_income": 1000000.0,
+                "depreciation_expense": 100000.0,
+                "cash": 500000.0,
+                "gross_ppe": 1000000.0,
+                # No dividends_paid key
+            },
+        ]
+
+        cash_flow = CashFlowStatement(metrics_history)
+        financing_cf = cash_flow._calculate_financing_cash_flow(metrics_history[0], {}, "annual")
+
+        # Should fall back to calculation: 1M * 0.3 = 300K
+        expected_dividends = 1000000 * 0.3  # Default 30% payout
+        assert financing_cf["dividends_paid"] == pytest.approx(-expected_dividends)
+
+    def test_insolvency_sets_dividends_to_zero(self):
+        """Test that insolvency scenarios set dividends to zero."""
+        manufacturer = WidgetManufacturer(self.config)
+
+        # Set up insolvency scenario
+        manufacturer.cash = 100
+        # Simulate very low equity situation
+        manufacturer.gross_ppe = 200  # Minimal assets
+
+        # Large loss that would trigger insolvency
+        manufacturer.update_balance_sheet(-50000)
+
+        # Dividends should be 0 when going insolvent
+        assert manufacturer._last_dividends_paid == 0
+
+    def test_reset_clears_dividends_tracking(self):
+        """Test that reset() clears the dividend tracking."""
+        manufacturer = WidgetManufacturer(self.config)
+
+        # Set some dividend value
+        manufacturer._last_dividends_paid = 99999
+
+        # Reset
+        manufacturer.reset()
+
+        # Should be cleared
+        assert manufacturer._last_dividends_paid == 0
+
+    def test_full_simulation_with_cash_constraints(self):
+        """Integration test: full simulation with varying cash levels."""
+        manufacturer = WidgetManufacturer(self.config)
+
+        # Run several years and track dividend behavior
+        metrics_list = []
+        for _ in range(5):
+            metrics = manufacturer.step()
+            metrics_list.append(metrics)
+
+        # Verify that dividends_paid is always non-negative
+        for metrics in metrics_list:
+            assert metrics["dividends_paid"] >= 0
+
+        # Verify that dividends never exceed net income * (1 - retention_ratio)
+        for metrics in metrics_list:
+            net_income = metrics.get("net_income", 0)
+            if net_income > 0:
+                max_dividends = net_income * (1 - manufacturer.retention_ratio)
+                assert metrics["dividends_paid"] <= max_dividends + 0.01
+
+    def test_cash_flow_reconciliation_with_constrained_dividends(self):
+        """Test that cash flow reconciles correctly with constrained dividends."""
+        manufacturer = WidgetManufacturer(self.config)
+
+        # Run a step
+        initial_cash = manufacturer.cash
+        metrics = manufacturer.step()
+
+        # Generate financial statements
+        from ergodic_insurance.financial_statements import FinancialStatementGenerator
+
+        generator = FinancialStatementGenerator(manufacturer)
+        cash_flow = generator.generate_cash_flow_statement(year=0)
+
+        # Extract ending cash from cash flow statement
+        ending_cash_reported = None
+        for _, row in cash_flow.iterrows():
+            if "Cash - End of Period" in row["Item"]:
+                ending_cash_reported = row["Year 0"]
+                break
+
+        # Actual ending cash
+        actual_ending_cash = manufacturer.cash
+
+        # They should match (or be very close)
+        if ending_cash_reported is not None:
+            assert abs(ending_cash_reported - actual_ending_cash) < 1.0
+
+
+class TestDividendEdgeCases:
+    """Edge case tests for dividend handling."""
+
+    base_config_params: dict[str, float | int]  # Set in setup_method
+
+    def setup_method(self):
+        """Set up base config for edge cases."""
+        self.base_config_params = {
+            "initial_assets": 1_000_000,
+            "base_operating_margin": 0.10,
+            "tax_rate": 0.25,
+            "asset_turnover_ratio": 0.8,
+        }
+
+    def test_zero_net_income(self):
+        """Test dividend handling with exactly zero net income."""
+        config = ManufacturerConfig(
+            **self.base_config_params,
+            retention_ratio=0.7,
+        )
+        manufacturer = WidgetManufacturer(config)
+
+        # Zero net income - no dividends
+        manufacturer.update_balance_sheet(0.0)
+        # Zero is not positive, so dividends code path is not triggered
+        # The else branch adds retained_earnings (0) to cash
+        assert manufacturer._last_dividends_paid == 0
+
+    def test_very_small_net_income(self):
+        """Test dividend handling with very small positive net income."""
+        config = ManufacturerConfig(
+            **self.base_config_params,
+            retention_ratio=0.7,
+        )
+        manufacturer = WidgetManufacturer(config)
+
+        # Small positive income
+        manufacturer.update_balance_sheet(0.01)
+        # Dividends should be 0.003 (0.01 * 0.3) if cash is sufficient
+        # Since the manufacturer has lots of cash, full dividends are paid
+        assert manufacturer._last_dividends_paid == pytest.approx(0.003, abs=0.001)
+
+    def test_retention_ratio_100_percent(self):
+        """Test with 100% retention ratio (no dividends)."""
+        config = ManufacturerConfig(
+            **self.base_config_params,
+            retention_ratio=1.0,  # 100% retention
+        )
+        manufacturer = WidgetManufacturer(config)
+
+        manufacturer.update_balance_sheet(100_000)
+        # 100% retention means theoretical dividends = 0
+        assert manufacturer._last_dividends_paid == 0
+
+    def test_retention_ratio_0_percent(self):
+        """Test with 0% retention ratio (all dividends)."""
+        config = ManufacturerConfig(
+            **self.base_config_params,
+            retention_ratio=0.0,  # 0% retention
+        )
+        manufacturer = WidgetManufacturer(config)
+
+        net_income = 100_000
+        initial_cash = manufacturer.cash
+        manufacturer.update_balance_sheet(net_income)
+
+        # With 0% retention:
+        # - retained_earnings = 0
+        # - theoretical_dividends = 100_000
+        # - projected_cash = initial_cash + 0 = initial_cash
+        # If initial_cash >= 100_000, full dividends paid
+        if initial_cash >= net_income:
+            assert manufacturer._last_dividends_paid == pytest.approx(net_income, rel=0.01)
+        else:
+            # Partial dividends based on available cash
+            assert manufacturer._last_dividends_paid <= initial_cash


### PR DESCRIPTION
## Summary

Fixes #239 - The Financial Statement generator was reporting cash outflows for dividends that never physically occurred when the manufacturer was cash-constrained.

**Root Cause:** Dividends were calculated independently in both `manufacturer.py` and `financial_statements.py` without considering cash constraints. The `update_balance_sheet` method implicitly distributed dividends by not adding them to retained earnings, but the `CashFlowStatement` calculated them independently based on the retention ratio.

**Solution:**
- Added `_last_dividends_paid` tracking variable to `WidgetManufacturer` 
- Modified `update_balance_sheet` to check cash constraints before paying dividends:
  - No dividends when projected cash ≤ 0
  - Partial dividends when projected cash < theoretical dividends  
  - Full dividends only when sufficient cash is available
- Modified `calculate_metrics` to use tracked actual dividends
- Modified `CashFlowStatement._calculate_dividends` to read from metrics first

## Changes

- `ergodic_insurance/manufacturer.py`: Added cash constraint checking and dividend tracking
- `ergodic_insurance/financial_statements.py`: Read dividends from metrics instead of calculating
- `ergodic_insurance/tests/test_dividend_phantom_payments.py`: New test suite with 16 tests

## Test plan

- [x] All 16 new dividend phantom payment tests pass
- [x] All 55 existing manufacturer tests pass
- [x] All 15 cash flow statement tests pass
- [x] All 8 cash reconciliation tests pass
- [x] All 10 financial integration tests pass
- [x] Pre-commit hooks pass (black, isort, mypy, pylint)