### PR TITLE
feat: Add mid-year liquidity detection to prevent blind spot insolvency (#279)

### DIFF
--- a/ergodic_insurance/config.py
+++ b/ergodic_insurance/config.py
@@ -150,6 +150,27 @@ class ManufacturerConfig(BaseModel):
         "(Issue #255: Enables explicit COGS/SG&A calculation in Manufacturer)",
     )
 
+    # Mid-year liquidity configuration (Issue #279)
+    premium_payment_month: int = Field(
+        default=0,
+        ge=0,
+        le=11,
+        description="Month when annual insurance premium is paid (0-11, where 0=January). "
+        "Used for intra-period liquidity estimation to detect mid-year insolvency.",
+    )
+    revenue_pattern: Literal["uniform", "seasonal", "back_loaded"] = Field(
+        default="uniform",
+        description="Revenue distribution pattern throughout the year. "
+        "'uniform': equal monthly revenue, 'seasonal': higher in Q4, "
+        "'back_loaded': 60% in H2. Used for mid-year liquidity estimation.",
+    )
+    check_intra_period_liquidity: bool = Field(
+        default=True,
+        description="Whether to check for potential mid-year insolvency by estimating "
+        "minimum cash point within each period. When True, the simulation estimates "
+        "the lowest cash point and triggers insolvency if it goes negative.",
+    )
+
     @model_validator(mode="after")
     def set_default_ppe_ratio(self):
         """Set default PPE ratio based on operating margin if not provided."""


### PR DESCRIPTION
## Summary

Closes #279

This PR addresses the mid-year liquidity blind spot where the `step()` function processes annual flows at year-end, potentially masking mid-year insolvency events. If a company pays a massive premium in Month 1 but earns revenue distributed across the year, it might run out of cash in Month 2, but the annual model would show the company as solvent.

## Changes Made

### Configuration (config.py)
- Added `premium_payment_month`: Month when annual insurance premium is paid (0-11, default=0/January)
- Added `revenue_pattern`: Revenue distribution pattern ("uniform", "seasonal", "back_loaded")
- Added `check_intra_period_liquidity`: Boolean flag to enable/disable the check (default=True)

### Core Implementation (manufacturer.py)
- Added `estimate_minimum_cash_point()` method that simulates monthly cash flows to find the lowest cash point within a year, considering:
  - Premium payments (based on configured month)
  - Quarterly tax payments (months 3, 5, 8, 11)
  - Revenue distribution (uniform, seasonal, or back-loaded)
- Added `check_liquidity_constraints()` method that triggers insolvency if minimum cash goes negative
- Added `_get_monthly_revenue_distribution()` helper for revenue pattern calculations
- Added `ruin_month` attribute to track when mid-year insolvency occurred
- Integrated liquidity check into `step()` method before main processing

### Ruin Probability Tracking (ruin_probability.py)
- Enhanced `RuinProbabilityResults` dataclass with:
  - `mid_year_ruin_count`: Number of simulations with mid-year ruin
  - `ruin_month_distribution`: Distribution of ruin events by month (0-11)
- Updated `summary()` to display mid-year ruin statistics
- Updated sequential and parallel simulation runners to collect mid-year ruin data

### Tests (test_manufacturer.py)
- Added `TestMidYearLiquidity` class with 12 comprehensive unit tests covering:
  - Minimum cash point estimation with different revenue patterns
  - Liquidity constraint checking (solvent, disabled, mid-year insolvency)
  - Step method integration
  - Backwards compatibility
  - Revenue distribution helpers
  - Ruin month tracking

## Testing Performed

- All 12 new unit tests pass
- All existing 66 manufacturer tests pass
- mypy type checking passes with no errors
- Pre-commit hooks (black, isort, mypy, pylint) all pass

## Backwards Compatibility

Simulations with `check_intra_period_liquidity=False` produce identical results to before this feature was added. The default is `True` to enable the protection by default.

## Acceptance Criteria Met

- [x] Company with low cash and high January premium correctly detects mid-year insolvency
- [x] Simulations with check disabled produce identical results (backwards compatible)
- [x] Ruin probability analysis reports mid-year vs year-end ruin events
- [x] All new code has comprehensive test coverage
- [x] All new methods have Google-style docstrings
- [x] mypy passes with no new errors