### PR TITLE
fix: Use self.engine in generate_monte_carlo_report for consistent engine selection

### DIFF
--- a/ergodic_insurance/tests/test_excel_reporter.py
+++ b/ergodic_insurance/tests/test_excel_reporter.py
@@ -423,3 +423,66 @@ class TestExcelReporter:
 
         assert output_file.exists()
         assert output_file.suffix == ".xlsx"
+
+    @pytest.mark.skipif(not XLSXWRITER_AVAILABLE, reason="XlsxWriter not available")
+    def test_monte_carlo_report_xlsxwriter(self, reporter_config):
+        """Test Monte Carlo report uses xlsxwriter engine when selected."""
+        reporter_config.engine = "xlsxwriter"
+        reporter = ExcelReporter(reporter_config)
+        assert reporter.engine == "xlsxwriter"
+
+        mock_results = Mock()
+        output_file = reporter.generate_monte_carlo_report(mock_results, "mc_xlsxwriter.xlsx")
+
+        assert output_file.exists()
+        assert output_file.suffix == ".xlsx"
+
+    @pytest.mark.skipif(not OPENPYXL_AVAILABLE, reason="openpyxl not available")
+    def test_monte_carlo_report_openpyxl(self, reporter_config):
+        """Test Monte Carlo report uses openpyxl engine when selected."""
+        reporter_config.engine = "openpyxl"
+        reporter = ExcelReporter(reporter_config)
+        assert reporter.engine == "openpyxl"
+
+        mock_results = Mock()
+        output_file = reporter.generate_monte_carlo_report(mock_results, "mc_openpyxl.xlsx")
+
+        assert output_file.exists()
+        assert output_file.suffix == ".xlsx"
+
+    @pytest.mark.skipif(
+        not OPENPYXL_AVAILABLE, reason="openpyxl not available (required by pandas Excel writer)"
+    )
+    def test_monte_carlo_report_pandas_fallback(self, reporter_config):
+        """Test Monte Carlo report works with pandas fallback engine."""
+        reporter_config.engine = "pandas"
+        reporter = ExcelReporter(reporter_config)
+        assert reporter.engine == "pandas"
+
+        mock_results = Mock()
+        output_file = reporter.generate_monte_carlo_report(mock_results, "mc_pandas.xlsx")
+
+        assert output_file.exists()
+        assert output_file.suffix == ".xlsx"
+
+    def test_get_pandas_engine_consistency(self, reporter_config):
+        """Test _get_pandas_engine returns correct engine for each setting."""
+        if XLSXWRITER_AVAILABLE:
+            reporter_config.engine = "xlsxwriter"
+            reporter = ExcelReporter(reporter_config)
+            assert reporter._get_pandas_engine() == "xlsxwriter"
+
+        if OPENPYXL_AVAILABLE:
+            reporter_config.engine = "openpyxl"
+            reporter = ExcelReporter(reporter_config)
+            assert reporter._get_pandas_engine() == "openpyxl"
+
+        reporter_config.engine = "pandas"
+        reporter = ExcelReporter(reporter_config)
+        engine = reporter._get_pandas_engine()
+        if OPENPYXL_AVAILABLE:
+            assert engine == "openpyxl"
+        elif XLSXWRITER_AVAILABLE:
+            assert engine == "xlsxwriter"
+        else:
+            assert engine is None


### PR DESCRIPTION
## Summary

Closes #296

`generate_monte_carlo_report` hardcoded `engine="openpyxl"` with a fallback to `engine=None`, ignoring `self.engine` entirely. This made it inconsistent with `generate_trajectory_report` and would fail at runtime when only `xlsxwriter` was available.

## Changes

- **Added `_get_pandas_engine()` helper** — centralises the mapping from `self.engine` to the `pd.ExcelWriter(engine=...)` argument. Prefers `openpyxl` in the `"pandas"` fallback path, then `xlsxwriter`, then `None`.
- **Updated `generate_monte_carlo_report`** to call `self._get_pandas_engine()` instead of the hardcoded `"openpyxl" if OPENPYXL_AVAILABLE else None`.
- **Updated `_generate_with_pandas`** to use the same helper for consistency.
- **Added 4 new tests**: engine-specific tests for `generate_monte_carlo_report` (xlsxwriter, openpyxl, pandas fallback) and a unit test for `_get_pandas_engine` consistency.

## Testing

- All 20 tests in `test_excel_reporter.py` pass (9 executed, 11 skipped due to no Excel libraries in local env).
- All pre-commit hooks pass (black, isort, mypy, pylint).
- Engine-specific tests use the same `skipif` pattern as the trajectory report tests.