### PR TITLE
fix: Make Ledger single source of truth to resolve cash flow divergence

### DIFF
--- a/ergodic_insurance/ledger.py
+++ b/ergodic_insurance/ledger.py
@@ -192,6 +192,10 @@ class TransactionType(Enum):
     # Non-cash
     ADJUSTMENT = "adjustment"
     ACCRUAL = "accrual"
+    WRITE_OFF = "write_off"  # Writing off bad debts or losses
+    REVALUATION = "revaluation"  # Asset value adjustments
+    LIQUIDATION = "liquidation"  # Bankruptcy/emergency liquidation
+    TRANSFER = "transfer"  # Internal asset transfers (e.g., cash to restricted)
 
 
 @dataclass


### PR DESCRIPTION
## Summary
Closes #275

This PR eliminates the "dual write" problem where `WidgetManufacturer` balance sheet properties were updated both directly (e.g., `self.cash = ...`) AND via ledger entries (`self.ledger.record_double_entry(...)`), causing the Direct method cash flow statement to diverge from the Indirect method.

### Key Changes:
- **Read-only balance sheet properties**: Converted all balance sheet properties (`cash`, `accounts_receivable`, `inventory`, `prepaid_insurance`, `gross_ppe`, `accumulated_depreciation`, `restricted_assets`, `accounts_payable`, `collateral`) to read-only properties that derive their values from the ledger
- **New transaction types**: Added `WRITE_OFF`, `REVALUATION`, `LIQUIDATION`, and `TRANSFER` transaction types to support the refactoring
- **Helper methods**: Added helper methods for common ledger operations (`_record_cash_adjustment`, `_record_asset_transfer`, `_record_proportional_revaluation`, etc.)
- **Removed dual writes**: Replaced all direct property assignments with appropriate ledger transactions throughout the codebase
- **Updated tests**: Modified tests to use ledger transactions instead of direct property assignment

## Test Plan
- [x] All 54 manufacturer tests pass
- [x] All 51 ledger tests pass
- [x] Pre-commit hooks (black, isort, mypy, pylint) pass
- [x] Verified balance sheet properties correctly read from ledger
- [x] Verified cash flow statements now reconcile properly