### PR TITLE
Fix: Remove cash flow statement plug to expose calculation errors (#240)

### DIFF
--- a/ergodic_insurance/financial_statements.py
+++ b/ergodic_insurance/financial_statements.py
@@ -416,20 +416,8 @@ class CashFlowStatement:
         # This ensures perfect reconciliation
         cash_flow_data.append(("CASH RECONCILIATION", "", ""))
         cash_flow_data.append(("  Cash - Beginning of Period", beginning_cash, ""))
-        cash_flow_data.append(("  Net Change in Cash", actual_cash_change, ""))
+        cash_flow_data.append(("  Net Change in Cash", net_cash_flow, ""))
         cash_flow_data.append(("  Cash - End of Period", ending_cash, ""))
-
-        # Check if our calculated cash flow matches actual
-        if abs(net_cash_flow - actual_cash_change) > 0.01:
-            # Replace the NET INCREASE (DECREASE) IN CASH with actual
-            for i, item in enumerate(cash_flow_data):
-                if item[0] == "NET INCREASE (DECREASE) IN CASH":
-                    cash_flow_data[i] = (
-                        "NET INCREASE (DECREASE) IN CASH",
-                        actual_cash_change,
-                        "total",
-                    )
-                    break
 
         # Create DataFrame
         df = pd.DataFrame(cash_flow_data, columns=["Item", f"{period_label} {year}", "Type"])

--- a/ergodic_insurance/tests/test_cash_flow_statement.py
+++ b/ergodic_insurance/tests/test_cash_flow_statement.py
@@ -31,9 +31,16 @@ class TestCashFlowStatement:
             },
             {
                 # Year 1 metrics - with changes
+                # Cash flow calculation:
+                #   Operating: 1,200k NI + 110k Dep - 50k AR - 30k Inv - 5k Prepaid
+                #              + 20k AP + 10k Accrued + 50k Claims = 1,305k
+                #   Investing: -(200k PP&E change + 110k Dep) = -310k
+                #   Financing: -360k dividends
+                #   Net: 1,305k - 310k - 360k = 635k
+                # Ending cash = 500k + 635k = 1,135k
                 "net_income": 1200000,
                 "depreciation_expense": 110000,
-                "cash": 600000,
+                "cash": 1135000,  # Consistent with cash flow calculation
                 "accounts_receivable": 250000,  # Increased by 50k
                 "inventory": 180000,  # Increased by 30k
                 "prepaid_insurance": 25000,  # Increased by 5k
@@ -153,11 +160,11 @@ class TestCashFlowStatement:
         # Beginning cash (Year 0) = 500,000
         assert values["beginning"] == 500000
 
-        # Ending cash (Year 1) = 600,000
-        assert values["ending"] == 600000
+        # Ending cash (Year 1) = 1,135,000 (consistent with cash flow calculation)
+        assert values["ending"] == 1135000
 
-        # The net change is what makes the equation balance
-        # We're not testing the exact amount, just that the reconciliation works
+        # The calculated cash flow must equal the actual cash change
+        # This is a critical integrity check - no "plug" allowed
         assert abs((values["beginning"] + values["net_change"]) - values["ending"]) < 0.01
 
     def test_monthly_period(self):

--- a/ergodic_insurance/tests/test_cash_reconciliation.py
+++ b/ergodic_insurance/tests/test_cash_reconciliation.py
@@ -16,6 +16,12 @@ class TestCashReconciliation:
 
     def test_simple_reconciliation(self):
         """Test basic cash reconciliation: Beginning + Net Change = Ending."""
+        # Cash flow calculation for Year 1:
+        #   Operating: 600k NI + 60k Dep = 660k
+        #   Investing: -(100k PP&E change + 60k Dep) = -160k
+        #   Financing: -180k dividends
+        #   Net: 660k - 160k - 180k = 320k
+        #   Ending cash: 1,000k + 320k = 1,320k
         metrics: MetricsDict = [
             {
                 "cash": 1000000,
@@ -25,7 +31,7 @@ class TestCashReconciliation:
                 "gross_ppe": 500000,
             },
             {
-                "cash": 1350000,
+                "cash": 1320000,  # Consistent with cash flow calculation
                 "net_income": 600000,
                 "dividends_paid": 180000,
                 "depreciation_expense": 60000,
@@ -49,7 +55,8 @@ class TestCashReconciliation:
 
         # Verify reconciliation
         assert reconciliation["beginning"] == 1000000
-        assert reconciliation["ending"] == 1350000
+        assert reconciliation["ending"] == 1320000
+        # Calculated cash flow must equal actual cash change (no plug)
         assert (
             abs(
                 (reconciliation["beginning"] + reconciliation["net_change"])
@@ -166,6 +173,13 @@ class TestCashReconciliation:
 
     def test_reconciliation_with_all_working_capital_changes(self):
         """Test reconciliation with comprehensive working capital changes."""
+        # Cash flow calculation for Year 1:
+        #   Operating: 600k NI + 110k Dep - 50k AR - 50k Inv - 10k Prepaid
+        #              + 30k AP + 20k Accrued + 50k Claims = 700k
+        #   Investing: -(300k PP&E change + 110k Dep) = -410k
+        #   Financing: -180k dividends
+        #   Net: 700k - 410k - 180k = 110k
+        #   Ending cash: 1,000k + 110k = 1,110k
         metrics: MetricsDict = [
             {
                 "cash": 1000000,
@@ -181,7 +195,7 @@ class TestCashReconciliation:
                 "dividends_paid": 150000,
             },
             {
-                "cash": 1200000,
+                "cash": 1110000,  # Consistent with cash flow calculation
                 "net_income": 600000,
                 "depreciation_expense": 110000,
                 "accounts_receivable": 250000,  # +50k
@@ -201,21 +215,18 @@ class TestCashReconciliation:
         values = self._extract_values_from_df(df, "Year 1")
 
         # Calculate expected net cash flow:
-        # Operating: 600k + 110k - 110k (WC increase) + 100k (liabilities increase) = 700k
+        # Operating: 600k + 110k - 50k - 50k - 10k + 30k + 20k + 50k = 700k
         # Investing: -(300k + 110k) = -410k
         # Financing: -180k
         # Net: 700k - 410k - 180k = 110k
-
-        # But actual change is 1200k - 1000k = 200k
-        # The difference might be due to how we're calculating some items
 
         beginning = values.get("Cash - Beginning of Period")
         ending = values.get("Cash - End of Period")
         net_change = values.get("NET INCREASE (DECREASE) IN CASH", 0)
 
         assert beginning == 1000000
-        assert ending == 1200000
-        # The net change should make the equation balance
+        assert ending == 1110000
+        # Calculated cash flow must equal actual cash change (no plug)
         assert abs((beginning + net_change) - ending) < 0.01
 
     def test_monthly_reconciliation(self):
@@ -260,6 +271,12 @@ class TestCashReconciliation:
 
     def test_zero_beginning_cash(self):
         """Test reconciliation when beginning cash is zero."""
+        # Cash flow calculation for Year 1:
+        #   Operating: 150k NI + 10k Dep = 160k
+        #   Investing: -(10k PP&E change + 10k Dep) = -20k
+        #   Financing: -45k dividends
+        #   Net: 160k - 20k - 45k = 95k
+        #   Ending cash: 0 + 95k = 95k
         metrics: MetricsDict = [
             {
                 "cash": 0,
@@ -269,7 +286,7 @@ class TestCashReconciliation:
                 "dividends_paid": 0,
             },
             {
-                "cash": 80000,
+                "cash": 95000,  # Consistent with cash flow calculation
                 "net_income": 150000,
                 "depreciation_expense": 10000,
                 "gross_ppe": 60000,
@@ -283,13 +300,19 @@ class TestCashReconciliation:
         values = self._extract_values_from_df(df, "Year 1")
 
         assert values.get("Cash - Beginning of Period") == 0
-        assert values.get("Cash - End of Period") == 80000
+        assert values.get("Cash - End of Period") == 95000
 
         net_change = values.get("NET INCREASE (DECREASE) IN CASH", 0)
-        assert net_change == 80000
+        assert net_change == 95000
 
     def test_large_capex_reconciliation(self):
         """Test reconciliation with large capital expenditures."""
+        # Cash flow calculation for Year 1:
+        #   Operating: 1200k NI + 250k Dep = 1450k
+        #   Investing: -(2000k PP&E change + 250k Dep) = -2250k
+        #   Financing: -360k dividends
+        #   Net: 1450k - 2250k - 360k = -1160k
+        #   Ending cash: 5000k - 1160k = 3840k
         metrics: MetricsDict = [
             {
                 "cash": 5000000,
@@ -299,7 +322,7 @@ class TestCashReconciliation:
                 "dividends_paid": 300000,
             },
             {
-                "cash": 3500000,  # Cash decreased due to large capex
+                "cash": 3840000,  # Consistent with cash flow calculation
                 "net_income": 1200000,
                 "depreciation_expense": 250000,
                 "gross_ppe": 4000000,  # Large increase in PP&E
@@ -317,13 +340,84 @@ class TestCashReconciliation:
         assert capex == 2250000
 
         # Net change should be negative due to large capex
+        # Calculated: 1450k - 2250k - 360k = -1160k
         net_change = values.get("NET INCREASE (DECREASE) IN CASH", 0)
-        assert net_change == -1500000  # 3.5M - 5M
+        assert net_change == -1160000
 
         # Verify reconciliation
         beginning = values.get("Cash - Beginning of Period")
         ending = values.get("Cash - End of Period")
         assert abs((beginning + net_change) - ending) < 0.01
+
+    def test_no_plug_regression(self):
+        """Regression test: Verify the cash flow plug has been removed.
+
+        This is a regression test for GitHub Issue #240.
+
+        Previously, the CashFlowStatement would silently overwrite the calculated
+        NET INCREASE (DECREASE) IN CASH with the actual cash change (ending - beginning)
+        if they didn't match. This "plug" hid underlying calculation errors.
+
+        This test verifies that:
+        1. The calculated cash flow matches the actual cash change
+        2. No silent overwriting occurs
+        """
+        # Create metrics where cash flow components are explicitly calculated
+        # to verify the statement shows calculated values, not plugged values
+        metrics: MetricsDict = [
+            {
+                "cash": 1000000,
+                "net_income": 400000,
+                "depreciation_expense": 100000,
+                "accounts_receivable": 100000,
+                "inventory": 100000,
+                "accounts_payable": 50000,
+                "gross_ppe": 500000,
+                "dividends_paid": 120000,
+            },
+            {
+                # Calculate ending cash from components:
+                # Operating: 500k NI + 120k Dep - 50k AR - 40k Inv + 30k AP = 560k
+                # Investing: -(100k PP&E change + 120k Dep) = -220k
+                # Financing: -150k dividends
+                # Net: 560k - 220k - 150k = 190k
+                # Ending: 1000k + 190k = 1190k
+                "cash": 1190000,  # Consistent with calculation
+                "net_income": 500000,
+                "depreciation_expense": 120000,
+                "accounts_receivable": 150000,  # +50k
+                "inventory": 140000,  # +40k
+                "accounts_payable": 80000,  # +30k
+                "gross_ppe": 600000,  # +100k
+                "dividends_paid": 150000,
+            },
+        ]
+
+        cash_flow = CashFlowStatement(metrics)
+        df = cash_flow.generate_statement(1)
+        values = self._extract_values_from_df(df, "Year 1")
+
+        # Get the reported values
+        net_cash_flow = values.get("NET INCREASE (DECREASE) IN CASH", 0)
+        beginning_cash = values.get("Cash - Beginning of Period")
+        ending_cash = values.get("Cash - End of Period")
+
+        # Verify the calculated cash flow matches actual change
+        actual_change = ending_cash - beginning_cash
+        assert net_cash_flow == actual_change, (
+            f"Calculated cash flow ({net_cash_flow}) does not match "
+            f"actual change ({actual_change}). This suggests the plug may be active."
+        )
+
+        # Explicitly verify the expected value
+        # Operating: 500k + 120k - 50k - 40k + 30k = 560k
+        # Investing: -(100k + 120k) = -220k
+        # Financing: -150k
+        # Net: 560k - 220k - 150k = 190k
+        assert net_cash_flow == 190000, (
+            f"Calculated cash flow ({net_cash_flow}) does not match "
+            "expected calculation (190000)."
+        )
 
     def _extract_values_from_df(self, df, column):
         """Helper to extract numeric values from DataFrame."""


### PR DESCRIPTION
## Summary

Closes #240

Removes the "plug" in `CashFlowStatement._format_statement()` that silently overwrote the calculated NET INCREASE (DECREASE) IN CASH with the actual cash change when they didn't match. This hidden reconciliation made the cash flow statement visually balance but rendered the line items unreliable for analysis.

## Changes Made

**`ergodic_insurance/financial_statements.py`:**
- Removed 10 lines of plug code that overwrote calculated cash flow with actual cash change
- The reconciliation section now shows the calculated `net_cash_flow` consistently

**`ergodic_insurance/tests/test_cash_flow_statement.py`:**
- Updated test fixture to use consistent cash values (ending cash = beginning cash + calculated cash flow)
- Updated assertion to expect the new consistent ending cash value

**`ergodic_insurance/tests/test_cash_reconciliation.py`:**
- Updated 4 test fixtures to use cash values consistent with the calculated cash flows
- Added new regression test `test_no_plug_regression` to verify the plug has been removed

## Test Plan

- [x] All 24 cash flow statement tests pass
- [x] All 26 financial statement tests pass  
- [x] New regression test explicitly verifies:
  - Calculated cash flow matches actual cash change
  - No silent overwriting occurs
- [x] Test fixtures now use consistent, calculable cash values

## Technical Notes

The test fixtures previously had arbitrary cash values that didn't match the cash flow calculation. For example:
- Original: Beginning 500k + Calculated 635k ≠ Ending 600k (difference of 535k!)
- Fixed: Beginning 500k + Calculated 635k = Ending 1,135k

This fix ensures financial statements show accurate calculated values and any reconciliation discrepancies are visible for debugging rather than hidden.