### PR TITLE
fix: Add missing hypothesis package dependency

### DIFF
--- a/ergodic_insurance/pyproject.toml
+++ b/ergodic_insurance/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
     "mypy>=1.17.1",
     "isort>=6.0.1",
     "types-PyYAML>=6.0.0",
+    "hypothesis>=6.100.0",
 ]
 notebooks = [
     "jupyter>=1.1.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
     "isort>=6.0.1",
     "types-PyYAML>=6.0.0",
     "pre-commit>=3.6.0",
+    "hypothesis>=6.100.0",
 ]
 notebooks = [
     "jupyter>=1.1.1",

--- a/uv.lock
+++ b/uv.lock
@@ -554,6 +554,8 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "black" },
+    { name = "coverage" },
+    { name = "hypothesis" },
     { name = "isort" },
     { name = "mypy" },
     { name = "pre-commit" },
@@ -573,6 +575,8 @@ notebooks = [
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=25.1.0" },
+    { name = "coverage", marker = "extra == 'dev'", specifier = ">=7.7.0" },
+    { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.100.0" },
     { name = "ipykernel", marker = "extra == 'notebooks'", specifier = ">=6.30.1" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=6.0.1" },
     { name = "jinja2", specifier = ">=3.1.0" },
@@ -717,6 +721,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.151.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/13/69648b6f8c41600ce922386f084f5921fef55912dc980ded8ff4948ea626/hypothesis-6.151.2.tar.gz", hash = "sha256:fc91f88a77074b31c7ab871eebab3d2e0210fd3095f1d1ecbd9440c1c6bc06d9", size = 475491, upload-time = "2026-01-26T06:45:41.447Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/3b/a6b9ecf082dd4d736bb553f7d9ad907a64373f41d0b57eb0be21acf157ee/hypothesis-6.151.2-py3-none-any.whl", hash = "sha256:909d2b5f0dc80640561bb2c3859f3c56a52ed8d1cc589e5e6450362ced8c31a0", size = 542937, upload-time = "2026-01-26T06:45:39.133Z" },
 ]
 
 [[package]]
@@ -2283,6 +2299,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes #268

Adds the missing `hypothesis>=6.100.0` package to dev dependencies, enabling property-based testing in `test_properties.py`.

## Changes Made

- Added `hypothesis>=6.100.0` to `pyproject.toml` (root) dev dependencies
- Added `hypothesis>=6.100.0` to `ergodic_insurance/pyproject.toml` dev dependencies
- Updated `uv.lock` with hypothesis and its dependency (sortedcontainers)

## Testing Performed

- Installed hypothesis package
- Ran `pytest ergodic_insurance/tests/test_properties.py -v` - all 9 property-based tests pass:
  - `TestErgodicProperties::test_growth_rate_properties`
  - `TestErgodicProperties::test_ergodic_coefficient_bounds`
  - `TestRiskMetricsProperties::test_var_monotonicity`
  - `TestRiskMetricsProperties::test_tvar_var_relationship`
  - `TestLossDistributionProperties::test_loss_generation_consistency`
  - `TestLossDistributionProperties::test_insurance_application_properties`
  - `TestConvergenceProperties::test_convergence_r_hat_properties`
  - `TestConvergenceProperties::test_effective_sample_size_properties`
  - `TestOptimizationProperties::test_optimization_bounds`

## Notes

The hypothesis package is a property-based testing framework by David MacIver, distinct from the project's custom statistical hypothesis testing in `statistical_tests.py`.