### PR TITLE
fix: Correct ledger equity accounting errors (#302)

### DIFF
--- a/ergodic_insurance/ledger.py
+++ b/ergodic_insurance/ledger.py
@@ -170,6 +170,8 @@ class TransactionType(Enum):
     COLLECTION = "collection"  # Cash collection from AR
     EXPENSE = "expense"
     PAYMENT = "payment"  # Cash payment for expenses/AP
+    WAGE_PAYMENT = "wage_payment"  # Cash payment for wages
+    INTEREST_PAYMENT = "interest_payment"  # Cash payment for interest
     INVENTORY_PURCHASE = "inventory_purchase"
     INVENTORY_SALE = "inventory_sale"  # COGS recognition
     INSURANCE_PREMIUM = "insurance_premium"
@@ -828,7 +830,7 @@ class Ledger:
         )
 
         flows["cash_for_wages"] = self.sum_by_transaction_type(
-            TransactionType.PAYMENT, period, "cash", EntryType.CREDIT
+            TransactionType.WAGE_PAYMENT, period, "cash", EntryType.CREDIT
         )
 
         # Investing activities

--- a/ergodic_insurance/tests/test_manufacturer.py
+++ b/ergodic_insurance/tests/test_manufacturer.py
@@ -247,11 +247,11 @@ class TestWidgetManufacturer:
         costs = manufacturer.calculate_collateral_costs()
         assert costs == 0
 
-        # Add collateral via ledger (Issue #275: ledger is single source of truth)
+        # Add collateral via restricted assets (Issue #302: collateral tracked via RESTRICTED_CASH)
         manufacturer.ledger.record_double_entry(
             date=0,
-            debit_account=AccountName.COLLATERAL,
-            credit_account=AccountName.RETAINED_EARNINGS,
+            debit_account=AccountName.RESTRICTED_CASH,
+            credit_account=AccountName.CASH,
             amount=1_000_000,
             transaction_type=TransactionType.TRANSFER,
             description="Post collateral for testing",


### PR DESCRIPTION
## Summary

Closes #302

Fixes 5 ledger accounting bugs that produced systematically incorrect financial states throughout simulations. The most critical fix (working capital phantom cash) directly affected simulation equity, while the others affected ledger integrity.

## Changes

### 1. Cash flow double-counting (`ledger.py`, `manufacturer.py`)
- Added `WAGE_PAYMENT` and `INTEREST_PAYMENT` to `TransactionType` enum
- Updated `_pay_accrued_expenses()` to use distinct types for wages and interest
- Updated `cash_for_wages` query to use `WAGE_PAYMENT` instead of generic `PAYMENT`
- `net_operating` calculation was already correct (only subtracted `cash_to_suppliers`)

### 2. Collateral phantom assets (`manufacturer.py`)
- Removed phantom `Debit COLLATERAL, Credit RETAINED_EARNINGS` entries during collateral posting and initialization
- Changed `self.collateral` property to read from `self.restricted_assets` (RESTRICTED_CASH tracks the same economic reality)
- Removed COLLATERAL from `_write_off_all_assets` (redundant with RESTRICTED_CASH)

### 3. Claim payment double-reduce equity (`manufacturer.py`)
- Removed phantom `Debit RETAINED_EARNINGS, Credit COLLATERAL` entry after claim payments
- The actual payment entry (`Debit CLAIM_LIABILITIES, Credit RESTRICTED_CASH`) already correctly handles the accounting

### 4. Dividend double-reduce equity (`manufacturer.py`)
- Removed the dividend declaration entry (`Debit RETAINED_EARNINGS, Credit DIVIDENDS`)
- The `total_retained` calculation already correctly accounts for dividends: `net_income - actual_dividends`
- Dividend amounts tracked via `self._last_dividends_paid` for reporting

### 5. Working capital phantom cash injection (`manufacturer.py`) — **Simulation-impacting**
- Replaced `_record_cash_adjustment` (which created `Debit CASH, Credit RETAINED_EARNINGS`) with proper vendor financing: `Debit CASH, Credit ACCOUNTS_PAYABLE`
- This creates a real liability instead of phantom equity when working capital changes push cash negative

### Test updates
- Updated `test_calculate_collateral_costs` to use `RESTRICTED_CASH` instead of `COLLATERAL` account

## Design decisions
- **Collateral tracking**: `self.collateral` now returns `self.restricted_assets` since restricted cash and collateral track the same amounts throughout the simulation lifecycle. The COLLATERAL ledger account is effectively unused.
- **Working capital shortfalls**: Modeled as vendor financing (AP increase) rather than phantom equity. This preserves A = L + E while transparently showing the working capital facility.
- **Scope**: Only addresses issues 1-5 from #302. Additional issues (insolvency phantom cash, missing claim liability entries, etc.) are deferred to #319.

## Test plan
- [x] All 66 manufacturer tests pass
- [x] All 155 accounting-related tests pass (ledger, balance sheet, cash flow, dividend, working capital)
- [x] Full test suite: 2614 passed, 1 failed (pre-existing `_run_chunk` issue), 28 skipped
- [x] All pre-commit hooks pass (black, isort, mypy, pylint)