### PR TITLE
fix: Use per-mille quantile keys to prevent sub-percentile collisions

### DIFF
--- a/ergodic_insurance/accuracy_validator.py
+++ b/ergodic_insurance/accuracy_validator.py
@@ -36,6 +36,8 @@ import numpy as np
 from scipy import stats
 from scipy.stats import kstwobign
 
+from ergodic_insurance.summary_statistics import format_quantile_key
+
 
 @dataclass
 class ValidationResult:
@@ -275,7 +277,7 @@ class StatisticalValidation:
         q1 = np.percentile(data1, [q * 100 for q in quantiles])
         q2 = np.percentile(data2, [q * 100 for q in quantiles])
         results["quantile_errors"] = {
-            f"q{int(q*100)}": abs(q1[i] - q2[i]) for i, q in enumerate(quantiles)
+            format_quantile_key(q): abs(q1[i] - q2[i]) for i, q in enumerate(quantiles)
         }
 
         return results

--- a/ergodic_insurance/tests/test_accuracy_validator.py
+++ b/ergodic_insurance/tests/test_accuracy_validator.py
@@ -260,10 +260,10 @@ class TestStatisticalValidation:
         data2 = np.random.normal(0, 2, 1000)
         results = val.compare_distributions(data1, data2)
         assert "quantile_errors" in results
-        assert "q1" in results["quantile_errors"]
-        assert "q99" in results["quantile_errors"]
+        assert "q0010" in results["quantile_errors"]
+        assert "q0990" in results["quantile_errors"]
         # Higher quantiles should have larger errors due to different std
-        assert results["quantile_errors"]["q99"] > results["quantile_errors"]["q50"]
+        assert results["quantile_errors"]["q0990"] > results["quantile_errors"]["q0500"]
 
     def test_validate_statistical_properties_valid(self):
         """Test statistical property validation with valid data."""


### PR DESCRIPTION
## Summary

Closes #334

- Extract shared `format_quantile_key()` helper using per-mille resolution (`round(q * 1000)`) to eliminate silent key collisions for sub-percentile quantiles
- Fix `TDigest.quantiles()`, `QuantileCalculator.calculate()`, and `accuracy_validator.compare_distributions()` — all three locations that used the broken `int(q * 100)` formatting
- Key format changes from 3-digit percentage (`q025`) to 4-digit per-mille (`q0250`), resolving collisions like `q=0.001` vs `q=0.005` (both mapped to `q000`) and `q=0.99` vs `q=0.995` (both mapped to `q099`)

## Changes

| File | Change |
|------|--------|
| `summary_statistics.py` | Add `format_quantile_key()` helper; update `TDigest.quantiles()` and `QuantileCalculator.calculate()` |
| `accuracy_validator.py` | Import and use `format_quantile_key()` in `compare_distributions()` |
| `tests/test_result_aggregation.py` | Update key assertions to 4-digit format; add `TestFormatQuantileKey` class; add `test_quantiles_no_subpercentile_collision` |
| `tests/test_accuracy_validator.py` | Update key assertions to 4-digit format |

## Testing

- All 58 tests in `test_result_aggregation.py` pass
- All 46 tests in `test_accuracy_validator.py` pass
- New tests explicitly verify that previously-colliding quantile pairs (0.001/0.005, 0.99/0.995) produce distinct keys
- All pre-commit hooks pass (black, isort, mypy, pylint)

## Breaking change note

Dictionary keys returned by `TDigest.quantiles()` and `QuantileCalculator.calculate()` change from 3-digit percentage format (`q025`) to 4-digit per-mille format (`q0250`). Any downstream code that hardcodes these keys will need updating.