### PR TITLE
Fix: Remove hardcoded retention_ratio fallback (#243)

### DIFF
--- a/ergodic_insurance/tests/test_cash_flow_statement.py
+++ b/ergodic_insurance/tests/test_cash_flow_statement.py
@@ -9,25 +9,28 @@ from ergodic_insurance.financial_statements import CashFlowStatement
 class TestCashFlowStatement:
     """Test suite for cash flow statement generation."""
 
+    metrics_history: list[dict[str, float]]
+    cash_flow: CashFlowStatement
+
     def setup_method(self):
         """Set up test fixtures."""
         # Create sample metrics history
-        self.metrics_history = [
+        self.metrics_history: list[dict[str, float]] = [
             {
                 # Year 0 metrics
-                "net_income": 1000000,
-                "depreciation_expense": 100000,
-                "cash": 500000,
-                "accounts_receivable": 200000,
-                "inventory": 150000,
-                "prepaid_insurance": 20000,
-                "accounts_payable": 100000,
-                "accrued_expenses": 50000,
-                "claim_liabilities": 0,
-                "gross_ppe": 1000000,
-                "dividends_paid": 300000,  # 30% payout ratio
-                "assets": 2000000,
-                "equity": 1500000,
+                "net_income": 1000000.0,
+                "depreciation_expense": 100000.0,
+                "cash": 500000.0,
+                "accounts_receivable": 200000.0,
+                "inventory": 150000.0,
+                "prepaid_insurance": 20000.0,
+                "accounts_payable": 100000.0,
+                "accrued_expenses": 50000.0,
+                "claim_liabilities": 0.0,
+                "gross_ppe": 1000000.0,
+                "dividends_paid": 300000.0,  # 30% payout ratio
+                "assets": 2000000.0,
+                "equity": 1500000.0,
             },
             {
                 # Year 1 metrics - with changes
@@ -38,19 +41,19 @@ class TestCashFlowStatement:
                 #   Financing: -360k dividends
                 #   Net: 1,305k - 310k - 360k = 635k
                 # Ending cash = 500k + 635k = 1,135k
-                "net_income": 1200000,
-                "depreciation_expense": 110000,
-                "cash": 1135000,  # Consistent with cash flow calculation
-                "accounts_receivable": 250000,  # Increased by 50k
-                "inventory": 180000,  # Increased by 30k
-                "prepaid_insurance": 25000,  # Increased by 5k
-                "accounts_payable": 120000,  # Increased by 20k
-                "accrued_expenses": 60000,  # Increased by 10k
-                "claim_liabilities": 50000,  # New claims
-                "gross_ppe": 1200000,  # Increased by 200k
-                "dividends_paid": 360000,  # 30% of 1.2M
-                "assets": 2500000,
-                "equity": 1900000,
+                "net_income": 1200000.0,
+                "depreciation_expense": 110000.0,
+                "cash": 1135000.0,  # Consistent with cash flow calculation
+                "accounts_receivable": 250000.0,  # Increased by 50k
+                "inventory": 180000.0,  # Increased by 30k
+                "prepaid_insurance": 25000.0,  # Increased by 5k
+                "accounts_payable": 120000.0,  # Increased by 20k
+                "accrued_expenses": 60000.0,  # Increased by 10k
+                "claim_liabilities": 50000.0,  # New claims
+                "gross_ppe": 1200000.0,  # Increased by 200k
+                "dividends_paid": 360000.0,  # 30% of 1.2M
+                "assets": 2500000.0,
+                "equity": 1900000.0,
             },
         ]
 
@@ -186,8 +189,8 @@ class TestCashFlowStatement:
     def test_no_dividends_on_loss(self):
         """Test that no dividends are paid when there's a loss."""
         # Create metrics with a loss
-        loss_metrics = [
-            {"net_income": -500000, "cash": 100000, "dividends_paid": 0},
+        loss_metrics: list[dict[str, float]] = [
+            {"net_income": -500000.0, "cash": 100000.0, "dividends_paid": 0.0},
         ]
 
         cash_flow = CashFlowStatement(loss_metrics)
@@ -225,7 +228,7 @@ class TestCashFlowStatement:
     def test_capex_with_no_prior_period(self):
         """Test capex calculation for first period."""
         current = self.metrics_history[0]
-        prior = {}
+        prior: dict[str, float] = {}
 
         capex = self.cash_flow._calculate_capex(current, prior)
 
@@ -277,21 +280,24 @@ class TestCashFlowStatement:
         This is a regression test for GitHub Issue #212.
         """
         # Create metrics that include insurance_premiums_paid
-        metrics_with_insurance = [
+        # Issue #243: Include dividends_paid in metrics (preferred path since Issue #239)
+        expected_dividends = 800000.0 * 0.3  # 30% payout on 800k net income = 240,000
+        metrics_with_insurance: list[dict[str, float]] = [
             {
-                "net_income": 800000,  # Already has insurance premiums deducted
-                "depreciation_expense": 100000,
-                "cash": 500000,
-                "accounts_receivable": 200000,
-                "inventory": 150000,
-                "prepaid_insurance": 20000,
-                "accounts_payable": 100000,
-                "accrued_expenses": 50000,
-                "claim_liabilities": 0,
-                "gross_ppe": 1000000,
-                "assets": 2000000,
-                "equity": 1500000,
-                "insurance_premiums_paid": 200000,  # This should NOT appear in financing
+                "net_income": 800000.0,  # Already has insurance premiums deducted
+                "depreciation_expense": 100000.0,
+                "cash": 500000.0,
+                "accounts_receivable": 200000.0,
+                "inventory": 150000.0,
+                "prepaid_insurance": 20000.0,
+                "accounts_payable": 100000.0,
+                "accrued_expenses": 50000.0,
+                "claim_liabilities": 0.0,
+                "gross_ppe": 1000000.0,
+                "assets": 2000000.0,
+                "equity": 1500000.0,
+                "insurance_premiums_paid": 200000.0,  # This should NOT appear in financing
+                "dividends_paid": expected_dividends,  # Actual dividends from simulation
             },
         ]
 
@@ -306,8 +312,7 @@ class TestCashFlowStatement:
             "they are already reflected in Net Income (Operating section)"
         )
 
-        # Verify total only includes dividends (default 30% payout ratio on 800k = 240k)
-        expected_dividends = 800000 * 0.3  # 240,000
+        # Verify total only includes dividends (30% payout ratio on 800k = 240k)
         assert financing_cf["dividends_paid"] == pytest.approx(-expected_dividends)
         assert financing_cf["total"] == pytest.approx(-expected_dividends)
 

--- a/ergodic_insurance/tests/test_cash_reconciliation.py
+++ b/ergodic_insurance/tests/test_cash_reconciliation.py
@@ -67,6 +67,7 @@ class TestCashReconciliation:
 
     def test_reconciliation_with_operating_activities(self):
         """Test reconciliation with detailed operating activities."""
+        # Issue #243: Include dividends_paid in metrics (preferred path since Issue #239)
         metrics: MetricsDict = [
             {
                 "cash": 500000,
@@ -76,6 +77,7 @@ class TestCashReconciliation:
                 "inventory": 80000,
                 "accounts_payable": 60000,
                 "gross_ppe": 500000,
+                "dividends_paid": 200000 * 0.3,  # 30% payout on net income
             },
             {
                 "cash": 680000,  # Should reconcile with cash flow
@@ -85,6 +87,7 @@ class TestCashReconciliation:
                 "inventory": 90000,  # Increased by 10k
                 "accounts_payable": 70000,  # Increased by 10k
                 "gross_ppe": 600000,  # Increased by 100k
+                "dividends_paid": 250000 * 0.3,  # 30% payout on net income (75k)
             },
         ]
 

--- a/ergodic_insurance/tests/test_working_capital_changes.py
+++ b/ergodic_insurance/tests/test_working_capital_changes.py
@@ -10,20 +10,20 @@ class TestWorkingCapitalChanges:
 
     def test_basic_working_capital_increase(self):
         """Test that increases in working capital assets reduce cash flow."""
-        metrics = [
+        metrics: list[dict[str, float]] = [
             {
-                "accounts_receivable": 100000,
-                "inventory": 50000,
-                "prepaid_insurance": 10000,
-                "accounts_payable": 30000,
-                "accrued_expenses": 20000,
+                "accounts_receivable": 100000.0,
+                "inventory": 50000.0,
+                "prepaid_insurance": 10000.0,
+                "accounts_payable": 30000.0,
+                "accrued_expenses": 20000.0,
             },
             {
-                "accounts_receivable": 150000,  # Increased by 50k (use of cash)
-                "inventory": 70000,  # Increased by 20k (use of cash)
-                "prepaid_insurance": 15000,  # Increased by 5k (use of cash)
-                "accounts_payable": 35000,  # Increased by 5k (source of cash)
-                "accrued_expenses": 25000,  # Increased by 5k (source of cash)
+                "accounts_receivable": 150000.0,  # Increased by 50k (use of cash)
+                "inventory": 70000.0,  # Increased by 20k (use of cash)
+                "prepaid_insurance": 15000.0,  # Increased by 5k (use of cash)
+                "accounts_payable": 35000.0,  # Increased by 5k (source of cash)
+                "accrued_expenses": 25000.0,  # Increased by 5k (source of cash)
             },
         ]
 
@@ -41,16 +41,16 @@ class TestWorkingCapitalChanges:
 
     def test_working_capital_decrease(self):
         """Test that decreases in working capital assets increase cash flow."""
-        metrics = [
+        metrics: list[dict[str, float]] = [
             {
-                "accounts_receivable": 200000,
-                "inventory": 100000,
-                "accounts_payable": 50000,
+                "accounts_receivable": 200000.0,
+                "inventory": 100000.0,
+                "accounts_payable": 50000.0,
             },
             {
-                "accounts_receivable": 150000,  # Decreased by 50k (source of cash)
-                "inventory": 80000,  # Decreased by 20k (source of cash)
-                "accounts_payable": 40000,  # Decreased by 10k (use of cash)
+                "accounts_receivable": 150000.0,  # Decreased by 50k (source of cash)
+                "inventory": 80000.0,  # Decreased by 20k (source of cash)
+                "accounts_payable": 40000.0,  # Decreased by 10k (use of cash)
             },
         ]
 
@@ -66,20 +66,20 @@ class TestWorkingCapitalChanges:
 
     def test_operating_cash_flow_with_working_capital(self):
         """Test that working capital changes affect operating cash flow correctly."""
-        metrics = [
+        metrics: list[dict[str, float]] = [
             {
-                "net_income": 500000,
-                "depreciation_expense": 50000,
-                "accounts_receivable": 100000,
-                "inventory": 80000,
-                "accounts_payable": 60000,
+                "net_income": 500000.0,
+                "depreciation_expense": 50000.0,
+                "accounts_receivable": 100000.0,
+                "inventory": 80000.0,
+                "accounts_payable": 60000.0,
             },
             {
-                "net_income": 600000,
-                "depreciation_expense": 60000,
-                "accounts_receivable": 130000,  # +30k
-                "inventory": 100000,  # +20k
-                "accounts_payable": 75000,  # +15k
+                "net_income": 600000.0,
+                "depreciation_expense": 60000.0,
+                "accounts_receivable": 130000.0,  # +30k
+                "inventory": 100000.0,  # +20k
+                "accounts_payable": 75000.0,  # +15k
             },
         ]
 
@@ -93,9 +93,9 @@ class TestWorkingCapitalChanges:
 
     def test_claim_liabilities_change(self):
         """Test that claim liability changes are handled correctly."""
-        metrics = [
-            {"claim_liabilities": 0, "net_income": 100000},
-            {"claim_liabilities": 500000, "net_income": 200000},  # New claims
+        metrics: list[dict[str, float]] = [
+            {"claim_liabilities": 0.0, "net_income": 100000.0},
+            {"claim_liabilities": 500000.0, "net_income": 200000.0},  # New claims
         ]
 
         cash_flow = CashFlowStatement(metrics)
@@ -106,16 +106,16 @@ class TestWorkingCapitalChanges:
 
     def test_zero_starting_working_capital(self):
         """Test working capital changes when starting from zero."""
-        metrics = [
+        metrics: list[dict[str, float]] = [
             {
-                "accounts_receivable": 0,
-                "inventory": 0,
-                "accounts_payable": 0,
+                "accounts_receivable": 0.0,
+                "inventory": 0.0,
+                "accounts_payable": 0.0,
             },
             {
-                "accounts_receivable": 100000,
-                "inventory": 50000,
-                "accounts_payable": 30000,
+                "accounts_receivable": 100000.0,
+                "inventory": 50000.0,
+                "accounts_payable": 30000.0,
             },
         ]
 
@@ -128,7 +128,7 @@ class TestWorkingCapitalChanges:
 
     def test_mixed_working_capital_changes(self):
         """Test mixed increases and decreases in working capital."""
-        metrics = [
+        metrics: list[dict[str, float]] = [
             {
                 "net_income": 100000.0,
                 "depreciation_expense": 10000.0,
@@ -167,30 +167,33 @@ class TestWorkingCapitalChanges:
 
     def test_statement_shows_working_capital_changes(self):
         """Test that working capital changes appear correctly in statement."""
-        metrics = [
+        # Issue #243: Include dividends_paid in metrics (preferred path since Issue #239)
+        metrics: list[dict[str, float]] = [
             {
-                "cash": 500000,
-                "net_income": 300000,
-                "depreciation_expense": 40000,
-                "accounts_receivable": 80000,
-                "inventory": 60000,
-                "prepaid_insurance": 10000,
-                "accounts_payable": 40000,
-                "accrued_expenses": 20000,
-                "claim_liabilities": 0,
-                "gross_ppe": 400000,
+                "cash": 500000.0,
+                "net_income": 300000.0,
+                "depreciation_expense": 40000.0,
+                "accounts_receivable": 80000.0,
+                "inventory": 60000.0,
+                "prepaid_insurance": 10000.0,
+                "accounts_payable": 40000.0,
+                "accrued_expenses": 20000.0,
+                "claim_liabilities": 0.0,
+                "gross_ppe": 400000.0,
+                "dividends_paid": 300000.0 * 0.3,  # 30% payout
             },
             {
-                "cash": 600000,
-                "net_income": 400000,
-                "depreciation_expense": 50000,
-                "accounts_receivable": 100000,  # +20k
-                "inventory": 75000,  # +15k
-                "prepaid_insurance": 12000,  # +2k
-                "accounts_payable": 50000,  # +10k
-                "accrued_expenses": 25000,  # +5k
-                "claim_liabilities": 30000,  # +30k
-                "gross_ppe": 500000,
+                "cash": 600000.0,
+                "net_income": 400000.0,
+                "depreciation_expense": 50000.0,
+                "accounts_receivable": 100000.0,  # +20k
+                "inventory": 75000.0,  # +15k
+                "prepaid_insurance": 12000.0,  # +2k
+                "accounts_payable": 50000.0,  # +10k
+                "accrued_expenses": 25000.0,  # +5k
+                "claim_liabilities": 30000.0,  # +30k
+                "gross_ppe": 500000.0,
+                "dividends_paid": 400000.0 * 0.3,  # 30% payout
             },
         ]
 
@@ -226,16 +229,16 @@ class TestWorkingCapitalChanges:
 
     def test_no_working_capital_changes(self):
         """Test when there are no working capital changes."""
-        metrics = [
+        metrics: list[dict[str, float]] = [
             {
-                "accounts_receivable": 100000,
-                "inventory": 50000,
-                "accounts_payable": 30000,
+                "accounts_receivable": 100000.0,
+                "inventory": 50000.0,
+                "accounts_payable": 30000.0,
             },
             {
-                "accounts_receivable": 100000,  # No change
-                "inventory": 50000,  # No change
-                "accounts_payable": 30000,  # No change
+                "accounts_receivable": 100000.0,  # No change
+                "inventory": 50000.0,  # No change
+                "accounts_payable": 30000.0,  # No change
             },
         ]
 
@@ -248,9 +251,9 @@ class TestWorkingCapitalChanges:
 
     def test_missing_working_capital_fields(self):
         """Test handling of missing working capital fields."""
-        metrics = [
-            {"net_income": 100000},
-            {"net_income": 150000, "accounts_receivable": 50000},
+        metrics: list[dict[str, float]] = [
+            {"net_income": 100000.0},
+            {"net_income": 150000.0, "accounts_receivable": 50000.0},
         ]
 
         cash_flow = CashFlowStatement(metrics)
@@ -263,7 +266,7 @@ class TestWorkingCapitalChanges:
 
     def test_monthly_working_capital_changes(self):
         """Test that monthly periods scale working capital changes correctly."""
-        annual_metrics = [
+        annual_metrics: list[dict[str, float]] = [
             {
                 "net_income": 200000.0,
                 "depreciation_expense": 20000.0,


### PR DESCRIPTION
## Summary
- Removes hardcoded `retention_ratio=0.7` fallback in `CashFlowStatement._calculate_dividends()`
- Raises `ValueError` when calculating dividends without either `dividends_paid` in metrics or `config.retention_ratio`
- Updates test fixtures to include `dividends_paid` key (preferred path per Issue #239)
- Adds explicit tests for custom retention ratios and error conditions

## Problem
The `CashFlowStatement` class silently fell back to a hardcoded `retention_ratio=0.7` when neither the metrics contained `dividends_paid` nor a config with `retention_ratio` was provided. This could cause dividend calculations to be incorrect when simulations used custom retention ratios.

## Solution
1. **Fail-fast**: If `dividends_paid` is not in metrics AND config lacks `retention_ratio`, raise a clear `ValueError` explaining what's needed
2. **Prefer metrics**: When `dividends_paid` is in metrics (from the simulation), use it directly
3. **Config fallback**: When config has `retention_ratio`, calculate dividends from net income

## Test Plan
- [x] All 52 related tests pass
- [x] New test `test_cash_flow_statement_fallback_with_custom_retention` verifies custom retention ratios work
- [x] New test `test_cash_flow_statement_error_without_config_or_metrics` verifies error is raised
- [x] Pre-commit hooks pass (black, isort, mypy, pylint)

Fixes #243