### PR TITLE
fix: Remove unreachable code and rename misleading parameter in summary_statistics

### DIFF
--- a/ergodic_insurance/tests/test_result_aggregation.py
+++ b/ergodic_insurance/tests/test_result_aggregation.py
@@ -577,7 +577,7 @@ class TestQuantileCalculator:
         exact = calculator.calculate(data)
 
         # Calculate streaming approximation (t-digest)
-        approx = calculator.streaming_quantiles(data, buffer_size=1000)
+        approx = calculator.streaming_quantiles(data, compression=200)
 
         # t-digest should achieve much tighter accuracy than reservoir sampling
         for key in exact:  # pylint: disable=consider-using-dict-items


### PR DESCRIPTION
## Summary

Closes #338

Two code quality improvements in `ergodic_insurance/summary_statistics.py`:

1. **Removed unreachable code** in `_calculate_basic_stats`: The weighted statistics branch contained a second `if len(data) == 0:` check (previously lines 206-219) that could never execute because the same condition already returns at line 171.

2. **Renamed `buffer_size` to `compression`** in `QuantileCalculator.streaming_quantiles()`: The old parameter name was misleading — it didn't control a buffer size but was mapped to the TDigest compression parameter via `min(buffer_size / 5, 500)`. The new `compression` parameter is passed directly to `TDigest`, matching the well-documented compression semantics (accuracy vs memory tradeoff, typical range 100-300).

## Changes Made

- `ergodic_insurance/summary_statistics.py`: Removed 16 lines of unreachable code; renamed parameter and simplified the mapping logic
- `ergodic_insurance/tests/test_result_aggregation.py`: Updated test call from `buffer_size=1000` to `compression=200` (equivalent behavior since old code did `1000/5=200`)

## Testing

- All 58 tests in `test_result_aggregation.py` pass (includes `TestQuantileCalculator::test_streaming_quantiles` and 14 `TestTDigest` tests)
- All pre-commit hooks pass (black, isort, mypy, pylint)