### PR TITLE
fix: Replace non-deterministic hash() and insecure pickle with safe alternatives (#312)

### DIFF
--- a/ergodic_insurance/batch_processor.py
+++ b/ergodic_insurance/batch_processor.py
@@ -24,6 +24,7 @@ from .loss_distributions import ManufacturingLossGenerator
 from .manufacturer import WidgetManufacturer
 from .monte_carlo import MonteCarloEngine, SimulationConfig, SimulationResults
 from .parallel_executor import ParallelExecutor
+from .safe_pickle import safe_dump, safe_load
 from .scenario_manager import ScenarioConfig, ScenarioManager
 
 
@@ -626,7 +627,7 @@ class BatchProcessor:
 
         checkpoint_path = self.checkpoint_dir / f"checkpoint_{datetime.now():%Y%m%d_%H%M%S}.pkl"
         with open(checkpoint_path, "wb") as f:
-            pickle.dump(checkpoint, f)
+            safe_dump(checkpoint, f)
 
         # Keep only the latest checkpoint
         checkpoints = sorted(self.checkpoint_dir.glob("checkpoint_*.pkl"))
@@ -648,7 +649,7 @@ class BatchProcessor:
         print(f"Loading checkpoint from {latest_checkpoint}")
 
         with open(latest_checkpoint, "rb") as f:
-            checkpoint: CheckpointData = pickle.load(f)
+            checkpoint: CheckpointData = safe_load(f)
 
         self.completed_scenarios = checkpoint.completed_scenarios
         self.failed_scenarios = checkpoint.failed_scenarios

--- a/ergodic_insurance/config_manager.py
+++ b/ergodic_insurance/config_manager.py
@@ -39,6 +39,8 @@ Note:
 """
 
 from functools import lru_cache
+import hashlib
+import json
 import logging
 import os
 from pathlib import Path
@@ -201,7 +203,7 @@ class ConfigManager:
                 return tuple(make_hashable(item) for item in obj)
             return obj
 
-        cache_key = f"{profile_name}_{hash(make_hashable(overrides))}"
+        cache_key = f"{profile_name}_{hashlib.sha256(json.dumps(overrides, sort_keys=True, default=str).encode()).hexdigest()[:16]}"
         if use_cache and cache_key in self._cache:
             return self._cache[cache_key]
 

--- a/ergodic_insurance/parallel_executor.py
+++ b/ergodic_insurance/parallel_executor.py
@@ -39,6 +39,7 @@ import platform
 import sys
 import time
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+import uuid
 import warnings
 
 import numpy as np
@@ -188,7 +189,7 @@ class SharedMemoryManager:
 
         # Create shared memory
         shm = shared_memory.SharedMemory(
-            create=True, size=array.nbytes, name=f"ergodic_array_{name}_{id(self)}"
+            create=True, size=array.nbytes, name=f"ergodic_array_{name}_{uuid.uuid4().hex[:12]}"
         )
 
         # Copy array to shared memory
@@ -238,7 +239,7 @@ class SharedMemoryManager:
 
         # Create shared memory
         shm = shared_memory.SharedMemory(
-            create=True, size=len(serialized), name=f"ergodic_obj_{name}_{id(self)}"
+            create=True, size=len(serialized), name=f"ergodic_obj_{name}_{uuid.uuid4().hex[:12]}"
         )
 
         # Copy to shared memory

--- a/ergodic_insurance/reporting/cache_manager.py
+++ b/ergodic_insurance/reporting/cache_manager.py
@@ -44,6 +44,8 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 
+from ..safe_pickle import safe_dump, safe_load
+
 
 class StorageBackend(Enum):
     """Supported storage backend types."""
@@ -215,7 +217,7 @@ class LocalStorageBackend(BaseStorageBackend):
 
         if file_format == "pickle":
             with open(full_path, "wb") as f:
-                pickle.dump(data, f)
+                safe_dump(data, f)
         elif file_format == "json":
             with open(full_path, "w") as f:
                 json.dump(data, f)
@@ -235,7 +237,7 @@ class LocalStorageBackend(BaseStorageBackend):
 
         if file_format == "pickle":
             with open(full_path, "rb") as f:
-                return pickle.load(f)
+                return safe_load(f)
         elif file_format == "json":
             with open(full_path, "r") as f:
                 return json.load(f)
@@ -708,7 +710,7 @@ class CacheManager:
         # Save figure
         if file_format == "pickle":
             with open(full_path, "wb") as f:
-                pickle.dump(figure, f)
+                safe_dump(figure, f)
         elif file_format == "json":
             # For Plotly figures
             import plotly.io as pio
@@ -923,7 +925,7 @@ class CacheManager:
         try:
             if key.startswith("fig_"):
                 with open(file_path, "rb") as f:
-                    pickle.load(f)
+                    safe_load(f)
             elif "_" in key and not key.startswith("fig_"):
                 pd.read_parquet(file_path)
             else:

--- a/ergodic_insurance/sensitivity.py
+++ b/ergodic_insurance/sensitivity.py
@@ -44,6 +44,8 @@ import numpy as np
 import pandas as pd
 from scipy import stats
 
+from .safe_pickle import safe_dump, safe_load
+
 
 @dataclass
 class SensitivityResult:
@@ -248,7 +250,7 @@ class SensitivityAnalyzer:
             if cache_file.exists():
                 try:
                     with open(cache_file, "rb") as f:
-                        result = pickle.load(f)
+                        result = safe_load(f)
                         self.results_cache[cache_key] = result
                         return result
                 except Exception:  # pylint: disable=broad-exception-caught
@@ -272,7 +274,7 @@ class SensitivityAnalyzer:
             cache_file = self.cache_dir / f"{cache_key}.pkl"
             try:
                 with open(cache_file, "wb") as f:
-                    pickle.dump(result, f)
+                    safe_dump(result, f)
             except Exception:  # pylint: disable=broad-exception-caught
                 # If caching fails, continue without it
                 pass

--- a/ergodic_insurance/strategy_backtester.py
+++ b/ergodic_insurance/strategy_backtester.py
@@ -25,6 +25,7 @@ Example:
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+import hashlib
 import logging
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -628,7 +629,7 @@ class StrategyBacktester:
             BacktestResult with performance metrics.
         """
         # Check cache
-        cache_key = f"{strategy.name}_{hash(str(config))}"
+        cache_key = f"{strategy.name}_{hashlib.sha256(str(config).encode()).hexdigest()[:16]}"
         if use_cache and cache_key in self.results_cache:
             logger.info(f"Using cached results for {strategy.name}")
             return self.results_cache[cache_key]

--- a/ergodic_insurance/tests/test_batch_processor.py
+++ b/ergodic_insurance/tests/test_batch_processor.py
@@ -24,6 +24,7 @@ from ergodic_insurance.insurance_program import InsuranceProgram
 from ergodic_insurance.loss_distributions import ManufacturingLossGenerator
 from ergodic_insurance.manufacturer import WidgetManufacturer
 from ergodic_insurance.monte_carlo import SimulationConfig, SimulationResults
+from ergodic_insurance.safe_pickle import safe_dump, safe_load
 from ergodic_insurance.scenario_manager import ScenarioConfig
 
 
@@ -554,7 +555,7 @@ class TestBatchProcessor:
 
         # Load and verify checkpoint
         with open(checkpoints[0], "rb") as f:
-            checkpoint = pickle.load(f)
+            checkpoint = safe_load(f)
         assert "id1" in checkpoint.completed_scenarios
         assert "id2" in checkpoint.failed_scenarios
         assert len(checkpoint.batch_results) == 1
@@ -570,7 +571,7 @@ class TestBatchProcessor:
         )
         checkpoint_path = temp_checkpoint_dir / "checkpoint_20240101_120000.pkl"
         with open(checkpoint_path, "wb") as f:
-            pickle.dump(checkpoint, f)
+            safe_dump(checkpoint, f)
 
         # Load checkpoint
         processor = BatchProcessor(checkpoint_dir=temp_checkpoint_dir)

--- a/ergodic_insurance/tests/test_sensitivity.py
+++ b/ergodic_insurance/tests/test_sensitivity.py
@@ -9,6 +9,7 @@ Date: 2025-01-29
 """
 
 from dataclasses import dataclass
+import hashlib
 from pathlib import Path
 import tempfile
 from typing import Any, Dict
@@ -41,7 +42,11 @@ class MockOptimizationResult:
     def __init__(self, config: Dict[str, Any]):
         """Create mock result based on config."""
         # Create deterministic but varying results based on config
-        base_value = sum(hash(str(k)) * v for k, v in config.items() if isinstance(v, (int, float)))
+        base_value = sum(
+            int(hashlib.sha256(str(k).encode()).hexdigest(), 16) % (10**9) * v
+            for k, v in config.items()
+            if isinstance(v, (int, float))
+        )
         base_value = abs(base_value) % 100
 
         self.optimal_strategy = self.Strategy(


### PR DESCRIPTION
## Summary

Closes #312

- Replace Python's non-deterministic `hash()` with `hashlib.sha256` for all persistent and in-memory cache keys across 4 production files
- Replace `id()` with `uuid.uuid4()` for shared memory naming in `parallel_executor.py`
- Add HMAC-signed pickle serialization via new `safe_pickle.py` module, replacing raw `pickle.load()`/`pickle.dump()` in 5 production files to prevent arbitrary code execution from tampered cache files
- Update test files to use safe pickle functions where tests directly create/read pickle files

## Changes Made

### New file
- **`ergodic_insurance/safe_pickle.py`** — HMAC-signed `safe_dump`/`safe_load`/`safe_dumps`/`safe_loads` functions and `deterministic_hash()` utility

### Non-deterministic `hash()` → `hashlib.sha256` (4 files)
- **`monte_carlo.py`** — `_get_cache_key()` now uses SHA-256 for insurance program and manufacturer hashing
- **`config_manager.py`** — Profile cache key uses `json.dumps(sort_keys=True)` + SHA-256
- **`strategy_backtester.py`** — Backtest results cache key uses SHA-256
- **`tests/test_sensitivity.py`** — Mock data generation uses SHA-256 for deterministic test values

### Non-deterministic `id()` → `uuid.uuid4()` (1 file)
- **`parallel_executor.py`** — Shared memory names use UUID instead of memory address

### Insecure `pickle` → HMAC-validated `safe_pickle` (5 files)
- **`monte_carlo.py`** — `_save_cache()` / `_load_cache()`
- **`batch_processor.py`** — `_save_checkpoint()` / `_load_checkpoint()`
- **`sensitivity.py`** — `_get_cached_result()` / `_cache_result()`
- **`reporting/cache_manager.py`** — `LocalStorageBackend.save()`/`.load()`, `cache_figure()`, `_validate_file()`
- **`tests/test_batch_processor.py`** — Updated to match new HMAC format

### Deliberately unchanged
- **`parallel_executor.py` pickle usage** — IPC via shared memory is ephemeral and doesn't have file-based security concerns
- **`test_deep_copy.py`** — Tests object serializability, not file persistence
- **`test_parallel_executor.py`** — Tests shared memory serialization, not file persistence

## Testing

- [x] `test_batch_processor.py` — 31 passed
- [x] `test_sensitivity.py` — 27 passed
- [x] `test_config_manager.py` — 32 passed
- [x] `test_parallel_executor.py` — 19 passed, 6 skipped
- [x] `test_cache_manager.py` — 54 passed
- [x] `test_walk_forward.py` — 24 passed
- [x] `test_deep_copy.py` — 25 passed
- [x] `test_monte_carlo.py` — 22 passed, 8 skipped
- [x] All pre-commit hooks pass (black, isort, mypy, pylint)