### PR TITLE
fix: Add depreciation-equity regression tests and correct test comments (#286)

### DIFF
--- a/ergodic_insurance/manufacturer.py
+++ b/ergodic_insurance/manufacturer.py
@@ -2766,7 +2766,21 @@ class WidgetManufacturer:
 
         Note:
             Depreciation is a non-cash expense that reduces taxable income
-            but does not affect cash flow directly.
+            but does not affect cash flow directly. However, it reduces equity
+            through two mechanisms:
+
+            1. **Asset reduction**: The credit to accumulated_depreciation (a
+               contra-asset account) reduces net PP&E, which reduces total_assets.
+               Since equity = total_assets - total_liabilities, lower assets
+               mean lower equity.
+
+            2. **Income reduction**: Depreciation expense reduces operating income,
+               which reduces net income and therefore retained earnings. Fewer
+               retained earnings are added back to cash, further limiting asset
+               growth.
+
+            When depreciation exceeds retained earnings for a period, equity
+            will decrease even if net income is positive. See Issue #286.
         """
         useful_life = to_decimal(useful_life_years)
         if self.gross_ppe > ZERO and useful_life > ZERO:

--- a/ergodic_insurance/tests/test_manufacturer_methods.py
+++ b/ergodic_insurance/tests/test_manufacturer_methods.py
@@ -375,9 +375,14 @@ class TestStepMethod:
         # Assets should increase with retained earnings
         assert manufacturer.total_assets > initial_assets
 
-        # Equity change reflects depreciation, tax accruals, and retained earnings
-        # With depreciation (500K) + tax accruals (83K) > retained earnings (125K),
-        # equity will decrease even with positive net income
+        # Equity change reflects depreciation, tax accruals, and retained earnings.
+        # With PP&E ratio=0.5 → gross_ppe=5M → depreciation=500K/yr (10yr life).
+        # Revenue=10M, base margin=10% → base operating income=1M.
+        # Operating income = 1M - 500K depreciation = 500K.
+        # Tax = 500K * 25% = 125K → net income = 375K.
+        # Retained earnings = 375K * 50% = 187.5K (added to cash).
+        # Depreciation (500K) + tax accrual (~125K) > retained earnings (187.5K),
+        # so equity decreases even with positive net income.
         equity_change = manufacturer.equity - initial_equity
         retained_earnings = metrics["net_income"] * to_decimal(manufacturer.retention_ratio)
         # Equity should decrease but by less than depreciation alone


### PR DESCRIPTION
## Summary

Closes #286

- Corrected inaccurate numeric values in `test_normal_operation` comments (depreciation 500K, tax accrual ~125K, retained earnings 187.5K — previously stated 83K and 125K respectively)
- Added `test_depreciation_reduces_equity` regression test that verifies depreciation reduces equity through the `total_assets` calculation in isolation
- Added `test_depreciation_reduces_equity_through_step` regression test that verifies equity decreases when depreciation exceeds retained earnings during a full `step()` call
- Documented how depreciation impacts equity in the `record_depreciation` docstring (asset reduction and income reduction mechanisms)

The root cause of the original bug (equity increasing instead of decreasing from depreciation) was that `accumulated_depreciation` returned negative raw ledger values, causing `total_assets = gross_ppe - (-accumulated_depreciation)` to add depreciation instead of subtracting it. This was already fixed in #285 (commit ede7656). This PR adds regression tests and documentation to prevent recurrence.

## Test plan

- [x] `test_normal_operation` passes
- [x] `test_depreciation_reduces_equity` passes (new — isolated depreciation-equity test)
- [x] `test_depreciation_reduces_equity_through_step` passes (new — full step integration test)
- [x] All 19 depreciation tracking tests pass
- [x] All pre-commit hooks pass (black, isort, mypy, pylint)
- [x] 4 pre-existing failures in `test_manufacturer_methods.py` confirmed unrelated (missing `cash` setter)