### PR TITLE
fix: Audit erroneous, duplicated, and hardcoded financial calculations (#314)

### DIFF
--- a/ergodic_insurance/config.py
+++ b/ergodic_insurance/config.py
@@ -53,13 +53,102 @@ Since:
     Version 0.1.0
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 import yaml
+
+# --- Module-level financial constants ---
+# Issue #314: Centralized constants to eliminate hardcoded values across modules
+
+DEFAULT_RISK_FREE_RATE: float = 0.02
+"""Default risk-free rate (2%) used for Sharpe ratio and risk-adjusted calculations."""
+
+
+@dataclass
+class BusinessOptimizerConfig:
+    """Calibration parameters for BusinessOptimizer financial heuristics.
+
+    Issue #314 (C1): Consolidates all hardcoded financial multipliers from
+    BusinessOptimizer into a single, documentable configuration object.
+
+    These are simplified model parameters used by the optimizer's heuristic
+    methods (_estimate_roe, _estimate_bankruptcy_risk, _estimate_growth_rate,
+    etc.). They are NOT derived from manufacturer data—they are tuning knobs
+    for the optimizer's internal scoring functions.
+    """
+
+    # _estimate_roe parameters
+    base_roe: float = 0.15
+    """Base return on equity (15%) before insurance adjustments."""
+    protection_benefit_factor: float = 0.05
+    """Coverage-to-assets ratio multiplier for protection benefit."""
+    roe_noise_std: float = 0.1
+    """Standard deviation of multiplicative noise applied to ROE."""
+
+    # _estimate_bankruptcy_risk parameters
+    base_bankruptcy_risk: float = 0.02
+    """Base annual bankruptcy probability (2%)."""
+    max_risk_reduction: float = 0.015
+    """Maximum risk reduction from insurance coverage (1.5%)."""
+    premium_burden_risk_factor: float = 0.5
+    """Multiplier converting premium burden ratio to risk increase."""
+    time_risk_constant: float = 20.0
+    """Time constant (years) for exponential risk accumulation."""
+
+    # _estimate_growth_rate parameters
+    base_growth_rate: float = 0.10
+    """Base growth rate (10%) before insurance adjustments."""
+    growth_boost_factor: float = 0.03
+    """Coverage ratio multiplier for growth boost (up to 3%)."""
+    premium_drag_factor: float = 0.5
+    """Multiplier for premium-to-revenue drag on growth."""
+    asset_growth_factor: float = 0.8
+    """Growth adjustment factor for asset metric."""
+    equity_growth_factor: float = 1.1
+    """Growth adjustment factor for equity metric."""
+
+    # _calculate_capital_efficiency parameters
+    risk_transfer_benefit_rate: float = 0.05
+    """Fraction of coverage limit freed up by risk transfer (5%)."""
+
+    # _estimate_insurance_return parameters
+    risk_reduction_value: float = 0.03
+    """Return contribution from risk reduction (3%)."""
+    stability_value: float = 0.02
+    """Return contribution from stability improvement (2%)."""
+    growth_enablement_value: float = 0.03
+    """Return contribution from growth enablement (3%)."""
+
+    # _calculate_ergodic_growth parameters
+    assumed_volatility: float = 0.20
+    """Assumed base volatility for ergodic correction."""
+    volatility_reduction_factor: float = 0.05
+    """Coverage ratio multiplier for volatility reduction."""
+    min_volatility: float = 0.05
+    """Floor for adjusted volatility."""
+
+
+@dataclass
+class DecisionEngineConfig:
+    """Calibration parameters for InsuranceDecisionEngine heuristics.
+
+    Issue #314 (C2): Consolidates hardcoded values from the decision engine's
+    growth estimation and simulation methods.
+    """
+
+    # _estimate_growth_rate parameters
+    base_growth_rate: float = 0.08
+    """Base growth rate (8%) for decision engine growth estimation."""
+    volatility_reduction_factor: float = 0.3
+    """Coverage ratio multiplier for volatility reduction."""
+    max_volatility_reduction: float = 0.15
+    """Maximum volatility reduction (15%)."""
+    growth_benefit_factor: float = 0.5
+    """Simplified growth benefit multiplier."""
 
 
 class ManufacturerConfig(BaseModel):

--- a/ergodic_insurance/financial_statements.py
+++ b/ergodic_insurance/financial_statements.py
@@ -1499,9 +1499,17 @@ class FinancialStatementGenerator:
         # Priority 3: Fall back to flat rate calculation (backward compatibility)
         if tax_provision is None:
             config = self.manufacturer_data.get("config")
-            tax_rate = to_decimal(
-                config.tax_rate if config and hasattr(config, "tax_rate") else Decimal("0.25")
-            )
+            if config and hasattr(config, "tax_rate"):
+                tax_rate = to_decimal(config.tax_rate)
+            else:
+                import warnings
+
+                warnings.warn(
+                    "Tax rate not available from manufacturer config; "
+                    "falling back to default 25% rate. Set config.tax_rate explicitly.",
+                    stacklevel=2,
+                )
+                tax_rate = Decimal("0.25")
             # Calculate tax provision on positive income only
             tax_provision = max(ZERO, to_decimal(pretax_income) * tax_rate)
 

--- a/ergodic_insurance/tests/test_decision_engine_edge_cases.py
+++ b/ergodic_insurance/tests/test_decision_engine_edge_cases.py
@@ -594,8 +594,10 @@ class TestBankruptcyAndNegativeEquityScenarios:
             optimization_method="none",
         )
 
-        # Set up for guaranteed negative equity
-        engine.manufacturer.base_operating_margin = -0.1  # Negative margin
+        # Set up for guaranteed negative equity.
+        # With the actual equity ratio (equity/total_assets ≈ 1.0 for a new manufacturer),
+        # the margin must be sufficiently negative to drain equity within 3 years.
+        engine.manufacturer.base_operating_margin = -1.0  # Deeply negative margin
 
         results = engine._run_simulation(decision, n_simulations=5, time_horizon=3)
 

--- a/ergodic_insurance/tests/test_simulation.py
+++ b/ergodic_insurance/tests/test_simulation.py
@@ -101,7 +101,6 @@ class TestSimulationResults:
         assert "roe_sharpe" in stats
         assert "roe_downside_deviation" in stats
         assert "roe_coefficient_variation" in stats
-        assert "roe_1yr_avg" in stats
         assert "roe_3yr_avg" in stats
         assert "roe_5yr_avg" in stats
 


### PR DESCRIPTION
## Summary

Closes #314

Comprehensive audit addressing erroneous calculations, code duplication, and hardcoded financial assumptions across 6 source modules and 2 test files.

### Erroneous Calculations Fixed (A1–A6)
- **A1**: Removed dead ergodic growth line in `business_optimizer.py` (immediately overwritten)
- **A2**: Replaced fabricated `roe_volatility * 0.7` downside deviation with proper calculation from below-mean observations in `decision_engine.py`
- **A3**: Parameterized `calculate_roe_components()` in `simulation.py` to accept `base_operating_margin` and `tax_rate` instead of hardcoding `0.08` and `0.25`
- **A4**: Removed redundant 1-year rolling ROE from `summary_stats()` (window=1 is mathematically identical to mean)
- **A5**: Tax effect in decision metrics now reads `manufacturer.config.tax_rate` with safe fallback
- **A6**: Replaced hardcoded `0.3` equity ratio in 6 locations with `manufacturer.equity / manufacturer.total_assets`

### Duplicated Calculations Consolidated (B1–B8)
- **B1**: `_calculate_cvar()` in decision engine replaced with `RiskMetrics.tvar(0.95)`; `expected_shortfall()` now delegates to `tvar()`
- **B2**: All 5 hardcoded `0.02` risk-free rates replaced with `DEFAULT_RISK_FREE_RATE` constant in `config.py`
- **B3–B5**: Tax rate, base operating margin, and equity ratio now read from manufacturer config
- **B6**: Growth estimation in both engines now uses config objects (`BusinessOptimizerConfig`, `DecisionEngineConfig`)
- **B7–B8**: Extracted `annual_premium` and `coverage_ratio` computations to avoid inline duplication

### Configuration Improvements (C1–C3)
- **C1**: Created `BusinessOptimizerConfig` dataclass with 19 documented calibration parameters
- **C2**: Created `DecisionEngineConfig` dataclass for engine heuristic parameters
- **C3**: Added `warnings.warn()` when financial_statements falls back to hardcoded 25% tax rate

## Changes Made

| File | Changes |
|------|---------|
| `config.py` | +91 lines: `DEFAULT_RISK_FREE_RATE`, `BusinessOptimizerConfig`, `DecisionEngineConfig` |
| `business_optimizer.py` | 16 hardcoded values → config references, dead code removed, duplicate calcs extracted |
| `decision_engine.py` | CVaR → RiskMetrics.tvar, equity ratio from manufacturer, tax/margin from config |
| `simulation.py` | ROE components parameterized, 1yr rolling removed, risk-free rate centralized |
| `risk_metrics.py` | expected_shortfall delegates to tvar, risk-free rate centralized (3 locations) |
| `financial_statements.py` | Tax rate fallback now emits warning |
| `tests/test_simulation.py` | Removed `roe_1yr_avg` assertion |
| `tests/test_decision_engine_edge_cases.py` | Updated bankruptcy test to use correct equity ratio |

## Test Plan

- [x] All 208 affected tests pass (7 test suites run)
- [x] `test_risk_metrics.py` — 42 pass
- [x] `test_decision_engine.py` — 33 pass
- [x] `test_decision_engine_edge_cases.py` — 34 pass (updated bankruptcy threshold)
- [x] `test_business_optimizer.py` — 31 pass
- [x] `test_simulation.py` — 16 pass (removed roe_1yr_avg assertion)
- [x] `test_financial_statements.py` — 40 pass
- [x] `test_roe_insurance.py` — 13 pass
- [x] All pre-commit hooks pass (black, isort, mypy, pylint)