### PR TITLE
fix: Eliminate phantom cash and fix ledger accounting errors (#319)

### DIFF
--- a/ergodic_insurance/financial_statements.py
+++ b/ergodic_insurance/financial_statements.py
@@ -406,6 +406,7 @@ class CashFlowStatement:
             "cash_for_insurance": -flows.get("cash_for_insurance", ZERO),
             "cash_for_taxes": -flows.get("cash_for_taxes", ZERO),
             "cash_for_wages": -flows.get("cash_for_wages", ZERO),
+            "cash_for_interest": -flows.get("cash_for_interest", ZERO),
         }
 
         # Calculate total
@@ -527,6 +528,10 @@ class CashFlowStatement:
                 cash_flow_data.append(("  Cash Paid for Taxes", operating["cash_for_taxes"], ""))
             if operating.get("cash_for_wages", 0) != 0:
                 cash_flow_data.append(("  Cash Paid for Wages", operating["cash_for_wages"], ""))
+            if operating.get("cash_for_interest", 0) != 0:
+                cash_flow_data.append(
+                    ("  Cash Paid for Interest", operating["cash_for_interest"], "")
+                )
         else:
             cash_flow_data.append(("CASH FLOWS FROM OPERATING ACTIVITIES", "", ""))
             cash_flow_data.append(("  Net Income", operating["net_income"], ""))


### PR DESCRIPTION
## Summary

Closes #319

Fixes additional ledger accounting errors extending the work from #302. Addresses phantom cash injection in insolvency handlers, missing claim liability ledger entries, incomplete cash flow calculations, and liquidation accounting bypass.

## Changes

### Critical: Remove phantom cash injection (manufacturer.py)
- **`handle_insolvency()`**: Removed `_record_cash_adjustment()` call that injected phantom cash (Debit CASH, Credit RETAINED_EARNINGS) to floor equity at zero. Negative equity now correctly represents the insolvent state — creditors absorb losses beyond shareholder investment.
- **`check_solvency()`**: Removed phantom cash injection that floored cash at zero. Negative cash now flows through to the equity check naturally, triggering insolvency.
- **`_record_cash_adjustment()`**: Updated docstring to warn this creates phantom assets and should only be used in tests.

### High: Add claim liability ledger recognition (manufacturer.py)
- Added `Debit INSURANCE_LOSS, Credit CLAIM_LIABILITIES` ledger entries at all 4 `ClaimLiability` creation sites:
  1. Insured claim — company portion
  2. Insured claim — unpayable portion
  3. Uninsured claim — immediate payment shortfall
  4. Uninsured claim — deferred payment
- This keeps the CLAIM_LIABILITIES ledger account synchronized with `ClaimLiability` Python objects, preventing permanent negative balance drift.

### High: Fix `get_cash_flows()` net_operating calculation (ledger.py)
- Added `cash_for_interest` extraction using `TransactionType.INTEREST_PAYMENT`
- Added `cash_for_wages` and `cash_for_interest` to `net_operating` subtraction (both were previously missing)

### Medium: Fix liquidation accounting (manufacturer.py)
- Changed `_record_liquidation()` to debit `INSURANCE_LOSS` instead of `RETAINED_EARNINGS`, routing losses through the income statement before closing to retained earnings.

### Medium: Resolve COLLATERAL account status (ledger.py)
- Added deprecation comments to `COLLATERAL` enum value and chart of accounts entry, documenting it is tracked via `RESTRICTED_CASH` per #302.

### Medium: Add accounting equation assertion (manufacturer.py)
- Added `_verify_accounting_equation()` method that asserts total debits == total credits
- Called at end of each `step()` to catch unbalanced entries immediately

### Display: Update financial statements (financial_statements.py)
- Added `cash_for_interest` to operating cash flow items
- Added "Cash Paid for Interest" display row in direct method cash flow statement

## Test plan

- [x] All 2614 tests pass (28 skipped, only pre-existing `test_parallel_chunk_processing` excluded)
- [x] 85.71% code coverage (above 80% threshold)
- [x] All pre-commit hooks pass (black, isort, mypy, mixed-line-endings)
- [x] Integration tests for claims, insolvency, and financial statements all pass
- [x] Dividend phantom payment tests pass (these use `_record_cash_adjustment` for test setup)
- [x] Exposure base tests pass (also use `_record_cash_adjustment` for test setup)