### PR TITLE
fix: Standardize Decimal types across financial calculations

### DIFF
--- a/ergodic_insurance/business_optimizer.py
+++ b/ergodic_insurance/business_optimizer.py
@@ -219,7 +219,7 @@ class BusinessOptimizer:
             f"Maximizing ROE over {time_horizon} years with {n_simulations} simulations"
         )
 
-        # Convert Decimal properties to float for scipy optimization
+        # Boundary: float for scipy.optimize
         total_assets = float(self.manufacturer.total_assets)
         revenue = float(self.manufacturer.calculate_revenue())
 
@@ -546,7 +546,9 @@ class BusinessOptimizer:
         results = []
 
         for strategy in strategies:
-            coverage_limit = strategy.get("coverage_limit", float(self.manufacturer.total_assets))
+            coverage_limit = strategy.get(
+                "coverage_limit", float(self.manufacturer.total_assets)
+            )  # Boundary: float for scipy.optimize
             deductible = strategy.get("deductible", 100000)
             premium_rate = strategy.get("premium_rate", 0.02)
             strategy_name = strategy.get("name", "Strategy")
@@ -623,7 +625,7 @@ class BusinessOptimizer:
                 obj.weight /= total_weight
 
         # Define optimization bounds
-        # Convert Decimal to float for scipy optimization
+        # Boundary: float for scipy.optimize
         total_assets = float(self.manufacturer.total_assets)
         bounds = [
             (1e6, min(total_assets * 2.5, 100e6)),  # Coverage limit
@@ -733,7 +735,7 @@ class BusinessOptimizer:
     ) -> float:
         """Simulate ROE with given insurance parameters."""
         roe_values = []
-        # Convert Decimal properties to float for calculations
+        # Boundary: float for scipy.optimize
         equity = float(self.manufacturer.equity)
         total_assets = float(self.manufacturer.total_assets)
 

--- a/ergodic_insurance/decimal_utils.py
+++ b/ergodic_insurance/decimal_utils.py
@@ -15,7 +15,7 @@ Example:
 """
 
 from decimal import ROUND_HALF_UP, Decimal, localcontext
-from typing import Union
+from typing import Dict, Union
 
 # Standard precision for financial calculations (2 decimal places = cents)
 CURRENCY_PLACES = Decimal("0.01")
@@ -24,6 +24,11 @@ CURRENCY_PLACES = Decimal("0.01")
 ZERO = Decimal("0.00")
 ONE = Decimal("1.00")
 PENNY = Decimal("0.01")
+
+# Type alias for metrics dictionaries used across the codebase.
+# Prefer Decimal for monetary values; float is accepted for backward
+# compatibility and is converted to Decimal at calculation boundaries.
+MetricsDict = Dict[str, Union[Decimal, float, int, bool]]
 
 
 def to_decimal(value: Union[float, int, str, Decimal, None]) -> Decimal:

--- a/ergodic_insurance/decision_engine.py
+++ b/ergodic_insurance/decision_engine.py
@@ -698,7 +698,9 @@ class InsuranceDecisionEngine:
         # Insurance cost ceiling constraint
         def insurance_cost_constraint(x):
             premium = self._calculate_premium(x)
-            revenue = float(self.manufacturer.total_assets) * self.manufacturer.asset_turnover_ratio
+            revenue = (
+                float(self.manufacturer.total_assets) * self.manufacturer.asset_turnover_ratio
+            )  # Boundary: float for scipy.optimize
             cost_ratio = premium / revenue if revenue > 0 else 0
             return constraints.max_insurance_cost_ratio - cost_ratio
 
@@ -749,11 +751,11 @@ class InsuranceDecisionEngine:
 
             # Cost component (minimize premium as % of assets)
             premium = self._calculate_premium(x)
-            assets = float(self.manufacturer.total_assets)
+            assets = float(self.manufacturer.total_assets)  # Boundary: float for scipy.optimize
             cost_obj = weights["cost"] * (premium / assets) * 10  # Scale
 
             total = growth_obj + risk_obj + cost_obj
-            return float(total)
+            return float(total)  # Boundary: float for scipy.optimize
 
         except Exception as e:
             logger.error(f"Error calculating objective: {e}")
@@ -790,7 +792,9 @@ class InsuranceDecisionEngine:
 
         # Insurance benefit increases growth by reducing volatility drag
         coverage = sum(layer_limits)
-        coverage_ratio = coverage / float(self.manufacturer.total_assets)
+        coverage_ratio = coverage / float(
+            self.manufacturer.total_assets
+        )  # Boundary: float for scipy.optimize
 
         # Estimate volatility reduction
         volatility_reduction = min(coverage_ratio * 0.3, 0.15)  # Max 15% reduction
@@ -798,7 +802,7 @@ class InsuranceDecisionEngine:
         # Ergodic growth benefit
         growth_benefit = volatility_reduction * 0.5  # Simplified
 
-        return float(base_growth + growth_benefit)
+        return float(base_growth + growth_benefit)  # Boundary: float for scipy.optimize
 
     def _calculate_cvar(self, losses: np.ndarray, percentile: float) -> float:
         """Calculate Conditional Value at Risk (CVaR).

--- a/ergodic_insurance/exposure_base.py
+++ b/ergodic_insurance/exposure_base.py
@@ -38,6 +38,7 @@ Since:
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+from decimal import Decimal
 from typing import Callable, Dict, List, Optional, Protocol, runtime_checkable
 
 import numpy as np
@@ -53,32 +54,32 @@ class FinancialStateProvider(Protocol):
     """
 
     @property
-    def current_revenue(self) -> float:
+    def current_revenue(self) -> Decimal:
         """Get current revenue."""
         ...
 
     @property
-    def current_assets(self) -> float:
+    def current_assets(self) -> Decimal:
         """Get current total assets."""
         ...
 
     @property
-    def current_equity(self) -> float:
+    def current_equity(self) -> Decimal:
         """Get current equity value."""
         ...
 
     @property
-    def base_revenue(self) -> float:
+    def base_revenue(self) -> Decimal:
         """Get base (initial) revenue for comparison."""
         ...
 
     @property
-    def base_assets(self) -> float:
+    def base_assets(self) -> Decimal:
         """Get base (initial) assets for comparison."""
         ...
 
     @property
-    def base_equity(self) -> float:
+    def base_equity(self) -> Decimal:
         """Get base (initial) equity for comparison."""
         ...
 
@@ -167,7 +168,7 @@ class RevenueExposure(ExposureBase):
 
     def get_exposure(self, time: float) -> float:
         """Return current actual revenue from manufacturer."""
-        return self.state_provider.current_revenue
+        return float(self.state_provider.current_revenue)  # Boundary: float for NumPy
 
     def get_frequency_multiplier(self, time: float) -> float:
         """Calculate multiplier from actual revenue ratio."""
@@ -176,7 +177,9 @@ class RevenueExposure(ExposureBase):
         # Handle negative or zero revenue (insolvency) by returning 0
         if self.state_provider.current_revenue <= 0:
             return 0.0
-        return self.state_provider.current_revenue / self.state_provider.base_revenue
+        return float(
+            self.state_provider.current_revenue / self.state_provider.base_revenue
+        )  # Boundary: float for NumPy
 
     def reset(self) -> None:
         """No internal state to reset for state-driven exposure."""
@@ -215,7 +218,7 @@ class AssetExposure(ExposureBase):
 
     def get_exposure(self, time: float) -> float:
         """Return current actual assets from manufacturer."""
-        return self.state_provider.current_assets
+        return float(self.state_provider.current_assets)  # Boundary: float for NumPy
 
     def get_frequency_multiplier(self, time: float) -> float:
         """Calculate multiplier from actual asset ratio."""
@@ -224,7 +227,9 @@ class AssetExposure(ExposureBase):
         # Handle negative or zero assets (insolvency) by returning 0
         if self.state_provider.current_assets <= 0:
             return 0.0
-        return self.state_provider.current_assets / self.state_provider.base_assets
+        return float(
+            self.state_provider.current_assets / self.state_provider.base_assets
+        )  # Boundary: float for NumPy
 
     def reset(self) -> None:
         """No internal state to reset for state-driven exposure."""
@@ -260,7 +265,7 @@ class EquityExposure(ExposureBase):
 
     def get_exposure(self, time: float) -> float:
         """Return current actual equity from manufacturer."""
-        return self.state_provider.current_equity
+        return float(self.state_provider.current_equity)  # Boundary: float for NumPy
 
     def get_frequency_multiplier(self, time: float) -> float:
         """Higher equity implies larger operations."""

--- a/ergodic_insurance/insurance_accounting.py
+++ b/ergodic_insurance/insurance_accounting.py
@@ -165,8 +165,11 @@ class InsuranceAccounting:
                 - prepaid_reduction: Reduction in prepaid asset
                 - remaining_prepaid: Remaining prepaid balance
         """
-        # Calculate expense for this month (handle partial months at end)
-        expense = min(self.monthly_expense, self.prepaid_insurance)
+        # Final month: absorb rounding residual to ensure zero prepaid balance
+        if self.current_month >= self.months_in_period - 1:
+            expense = self.prepaid_insurance
+        else:
+            expense = min(self.monthly_expense, self.prepaid_insurance)
 
         # Reduce prepaid asset
         self.prepaid_insurance -= expense

--- a/ergodic_insurance/loss_distributions.py
+++ b/ergodic_insurance/loss_distributions.py
@@ -497,14 +497,14 @@ class LossData:
 
         return {
             "count": len(self.loss_amounts),
-            "total": float(np.sum(self.loss_amounts)),
-            "mean": float(np.mean(self.loss_amounts)),
-            "std": float(np.std(self.loss_amounts)),
-            "min": float(np.min(self.loss_amounts)),
-            "max": float(np.max(self.loss_amounts)),
-            "p50": float(np.percentile(self.loss_amounts, 50)),
-            "p95": float(np.percentile(self.loss_amounts, 95)),
-            "p99": float(np.percentile(self.loss_amounts, 99)),
+            "total": float(np.sum(self.loss_amounts)),  # Boundary: float for NumPy
+            "mean": float(np.mean(self.loss_amounts)),  # Boundary: float for NumPy
+            "std": float(np.std(self.loss_amounts)),  # Boundary: float for NumPy
+            "min": float(np.min(self.loss_amounts)),  # Boundary: float for NumPy
+            "max": float(np.max(self.loss_amounts)),  # Boundary: float for NumPy
+            "p50": float(np.percentile(self.loss_amounts, 50)),  # Boundary: float for NumPy
+            "p95": float(np.percentile(self.loss_amounts, 95)),  # Boundary: float for NumPy
+            "p99": float(np.percentile(self.loss_amounts, 99)),  # Boundary: float for NumPy
         }
 
 
@@ -562,7 +562,7 @@ class FrequencyGenerator:
         if revenue <= 0:
             return 0.0
 
-        # Convert to float to handle Decimal inputs - power operation requires float
+        # Boundary: float for NumPy - power operation requires float
         revenue_float = float(revenue)
         scaling_factor = (revenue_float / self.reference_revenue) ** self.revenue_scaling_exponent
         return float(self.base_frequency * scaling_factor)

--- a/ergodic_insurance/reporting/formatters.py
+++ b/ergodic_insurance/reporting/formatters.py
@@ -76,7 +76,7 @@ class NumberFormatter:
 
         decimals = decimals if decimals is not None else self.decimal_places
 
-        # Convert to float for comparison and calculations
+        # Boundary: float for display formatting
         float_value = float(value)
         abs_value = abs(float_value)
 

--- a/ergodic_insurance/tests/test_cash_reconciliation.py
+++ b/ergodic_insurance/tests/test_cash_reconciliation.py
@@ -1,14 +1,16 @@
 """Tests for cash flow reconciliation."""
 
-from typing import Union
+from decimal import Decimal
+from typing import List, Union
 
 import numpy as np
 import pytest
 
+from ergodic_insurance.decimal_utils import MetricsDict
 from ergodic_insurance.financial_statements import CashFlowStatement
 
-# Type alias for metrics dictionaries
-MetricsDict = list[dict[str, Union[int, float]]]
+# Type alias for metrics lists
+MetricsList = List[MetricsDict]
 
 
 class TestCashReconciliation:
@@ -22,7 +24,7 @@ class TestCashReconciliation:
         #   Financing: -180k dividends
         #   Net: 660k - 160k - 180k = 320k
         #   Ending cash: 1,000k + 320k = 1,320k
-        metrics: MetricsDict = [
+        metrics: MetricsList = [
             {
                 "cash": 1000000,
                 "net_income": 500000,
@@ -68,7 +70,7 @@ class TestCashReconciliation:
     def test_reconciliation_with_operating_activities(self):
         """Test reconciliation with detailed operating activities."""
         # Issue #243: Include dividends_paid in metrics (preferred path since Issue #239)
-        metrics: MetricsDict = [
+        metrics: MetricsList = [
             {
                 "cash": 500000,
                 "net_income": 200000,
@@ -111,7 +113,7 @@ class TestCashReconciliation:
 
     def test_reconciliation_negative_cash_flow(self):
         """Test reconciliation when cash decreases."""
-        metrics: MetricsDict = [
+        metrics: MetricsList = [
             {
                 "cash": 1000000,
                 "net_income": 100000,
@@ -143,7 +145,7 @@ class TestCashReconciliation:
 
     def test_reconciliation_first_year(self):
         """Test cash reconciliation for year 0 (no prior period)."""
-        metrics: MetricsDict = [
+        metrics: MetricsList = [
             {
                 "cash": 500000,
                 "net_income": 100000,
@@ -183,7 +185,7 @@ class TestCashReconciliation:
         #   Financing: -180k dividends
         #   Net: 700k - 410k - 180k = 110k
         #   Ending cash: 1,000k + 110k = 1,110k
-        metrics: MetricsDict = [
+        metrics: MetricsList = [
             {
                 "cash": 1000000,
                 "net_income": 500000,
@@ -234,7 +236,7 @@ class TestCashReconciliation:
 
     def test_monthly_reconciliation(self):
         """Test cash reconciliation for monthly periods."""
-        metrics: MetricsDict = [
+        metrics: MetricsList = [
             {
                 "cash": 100000,
                 "net_income": 120000,  # Annual
@@ -258,10 +260,10 @@ class TestCashReconciliation:
 
         # Monthly values
         monthly_net_income = values.get("Net Income")
-        assert monthly_net_income == pytest.approx(144000 / 12)
+        assert float(monthly_net_income) == pytest.approx(144000 / 12)
 
         monthly_depreciation = values.get("Depreciation and Amortization")
-        assert monthly_depreciation == pytest.approx(12000 / 12)
+        assert float(monthly_depreciation) == pytest.approx(12000 / 12)
 
         # Reconciliation should still work
         beginning = values.get("Cash - Beginning of Period")
@@ -280,7 +282,7 @@ class TestCashReconciliation:
         #   Financing: -45k dividends
         #   Net: 160k - 20k - 45k = 95k
         #   Ending cash: 0 + 95k = 95k
-        metrics: MetricsDict = [
+        metrics: MetricsList = [
             {
                 "cash": 0,
                 "net_income": 100000,
@@ -316,7 +318,7 @@ class TestCashReconciliation:
         #   Financing: -360k dividends
         #   Net: 1450k - 2250k - 360k = -1160k
         #   Ending cash: 5000k - 1160k = 3840k
-        metrics: MetricsDict = [
+        metrics: MetricsList = [
             {
                 "cash": 5000000,
                 "net_income": 1000000,
@@ -367,7 +369,7 @@ class TestCashReconciliation:
         """
         # Create metrics where cash flow components are explicitly calculated
         # to verify the statement shows calculated values, not plugged values
-        metrics: MetricsDict = [
+        metrics: MetricsList = [
             {
                 "cash": 1000000,
                 "net_income": 400000,
@@ -428,6 +430,6 @@ class TestCashReconciliation:
         for _, row in df.iterrows():
             item = row["Item"].strip()
             value = row[column]
-            if value != "" and isinstance(value, (int, float)):
+            if value != "" and isinstance(value, (int, float, Decimal)):
                 values[item] = value
         return values

--- a/ergodic_insurance/tests/test_financial_statements.py
+++ b/ergodic_insurance/tests/test_financial_statements.py
@@ -998,9 +998,9 @@ class TestFinancialStatementGenerator:
 
         # If pretax income is positive, tax should be ~25% (default rate)
         if pretax_income_value > 0:
-            expected_tax = pretax_income_value * 0.25
+            expected_tax = float(pretax_income_value) * 0.25
             assert (
-                abs(tax_expense_value - expected_tax) < 1
+                abs(float(tax_expense_value) - expected_tax) < 1
             ), f"Tax expense should be ~25% of pretax income ({expected_tax}), got {tax_expense_value}"
 
     def test_monthly_income_statement(self, generator):
@@ -1091,7 +1091,7 @@ class TestFinancialStatementGenerator:
 
         # Verify gross margin is approximately 20%
         if revenue_val and gross_profit_val:
-            actual_margin = gross_profit_val / revenue_val
+            actual_margin = float(gross_profit_val) / float(revenue_val)
             assert (
                 abs(actual_margin - 0.20) < 0.05
             ), f"Gross margin should be ~20%, got {actual_margin*100:.1f}%"
@@ -1154,7 +1154,7 @@ class TestFinancialStatementGenerator:
 
         # Gross margin should be approximately 25% (the configured gross_margin_ratio)
         # The value is stored as percentage (e.g., 25.0 for 25%)
-        actual_margin = df["Year 0"].values[gross_margin_row]
+        actual_margin = float(df["Year 0"].values[gross_margin_row])
         assert (
             abs(actual_margin - 25.0) < 1.0
         ), f"Gross margin should be ~25% (configured), got {actual_margin:.1f}%"

--- a/ergodic_insurance/tests/test_working_capital_changes.py
+++ b/ergodic_insurance/tests/test_working_capital_changes.py
@@ -1,7 +1,11 @@
 """Tests for working capital change calculations in cash flow statements."""
 
+from decimal import Decimal
+from typing import List
+
 import pytest
 
+from ergodic_insurance.decimal_utils import MetricsDict
 from ergodic_insurance.financial_statements import CashFlowStatement
 
 
@@ -10,7 +14,7 @@ class TestWorkingCapitalChanges:
 
     def test_basic_working_capital_increase(self):
         """Test that increases in working capital assets reduce cash flow."""
-        metrics: list[dict[str, float]] = [
+        metrics: List[MetricsDict] = [
             {
                 "accounts_receivable": 100000.0,
                 "inventory": 50000.0,
@@ -41,7 +45,7 @@ class TestWorkingCapitalChanges:
 
     def test_working_capital_decrease(self):
         """Test that decreases in working capital assets increase cash flow."""
-        metrics: list[dict[str, float]] = [
+        metrics: List[MetricsDict] = [
             {
                 "accounts_receivable": 200000.0,
                 "inventory": 100000.0,
@@ -66,7 +70,7 @@ class TestWorkingCapitalChanges:
 
     def test_operating_cash_flow_with_working_capital(self):
         """Test that working capital changes affect operating cash flow correctly."""
-        metrics: list[dict[str, float]] = [
+        metrics: List[MetricsDict] = [
             {
                 "net_income": 500000.0,
                 "depreciation_expense": 50000.0,
@@ -93,7 +97,7 @@ class TestWorkingCapitalChanges:
 
     def test_claim_liabilities_change(self):
         """Test that claim liability changes are handled correctly."""
-        metrics: list[dict[str, float]] = [
+        metrics: List[MetricsDict] = [
             {"claim_liabilities": 0.0, "net_income": 100000.0},
             {"claim_liabilities": 500000.0, "net_income": 200000.0},  # New claims
         ]
@@ -106,7 +110,7 @@ class TestWorkingCapitalChanges:
 
     def test_zero_starting_working_capital(self):
         """Test working capital changes when starting from zero."""
-        metrics: list[dict[str, float]] = [
+        metrics: List[MetricsDict] = [
             {
                 "accounts_receivable": 0.0,
                 "inventory": 0.0,
@@ -128,7 +132,7 @@ class TestWorkingCapitalChanges:
 
     def test_mixed_working_capital_changes(self):
         """Test mixed increases and decreases in working capital."""
-        metrics: list[dict[str, float]] = [
+        metrics: List[MetricsDict] = [
             {
                 "net_income": 100000.0,
                 "depreciation_expense": 10000.0,
@@ -168,7 +172,7 @@ class TestWorkingCapitalChanges:
     def test_statement_shows_working_capital_changes(self):
         """Test that working capital changes appear correctly in statement."""
         # Issue #243: Include dividends_paid in metrics (preferred path since Issue #239)
-        metrics: list[dict[str, float]] = [
+        metrics: List[MetricsDict] = [
             {
                 "cash": 500000.0,
                 "net_income": 300000.0,
@@ -205,7 +209,7 @@ class TestWorkingCapitalChanges:
         for _, row in df.iterrows():
             item = row["Item"].strip()
             value = row["Year 1"]
-            if value != "" and isinstance(value, (int, float)):
+            if value != "" and isinstance(value, (int, float, Decimal)):
                 if "Accounts Receivable" in item:
                     wc_items["AR"] = value
                 elif "Inventory" in item:
@@ -229,7 +233,7 @@ class TestWorkingCapitalChanges:
 
     def test_no_working_capital_changes(self):
         """Test when there are no working capital changes."""
-        metrics: list[dict[str, float]] = [
+        metrics: List[MetricsDict] = [
             {
                 "accounts_receivable": 100000.0,
                 "inventory": 50000.0,
@@ -251,7 +255,7 @@ class TestWorkingCapitalChanges:
 
     def test_missing_working_capital_fields(self):
         """Test handling of missing working capital fields."""
-        metrics: list[dict[str, float]] = [
+        metrics: List[MetricsDict] = [
             {"net_income": 100000.0},
             {"net_income": 150000.0, "accounts_receivable": 50000.0},
         ]
@@ -266,7 +270,7 @@ class TestWorkingCapitalChanges:
 
     def test_monthly_working_capital_changes(self):
         """Test that monthly periods scale working capital changes correctly."""
-        annual_metrics: list[dict[str, float]] = [
+        annual_metrics: List[MetricsDict] = [
             {
                 "net_income": 200000.0,
                 "depreciation_expense": 20000.0,


### PR DESCRIPTION
## Summary

- Introduce `MetricsDict` type alias (`Dict[str, Union[Decimal, float, int, bool]]`) in `decimal_utils.py` for consistent metrics dictionary typing
- Fix `FinancialStateProvider` protocol to return `Decimal` instead of `float` for all financial properties
- Wrap all `metrics.get()` calls in financial statement builders with `to_decimal()` and `ZERO` defaults to prevent mixed-type arithmetic
- Fix premium amortization rounding residual: final month absorbs any cent-level difference so prepaid insurance reaches exactly zero
- Add `float()` boundary casts with comments at NumPy/SciPy and display formatting interfaces
- Update test type annotations to use `MetricsDict` / `MetricsList` and add `Decimal` to `isinstance` checks

Closes #308, closes #321

## Test plan

- [x] All pre-commit hooks pass (black, isort, mypy, pylint)
- [x] No `TypeError` from mixed Decimal/float arithmetic in financial statement generation
- [x] Premium amortization fully expensed with no residual
- [x] Float conversions documented at NumPy/SciPy/display boundaries only
- [ ] Full test suite passes (`python -m pytest ergodic_insurance/tests/ -v`)