### PR TITLE
fix: Wrap Decimal values in float() for pytest.approx compatibility (#284)

### DIFF
--- a/ergodic_insurance/tests/test_manufacturer_methods.py
+++ b/ergodic_insurance/tests/test_manufacturer_methods.py
@@ -399,8 +399,8 @@ class TestStepMethod:
         ), "Equity decrease should be partially offset by retained earnings"
 
         # Balance sheet should remain balanced (Assets = Liabilities + Equity)
-        assert manufacturer.total_assets == pytest.approx(
-            manufacturer.total_liabilities + manufacturer.equity, rel=1e-9
+        assert float(manufacturer.total_assets) == pytest.approx(
+            float(manufacturer.total_liabilities + manufacturer.equity), rel=1e-9
         )
 
     def test_with_collateral_costs(self, manufacturer):
@@ -538,14 +538,14 @@ class TestStepMethod:
             # Balance sheet equation: Assets = Liabilities + Equity
             # Therefore: Equity = Assets - Liabilities
             # The manufacturer.equity property correctly implements this
-            assert manufacturer.equity == pytest.approx(
-                manufacturer.total_assets - manufacturer.total_liabilities,
+            assert float(manufacturer.equity) == pytest.approx(
+                float(manufacturer.total_assets - manufacturer.total_liabilities),
                 rel=0.01,
             )
 
             # Alternative check: Assets should equal Liabilities + Equity
-            assert manufacturer.total_assets == pytest.approx(
-                manufacturer.total_liabilities + manufacturer.equity,
+            assert float(manufacturer.total_assets) == pytest.approx(
+                float(manufacturer.total_liabilities + manufacturer.equity),
                 rel=0.01,
             )
 
@@ -567,7 +567,7 @@ class TestStepMethod:
         assert metrics["revenue"] > 0
         # Revenue = Assets * Turnover Ratio
         expected_revenue = initial_assets * to_decimal(initial_turnover)
-        assert metrics["revenue"] == pytest.approx(expected_revenue, rel=0.01)
+        assert float(metrics["revenue"]) == pytest.approx(float(expected_revenue), rel=0.01)
 
     def test_claim_liability_payments(self, manufacturer):
         """Test that claim liabilities are paid according to schedule."""


### PR DESCRIPTION
## Summary

Closes #284

Fixes `TypeError: unsupported operand type(s) for *: 'float' and 'decimal.Decimal'` when `pytest.approx()` compares Decimal values that are not exactly equal. The bug is latent — `pytest.approx` short-circuits on exact equality, but when values differ even slightly, it internally computes `rel * expected` (`float * Decimal`), which Python's Decimal module does not support.

## Changes

- **test_depreciation_tracking.py**: Wrapped Decimal values in `float()` for 10 assertions across 8 tests (`test_initial_ppe_allocation`, `test_custom_ppe_ratio`, `test_straight_line_depreciation`, `test_depreciation_accumulation_over_time`, `test_depreciation_in_monthly_steps`, `test_prepaid_insurance_amortization`, `test_prepaid_insurance_full_amortization`, `test_prepaid_insurance_cannot_over_amortize`, `test_prepaid_insurance_amortization_in_monthly_steps`, `test_different_useful_lives`, `test_depreciation_reduces_equity`)
- **test_manufacturer_methods.py**: Wrapped Decimal values in `float()` for 3 assertions across 3 tests (`test_normal_operation`, `test_balance_sheet_consistency`, `test_revenue_calculation`)

## Audit

Beyond the 3 tests specified in the issue, audited all `pytest.approx` usages across both files and fixed every assertion comparing Decimal properties (cash, equity, total_assets, accumulated_depreciation, net_ppe, prepaid_insurance, etc.) — 13 total assertions fixed.

## Testing

- All 48 tests in both modified files pass
- All pre-commit hooks pass (black, isort, mypy, pylint)