### PR TITLE
fix: Stop simulation on insolvency, make Simulation re-entrant, and fix runtime errors (#304)

### DIFF
--- a/ergodic_insurance/monte_carlo.py
+++ b/ergodic_insurance/monte_carlo.py
@@ -1328,7 +1328,7 @@ class MonteCarloEngine:
                     metadata={
                         "Simulations": self.config.n_simulations,
                         "Years": self.config.n_years,
-                        "Ruin Probability": f"{results.ruin_probability:.2%}",
+                        "Ruin Probability": f"{results.ruin_probability.get(str(self.config.n_years), 0.0):.2%}",
                         "Mean Growth Rate": f"{np.mean(results.growth_rates):.4f}",
                     },
                 )

--- a/ergodic_insurance/tests/test_simulation.py
+++ b/ergodic_insurance/tests/test_simulation.py
@@ -87,7 +87,7 @@ class TestSimulationResults:
         stats = results.summary_stats()
 
         assert stats["mean_roe"] == pytest.approx(0.11, rel=0.01)
-        assert stats["std_roe"] == pytest.approx(0.00816, rel=0.1)
+        assert stats["std_roe"] == pytest.approx(0.01, rel=0.1)  # sample std (ddof=1)
         assert stats["median_roe"] == pytest.approx(0.11, rel=0.01)
         assert stats["final_assets"] == 130
         assert stats["final_equity"] == 65


### PR DESCRIPTION
## Summary

Closes #304

Fixes 5 bugs in the simulation and Monte Carlo engine:

- **Insolvency break**: Simulation loop now stops after insolvency is detected instead of continuing to step a bankrupt manufacturer
- **Re-entrancy**: `run()` and `run_with_loss_data()` reset `insolvency_year` and all arrays at start, so a `Simulation` object can be run multiple times
- **KeyError fix**: `compare_insurance_strategies` no longer accesses non-existent `mc_results["statistics"]` — it computes stats directly from the `SimulationResults` object
- **TypeError fix**: `_perform_advanced_aggregation` extracts a scalar from the `ruin_probability` dict instead of formatting the dict itself
- **ddof=1**: ROE standard deviation uses sample std (`ddof=1`) instead of population std

## Changes

| File | Change |
|------|--------|
| `ergodic_insurance/simulation.py` | Added `break` after insolvency fill (both `run()` and `run_with_loss_data()`); added state reset at top of both run methods; rewrote `compare_insurance_strategies` to compute stats from `SimulationResults`; added `ddof=1` to `np.std` calls |
| `ergodic_insurance/monte_carlo.py` | Extract scalar from `ruin_probability` dict in `_perform_advanced_aggregation` |
| `ergodic_insurance/tests/test_simulation.py` | Updated `std_roe` test expectation to match sample std (`ddof=1`) |

## Test plan

- [x] `test_simulation.py` — 15 passed, 1 skipped
- [x] `test_monte_carlo.py` — 22 passed, 8 skipped
- [x] `test_monte_carlo_extended.py` — 17 passed, 1 pre-existing failure (unrelated `_run_chunk` AttributeError)
- [x] `test_simulation_pipeline.py` — 10 passed, 2 skipped
- [x] All pre-commit hooks pass (black, isort, mypy, pylint)