### PR TITLE
Fix: Remove working capital double-counting in revenue calculation (#244)

### DIFF
--- a/ergodic_insurance/docs/architecture/class_diagrams/core_classes.md
+++ b/ergodic_insurance/docs/architecture/class_diagrams/core_classes.md
@@ -52,7 +52,7 @@ classDiagram
         +calculate_revenue() float
         +calculate_operating_income() float
         +process_insurance_claim(amount, deductible, limit) tuple
-        +step(working_capital_pct, growth_rate) dict
+        +step(growth_rate) dict
         +apply_dividends(retention_ratio: float)
         +update_balance_sheet()
         +is_solvent() bool

--- a/ergodic_insurance/docs/tutorials/02_basic_simulation.md
+++ b/ergodic_insurance/docs/tutorials/02_basic_simulation.md
@@ -44,7 +44,6 @@ The `step()` method advances the simulation by one year:
 ```python
 # Run one year of operations
 metrics = manufacturer.step(
-    working_capital_pct=0.2,   # 20% of assets as working capital
     growth_rate=0.05           # 5% asset growth target
 )
 
@@ -73,7 +72,6 @@ manufacturer.process_insurance_claim(
 
 # Run the year with the claim impact
 metrics = manufacturer.step(
-    working_capital_pct=0.2,
     letter_of_credit_rate=0.015  # 1.5% collateral cost
 )
 

--- a/ergodic_insurance/docs/user_guide/case_studies.rst
+++ b/ergodic_insurance/docs/user_guide/case_studies.rst
@@ -48,7 +48,6 @@ Analysis Process
        'base_revenue': 15_000_000,
        'base_operating_margin': 0.08,
        'tax_rate': 0.25,
-       'working_capital_pct': 0.20,
        'growth_volatility': 0.15
    }
 

--- a/ergodic_insurance/docs/user_guide/quick_start.rst
+++ b/ergodic_insurance/docs/user_guide/quick_start.rst
@@ -33,7 +33,6 @@ First, let's define your company using our configuration system. Create a YAML f
      base_revenue: 15_000_000     # Annual revenue
      base_operating_margin: 0.08        # 8% profit margin
      tax_rate: 0.25                # 25% corporate tax
-     working_capital_pct: 0.20     # 20% of revenue tied up in working capital
 
    growth:
      base_growth_rate: 0.06        # 6% organic growth

--- a/ergodic_insurance/docs/user_guide/running_analysis.rst
+++ b/ergodic_insurance/docs/user_guide/running_analysis.rst
@@ -52,7 +52,6 @@ Edit your configuration file with company-specific parameters:
        base_revenue=15_000_000,
        base_operating_margin=0.08,
        tax_rate=0.25,
-       working_capital_pct=0.20,
        dividend_rate=0.30,  # 30% of profits as dividends
        capex_rate=0.05,      # 5% of revenue for capital expenditure
        debt_capacity=0.5     # Can borrow up to 50% of assets

--- a/ergodic_insurance/examples/demo_collateral_management.py
+++ b/ergodic_insurance/examples/demo_collateral_management.py
@@ -42,7 +42,7 @@ def main():
 
     # Year 0: Normal operations
     print("YEAR 0: Normal Operations")
-    metrics = manufacturer.step(working_capital_pct=0.2, growth_rate=0.05)
+    metrics = manufacturer.step(growth_rate=0.05)
     print(f"  Revenue:            ${metrics['revenue']:,.0f}")
     print(f"  Net Income:         ${metrics['net_income']:,.0f}")
     print(f"  New Assets:         ${metrics['assets']:,.0f}")
@@ -78,7 +78,7 @@ def main():
     print("-" * 70)
 
     for year in range(1, 6):
-        metrics = manufacturer.step(working_capital_pct=0.2, letter_of_credit_rate=annual_rate)
+        metrics = manufacturer.step(letter_of_credit_rate=annual_rate)
         print(
             f"{year:<6} ${metrics['net_income']:>12,.0f}  ${metrics['assets']:>12,.0f}  "
             f"${metrics['collateral']:>12,.0f}  ${metrics['claim_liabilities']:>12,.0f}  "
@@ -108,7 +108,7 @@ def main():
     print("Running simulation until insolvency...")
     year = 1
     while not manufacturer.is_ruined and year <= 20:
-        metrics = manufacturer.step(working_capital_pct=0.2, letter_of_credit_rate=annual_rate)
+        metrics = manufacturer.step(letter_of_credit_rate=annual_rate)
         if year % 2 == 0 or manufacturer.is_ruined:  # Print every other year or on ruin
             print(
                 f"  Year {year:2}: Equity = ${metrics['equity']:>12,.0f}, "

--- a/ergodic_insurance/examples/demo_excel_reports.py
+++ b/ergodic_insurance/examples/demo_excel_reports.py
@@ -92,9 +92,7 @@ def run_simulation_with_claims(years: int = 10, seed: int = 42) -> WidgetManufac
         insurance_premium = revenue_estimate * insurance.base_premium_rate
 
         # Run annual step
-        metrics = manufacturer.step(
-            working_capital_pct=0.2, letter_of_credit_rate=0.015, growth_rate=0.03
-        )
+        metrics = manufacturer.step(letter_of_credit_rate=0.015, growth_rate=0.03)
 
         # Deduct insurance costs
         manufacturer.assets -= insurance_premium

--- a/ergodic_insurance/examples/demo_manufacturer.py
+++ b/ergodic_insurance/examples/demo_manufacturer.py
@@ -39,7 +39,7 @@ def main():
 
     # Year 0: Normal operations
     print("YEAR 0: Normal Operations")
-    metrics = manufacturer.step(working_capital_pct=0.2, growth_rate=0.05)
+    metrics = manufacturer.step(growth_rate=0.05)
     print(f"  Revenue:          ${metrics['revenue']:,.0f}")
     print(f"  Operating Income: ${metrics['operating_income']:,.0f}")
     print(f"  Net Income:       ${metrics['net_income']:,.0f}")
@@ -56,7 +56,7 @@ def main():
     )
     print(f"  Collateral added: ${manufacturer.collateral:,.0f}")
 
-    metrics = manufacturer.step(working_capital_pct=0.2, letter_of_credit_rate=0.015)
+    metrics = manufacturer.step(letter_of_credit_rate=0.015)
     print(f"  Revenue:          ${metrics['revenue']:,.0f}")
     print(f"  Operating Income: ${metrics['operating_income']:,.0f}")
     print(f"  Collateral Costs: ${manufacturer.calculate_collateral_costs():,.0f}")
@@ -68,7 +68,7 @@ def main():
     # Years 2-5: Recovery period
     print("YEARS 2-5: Recovery Period")
     for year in range(2, 6):
-        metrics = manufacturer.step(working_capital_pct=0.2, letter_of_credit_rate=0.015)
+        metrics = manufacturer.step(letter_of_credit_rate=0.015)
         print(f"  Year {year}:")
         print(f"    Net Income:     ${metrics['net_income']:,.0f}")
         print(f"    Assets:         ${metrics['assets']:,.0f}")

--- a/ergodic_insurance/monte_carlo.py
+++ b/ergodic_insurance/monte_carlo.py
@@ -175,7 +175,6 @@ class SimulationConfig:
         monitor_performance: Track detailed performance metrics
         adaptive_chunking: Enable adaptive chunk sizing
         shared_memory: Enable shared memory for read-only data
-        working_capital_pct: Working capital as percentage of revenue (typical: 0.15-0.25)
     """
 
     n_simulations: int = 100_000
@@ -208,8 +207,6 @@ class SimulationConfig:
     bootstrap_method: str = "percentile"
     # Periodic ruin evaluation options
     ruin_evaluation: Optional[List[int]] = None
-    # Working capital configuration
-    working_capital_pct: float = 0.0  # Default to 0% for full asset revenue generation
     # Insolvency tolerance
     insolvency_tolerance: float = 10_000  # Company is insolvent when equity <= this threshold
 
@@ -1023,7 +1020,6 @@ class MonteCarloEngine:
             growth_rate = 0.0  # No exogenous growth, only endogenous growth from retained earnings
 
             manufacturer.step(
-                working_capital_pct=self.config.working_capital_pct,  # Use configured working capital
                 growth_rate=growth_rate,  # Only endogenous growth from retained earnings
                 apply_stochastic=apply_stochastic,
             )

--- a/ergodic_insurance/notebooks/run_basic_simulation.py
+++ b/ergodic_insurance/notebooks/run_basic_simulation.py
@@ -231,7 +231,6 @@ def run_basic_simulation(
             cache_results=False,
             progress_bar=True,
             ruin_evaluation=[5, 10, 15, 20, 25, 30, 35, 40, 45, 50],
-            working_capital_pct=0.0,  # Set working capital to 0% for full asset revenue generation
             seed=seed + 450,
         )
 

--- a/ergodic_insurance/ruin_probability.py
+++ b/ergodic_insurance/ruin_probability.py
@@ -369,7 +369,7 @@ class RuinProbabilityAnalyzer:
     ) -> Dict[str, float]:
         """Process a single year of simulation."""
         # Update state FIRST (process year's normal operations)
-        metrics: Dict[str, float] = manufacturer.step(working_capital_pct=0.2, growth_rate=0.0)
+        metrics: Dict[str, float] = manufacturer.step(growth_rate=0.0)
 
         # Then apply losses at END of year
         # This prevents newly-created liabilities from being paid in the same year

--- a/ergodic_insurance/simulation.py
+++ b/ergodic_insurance/simulation.py
@@ -583,9 +583,7 @@ class Simulation:
         # Step manufacturer forward FIRST (process year's normal operations)
         # Then apply losses at END of year to prevent newly-created liabilities
         # from being paid in the same year they're created
-        metrics = self.manufacturer.step(
-            working_capital_pct=0.2, letter_of_credit_rate=0.015, growth_rate=0.03
-        )
+        metrics = self.manufacturer.step(letter_of_credit_rate=0.015, growth_rate=0.03)
 
         # Process losses at END of year
         total_loss_amount = sum(loss.amount for loss in losses)

--- a/ergodic_insurance/tests/integration/test_critical_integrations.py
+++ b/ergodic_insurance/tests/integration/test_critical_integrations.py
@@ -1131,7 +1131,7 @@ class TestClaimPaymentTiming:
         manufacturer.current_year = 0  # Start at year 0
 
         # Simulate the step/claim processing flow
-        manufacturer.step(working_capital_pct=0.2, letter_of_credit_rate=0.015, growth_rate=0.03)
+        manufacturer.step(letter_of_credit_rate=0.015, growth_rate=0.03)
         # After step(), current_year is now 1
 
         # Process a claim (this happens after step() increments the year)
@@ -1193,7 +1193,7 @@ class TestClaimPaymentTiming:
         # Create an uninsured claim with scheduled payments
         claim_amount = 1_000_000
         manufacturer.current_year = 0
-        manufacturer.step(working_capital_pct=0.2, letter_of_credit_rate=0.015, growth_rate=0.03)
+        manufacturer.step(letter_of_credit_rate=0.015, growth_rate=0.03)
 
         # Process uninsured claim (creates liability with payment schedule)
         manufacturer.process_uninsured_claim(
@@ -1223,9 +1223,7 @@ class TestClaimPaymentTiming:
         # Test with insurance
         manufacturer_insured = WidgetManufacturer(config.manufacturer)
         manufacturer_insured.current_year = 0
-        manufacturer_insured.step(
-            working_capital_pct=0.2, letter_of_credit_rate=0.015, growth_rate=0.03
-        )
+        manufacturer_insured.step(letter_of_credit_rate=0.015, growth_rate=0.03)
 
         manufacturer_insured.process_insurance_claim(
             claim_amount=500_000,
@@ -1240,9 +1238,7 @@ class TestClaimPaymentTiming:
         # Test without insurance
         manufacturer_uninsured = WidgetManufacturer(config.manufacturer)
         manufacturer_uninsured.current_year = 0
-        manufacturer_uninsured.step(
-            working_capital_pct=0.2, letter_of_credit_rate=0.015, growth_rate=0.03
-        )
+        manufacturer_uninsured.step(letter_of_credit_rate=0.015, growth_rate=0.03)
 
         manufacturer_uninsured.process_uninsured_claim(
             claim_amount=500_000,

--- a/ergodic_insurance/tests/test_accrual_integration.py
+++ b/ergodic_insurance/tests/test_accrual_integration.py
@@ -29,7 +29,7 @@ class TestAccrualIntegration:
     def test_quarterly_tax_accrual_and_payment(self, manufacturer):
         """Test quarterly tax accrual and payment schedule."""
         # Generate income and accrue taxes
-        metrics = manufacturer.step(working_capital_pct=0.2, time_resolution="annual")
+        metrics = manufacturer.step(time_resolution="annual")
 
         # Check that taxes were accrued
         assert metrics["accrued_taxes"] > 0
@@ -39,7 +39,7 @@ class TestAccrualIntegration:
         tax_payments_made = False
         for month in range(12):
             cash_before_step = manufacturer.cash
-            month_metrics = manufacturer.step(working_capital_pct=0.2, time_resolution="monthly")
+            month_metrics = manufacturer.step(time_resolution="monthly")
 
             # Check if tax payment was made (accrued taxes decreased)
             if month_metrics["accrued_taxes"] < initial_accrued_taxes:
@@ -110,7 +110,7 @@ class TestAccrualIntegration:
         )
 
         # Run a simulation step
-        metrics = manufacturer.step(working_capital_pct=0.2)
+        metrics = manufacturer.step()
 
         # Check metrics include accrual breakdown
         assert "accrued_wages" in metrics
@@ -141,7 +141,7 @@ class TestAccrualIntegration:
         """Test accrual manager syncs with monthly resolution."""
         # Run monthly steps
         for month in range(6):
-            manufacturer.step(working_capital_pct=0.2, time_resolution="monthly")
+            manufacturer.step(time_resolution="monthly")
 
         # Check accrual manager period is synchronized
         # After 6 steps, we've processed periods 0-5, and current_period should be 5
@@ -152,7 +152,7 @@ class TestAccrualIntegration:
     def test_accrual_impact_on_cash_flow(self, manufacturer):
         """Test that accruals affect cash flow timing."""
         # Run first year to generate tax liability
-        metrics_year1 = manufacturer.step(working_capital_pct=0.2, time_resolution="annual")
+        metrics_year1 = manufacturer.step(time_resolution="annual")
 
         net_income_year1 = metrics_year1["net_income"]
         accrued_taxes_year1 = metrics_year1["accrued_taxes"]
@@ -168,7 +168,7 @@ class TestAccrualIntegration:
             for quarter in range(4):
                 # Each quarter is 3 months
                 for month in range(3):
-                    manufacturer.step(working_capital_pct=0.2, time_resolution="monthly")
+                    manufacturer.step(time_resolution="monthly")
 
             # Cash should have decreased by tax payments
             cash_after = manufacturer.cash

--- a/ergodic_insurance/tests/test_exposure_base.py
+++ b/ergodic_insurance/tests/test_exposure_base.py
@@ -84,7 +84,7 @@ class TestRevenueExposure:
         initial_multiplier = exposure.get_frequency_multiplier(1.0)
 
         # Simulate business growth through retained earnings
-        manufacturer.step(working_capital_pct=0.2, growth_rate=0.05)
+        manufacturer.step(growth_rate=0.05)
 
         # Exposure should reflect actual business state, not artificial growth
         # The multiplier will depend on actual financial performance

--- a/ergodic_insurance/tests/test_monte_carlo_parallel.py
+++ b/ergodic_insurance/tests/test_monte_carlo_parallel.py
@@ -375,7 +375,7 @@ class TestParallelRuinProbability:
         # Mock step to return low operating income that triggers debt service failure
         call_count = [0]
 
-        def mock_step(working_capital_pct, growth_rate):
+        def mock_step(growth_rate=0.0, **kwargs):
             call_count[0] += 1
             return {
                 "equity": 3_000_000,

--- a/ergodic_insurance/tests/test_parameter_sweep.py
+++ b/ergodic_insurance/tests/test_parameter_sweep.py
@@ -505,7 +505,6 @@ class TestParameterSweeper:
         """Test manufacturer creation from parameters."""
         params = {
             "initial_assets": 20e6,
-            "working_capital_pct": 0.15,
             "base_operating_margin": 0.10,
             "asset_turnover": 1.2,
             "tax_rate": 0.30,

--- a/ergodic_insurance/tests/test_roe_insurance.py
+++ b/ergodic_insurance/tests/test_roe_insurance.py
@@ -62,8 +62,7 @@ class TestROEWithInsurance:
 
         # ROE should be reduced by the premium impact
         # Net income = (revenue * margin - premium - depreciation) * (1 - tax_rate)
-        # Use default working_capital_pct to match calculate_metrics()
-        revenue = manufacturer.calculate_revenue()  # Uses default working_capital_pct=0.0
+        revenue = manufacturer.calculate_revenue()
         annual_depreciation = manufacturer.gross_ppe / 10 if manufacturer.gross_ppe > 0 else 0.0
         operating_income = revenue * 0.12 - premium - annual_depreciation
         # Apply taxes only on positive income
@@ -86,7 +85,7 @@ class TestROEWithInsurance:
         metrics = manufacturer.calculate_metrics()
 
         # ROE should be reduced by the loss impact
-        revenue = manufacturer.calculate_revenue()  # Uses default working_capital_pct=0.0
+        revenue = manufacturer.calculate_revenue()
         annual_depreciation = manufacturer.gross_ppe / 10 if manufacturer.gross_ppe > 0 else 0.0
         operating_income = revenue * 0.12 - losses - annual_depreciation
         # Apply taxes only on positive income
@@ -113,7 +112,7 @@ class TestROEWithInsurance:
         metrics = manufacturer.calculate_metrics()
 
         # ROE should reflect both costs
-        revenue = manufacturer.calculate_revenue()  # Uses default working_capital_pct=0.0
+        revenue = manufacturer.calculate_revenue()
         annual_depreciation = manufacturer.gross_ppe / 10 if manufacturer.gross_ppe > 0 else 0.0
         operating_income = revenue * 0.12 - total_costs - annual_depreciation
         # Apply taxes only on positive income
@@ -142,7 +141,7 @@ class TestROEWithInsurance:
         assert metrics["total_insurance_costs"] == premium + losses
 
         # Verify the calculation
-        revenue = manufacturer.calculate_revenue()  # Uses default working_capital_pct=0.0
+        revenue = manufacturer.calculate_revenue()
         annual_depreciation = manufacturer.gross_ppe / 10 if manufacturer.gross_ppe > 0 else 0.0
         operating_income = revenue * 0.12 - premium - losses - annual_depreciation
         taxes = max(0, operating_income * 0.25)  # No taxes on negative income
@@ -199,9 +198,7 @@ class TestROEWithInsurance:
         manufacturer.record_insurance_loss(losses)
 
         # Run a step
-        metrics_from_step = manufacturer.step(
-            working_capital_pct=0.2, letter_of_credit_rate=0.015, growth_rate=0.0
-        )
+        metrics_from_step = manufacturer.step(letter_of_credit_rate=0.015, growth_rate=0.0)
 
         # ROE from step should include insurance costs
         assert metrics_from_step["insurance_premiums"] == premium
@@ -211,9 +208,6 @@ class TestROEWithInsurance:
         assert metrics_from_step["roe"] < 0.09  # Less than operating ROE
 
         # Net income should be reduced by insurance costs
-        # Note: calculate_metrics() recalculates revenue using updated assets without
-        # working_capital_pct, leading to higher revenue than used in the actual step
-        # calculation. This inflates the final net income in metrics.
         assert metrics_from_step["net_income"] < 750_000  # Reduced from normal ~$900k
 
     def test_roe_reset_after_period(self, manufacturer):
@@ -283,7 +277,7 @@ class TestROEWithInsurance:
         manufacturer.record_insurance_loss(losses)
 
         # Calculate expected values
-        revenue = manufacturer.calculate_revenue()  # Uses default working_capital_pct=0.0
+        revenue = manufacturer.calculate_revenue()
         annual_depreciation = manufacturer.gross_ppe / 10 if manufacturer.gross_ppe > 0 else 0.0
         operating_income = revenue * 0.12 - premium - losses - annual_depreciation
         # Apply taxes only on positive income

--- a/simone/SPRINT_01_ISSUES.md
+++ b/simone/SPRINT_01_ISSUES.md
@@ -88,7 +88,7 @@ The `process_insurance_claim()` method needs to:
 ### Implementation Steps
 1. Add `step()` method to WidgetManufacturer class:
    ```python
-   def step(self, working_capital_pct=0.2, letter_of_credit_rate=0.015, growth_rate=0.03):
+   def step(self, letter_of_credit_rate=0.015, growth_rate=0.0):
        # Calculate revenue from assets
        # Apply operating margin for profit
        # Deduct taxes


### PR DESCRIPTION
## Summary

Closes #244

Fixes double-counting of working capital in the financial model. The `working_capital_pct` parameter in `calculate_revenue()` was applying a P&L penalty (reduced revenue) while the cash flow statement also deducted working capital changes from operating cash flow.

## Changes

- **Removed** the revenue denominator adjustment formula: `Revenue = Assets * Turnover / (1 + Turnover * WC%)`
- **Added** `warnings` import to manufacturer.py
- **Added** `DeprecationWarning` when `working_capital_pct > 0` is passed to `calculate_revenue()`
- **Updated** docstring to explain the deprecation and reference Issue #244
- **Updated** test `test_calculate_revenue_with_working_capital` → `test_calculate_revenue_with_working_capital_deprecated`

## Technical Details

**Before (double-counting):**
1. P&L Penalty: Revenue reduced by working capital denominator
2. Cash Flow Penalty: Working capital changes deducted in cash flow statement

**After (GAAP-compliant):**
- Working capital impact flows only through `calculate_working_capital_components()` and the cash flow statement
- Revenue is calculated simply as: `Revenue = Assets * Turnover`

## Test Plan

- [x] `test_calculate_revenue_with_working_capital_deprecated` - verifies deprecation warning and unchanged revenue
- [x] All 55 manufacturer tests pass
- [x] All 14 working capital calculation tests pass  
- [x] All 15 cash flow statement tests pass
- [x] All 13 ROE insurance tests pass