### PR TITLE
refactor: Integrate ClaimLiability with ClaimDevelopment using Strategy Pattern

### DIFF
--- a/ergodic_insurance/docs/architecture/class_diagrams/core_classes.md
+++ b/ergodic_insurance/docs/architecture/class_diagrams/core_classes.md
@@ -59,12 +59,29 @@ classDiagram
     }
 
     class ClaimLiability {
-        +total_amount: float
-        +payment_schedule: List[float]
-        +years_remaining: int
-        +get_annual_payment() float
-        +advance_year()
+        +original_amount: Decimal
+        +remaining_amount: Decimal
+        +year_incurred: int
+        +is_insured: bool
+        +development_strategy: ClaimDevelopment
+        +payment_schedule: List[float]  <<property>>
+        +get_payment(years_since_incurred) Decimal
+        +make_payment(amount) Decimal
     }
+
+    class ClaimDevelopment {
+        +pattern_name: str
+        +development_factors: List[float]
+        +tail_factor: float
+        +calculate_payments(claim_amount, accident_year, payment_year) float
+        +get_cumulative_paid(years_since_accident) float
+        +create_immediate() ClaimDevelopment
+        +create_medium_tail_5yr() ClaimDevelopment
+        +create_long_tail_10yr() ClaimDevelopment
+        +create_very_long_tail_15yr() ClaimDevelopment
+    }
+
+    ClaimLiability --> ClaimDevelopment : uses
 
     %% Insurance Classes
     class InsurancePolicy {

--- a/ergodic_insurance/tests/test_manufacturer.py
+++ b/ergodic_insurance/tests/test_manufacturer.py
@@ -11,6 +11,7 @@ from typing import Dict
 
 import pytest
 
+from ergodic_insurance.claim_development import ClaimDevelopment
 from ergodic_insurance.config import ManufacturerConfig
 from ergodic_insurance.decimal_utils import ZERO, to_decimal
 from ergodic_insurance.ledger import AccountName, TransactionType


### PR DESCRIPTION
## Summary

Closes #274

This PR refactors the `ClaimLiability` class to use `ClaimDevelopment` as a strategy for payment timing, eliminating redundant and duplicate claim payment logic in the codebase.

### Changes Made

- **Replaced `payment_schedule: List[float]` with `development_strategy: ClaimDevelopment`** in the `ClaimLiability` dataclass
- **Updated `get_payment()` method** to delegate to `ClaimDevelopment.calculate_payments()` instead of using a hardcoded list
- **Added `payment_schedule` property** for backward compatibility with existing code that reads the payment schedule
- **Updated `__deepcopy__` method** to properly create independent copies of the `ClaimDevelopment` strategy
- **Updated `record_claim_accrual()` method** to accept `ClaimDevelopment` instead of `List[float]`
- **Updated tests** in `test_manufacturer.py` and `test_deep_copy.py` to use the new pattern
- **Updated documentation** in `core_classes.md` to reflect the strategy pattern design

### Design Pattern

This refactoring follows the **Strategy Pattern**:
- `ClaimDevelopment` = Strategy interface with factory methods
- `create_immediate()`, `create_long_tail_10yr()`, etc. = Concrete strategies
- `ClaimLiability` = Context that uses the strategy

### Before/After

**Before:** Two identical 10-year payment patterns defined separately in `ClaimLiability` and `ClaimDevelopment.create_long_tail_10yr()`

**After:** Single source of truth in `ClaimDevelopment`, used by `ClaimLiability` via composition

## Test Plan

- [x] All `test_manufacturer.py` tests pass (54 tests)
- [x] All `test_deep_copy.py` tests pass (25 tests)  
- [x] All `test_claim_development.py` tests pass (27 tests)
- [x] `test_manufacturer_methods.py::test_claim_liability_payment_schedule_edge_cases` passes
- [x] mypy type checking passes
- [x] Pre-commit hooks (black, isort, pylint) pass