### PR TITLE
fix: Add xlsxwriter and openpyxl as optional dependencies

### DIFF
--- a/ergodic_insurance/financial_statements.py
+++ b/ergodic_insurance/financial_statements.py
@@ -1167,7 +1167,7 @@ class FinancialStatementGenerator:
 
         # TOTAL LIABILITIES + EQUITY should equal TOTAL ASSETS
         # Calculate the actual sum of liabilities and equity
-        total_liabilities_and_equity = total_liabilities + equity
+        total_liabilities_and_equity = total_liabilities + to_decimal(equity)
 
         # Add the total liabilities + equity line
         data.append(

--- a/ergodic_insurance/tests/test_excel_reporter.py
+++ b/ergodic_insurance/tests/test_excel_reporter.py
@@ -88,16 +88,18 @@ class TestExcelReporter:
         # Create sample metrics history
         manufacturer.metrics_history = []
         for year in range(5):
+            growth = 1.03**year
             metrics = {
                 "year": year,
-                "assets": 10_000_000 * (1.03**year),
-                "equity": 10_000_000 * (1.03**year),
-                "revenue": 5_000_000 * (1.03**year),
-                "operating_income": 400_000 * (1.03**year),
-                "net_income": 300_000 * (1.03**year),
+                "assets": 10_000_000 * growth,
+                "equity": 10_000_000 * growth,
+                "revenue": 5_000_000 * growth,
+                "operating_income": 400_000 * growth,
+                "net_income": 300_000 * growth,
                 "collateral": 100_000 * year,
                 "restricted_assets": 100_000 * year,
-                "available_assets": 10_000_000 * (1.03**year) - 100_000 * year,
+                "available_assets": 10_000_000 * growth - 100_000 * year,
+                "cash": 1_000_000 * growth,
                 "claim_liabilities": 50_000 * year if year > 0 else 0,
                 "is_solvent": True,
                 "base_operating_margin": 0.08,
@@ -106,9 +108,17 @@ class TestExcelReporter:
                 "asset_turnover": 0.5,
                 "collateral_to_equity": 0.01 * year,
                 "collateral_to_assets": 0.01 * year,
-                "depreciation_expense": 200_000
-                * (1.03**year),  # Required for financial statements
-                "gross_ppe": 2_000_000 * (1.03**year),  # Required for cash flow statement
+                "depreciation_expense": 200_000 * growth,
+                "gross_ppe": 2_000_000 * growth,
+                # COGS breakdown (Issue #255)
+                "direct_materials": 1_500_000 * growth,
+                "direct_labor": 900_000 * growth,
+                "manufacturing_overhead": 480_000 * growth,
+                "mfg_depreciation": 120_000 * growth,
+                # SG&A breakdown (Issue #255)
+                "selling_expenses": 800_000 * growth,
+                "general_admin_expenses": 720_000 * growth,
+                "admin_depreciation": 80_000 * growth,
             }
             manufacturer.metrics_history.append(metrics)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+excel = [
+    "xlsxwriter>=3.1.0",
+    "openpyxl>=3.1.0",
+]
 dev = [
     "pytest>=8.4.1",
     "pytest-cov>=6.2.1",
@@ -43,6 +47,8 @@ dev = [
     "types-PyYAML>=6.0.0",
     "pre-commit>=3.6.0",
     "hypothesis>=6.100.0",
+    "xlsxwriter>=3.1.0",
+    "openpyxl>=3.1.0",
 ]
 notebooks = [
     "jupyter>=1.1.1",


### PR DESCRIPTION
## Summary

Closes #294

Adds `xlsxwriter` and `openpyxl` as optional dependencies in `pyproject.toml`, enabling the Excel report generation module to function fully. Also fixes pre-existing test failures that were previously hidden by skip conditions.

## Changes

- **`pyproject.toml`**: Added `excel` optional dependency group (`xlsxwriter>=3.1.0`, `openpyxl>=3.1.0`) and added both to the `dev` group
- **`ergodic_insurance/financial_statements.py`**: Fixed `Decimal + float` type mismatch in `_build_equity_section` by wrapping `equity` with `to_decimal()`
- **`ergodic_insurance/tests/test_excel_reporter.py`**: Updated mock manufacturer fixture to include `cash` (Issue #256) and COGS/SG&A breakdown fields (`direct_materials`, `direct_labor`, `manufacturing_overhead`, `mfg_depreciation`, `selling_expenses`, `general_admin_expenses`, `admin_depreciation`) required by Issue #255

## Testing

- All 20 tests in `test_excel_reporter.py` pass with 0 skips (previously 11 skipped)
- Pre-commit hooks pass (black, isort, mypy, pylint)

## Notes

The test failures were pre-existing bugs hidden by the skip conditions — once the libraries were installed, the tests ran but failed due to:
1. Missing `cash` field in mock metrics (required since Issue #256)
2. Missing COGS/SG&A breakdown fields (required since Issue #255)
3. `Decimal` + `float` type mismatch in `_build_equity_section`