### PR TITLE
fix: correct sign error in augmented Lagrangian slack threshold

### DIFF
--- a/ergodic_insurance/optimization.py
+++ b/ergodic_insurance/optimization.py
@@ -469,9 +469,10 @@ class AugmentedLagrangianOptimizer:
             if constr["type"] == "ineq":
                 # Inequality constraint g(x) >= 0
                 g = constr["fun"](x)
-                # Augmented term: -lambda*g + (rho/2)*max(0, -g - lambda/rho)^2
-                slack = max(0, -g - lambdas[ineq_idx] / rho)
-                L += -lambdas[ineq_idx] * g + (rho / 2) * slack**2
+                # Standard augmented Lagrangian (Bertsekas, 1999, Section 4.2):
+                # L_A += (rho/2) * max(0, lambda/rho - g)^2 - lambda^2/(2*rho)
+                slack = max(0, lambdas[ineq_idx] / rho - g)
+                L += (rho / 2) * slack**2 - lambdas[ineq_idx] ** 2 / (2 * rho)
                 ineq_idx += 1
             else:
                 # Equality constraint h(x) = 0


### PR DESCRIPTION
## Summary

- Fixes the sign error in the augmented Lagrangian inequality constraint penalty (slack threshold used `-lambda/rho` instead of `+lambda/rho`)
- Replaces the non-standard split formulation with the standard Bertsekas (1999) single-formula approach: `L_A += (rho/2) * max(0, lambda/rho - g)^2 - lambda^2/(2*rho)`
- Adds 3 tests covering all acceptance criteria from the issue

Closes #381

## What was wrong

The slack variable was computed as `max(0, -g - lambda/rho)`, which activates the penalty when `g < -lambda/rho`. Since `lambda >= 0`, this threshold is always more lenient than correct, causing the optimizer to tolerate constraint violations it shouldn't.

## What changed

**`ergodic_insurance/optimization.py`** (lines 469-475): Replaced the inequality block in `_augmented_lagrangian` with the standard formulation from Bertsekas (1999, Section 4.2).

**`ergodic_insurance/tests/test_optimization.py`**: Added 3 new tests:
1. Penalty term is nonzero when constraint is violated (exact value verified)
2. Optimizer converges to constrained optimum for `min x^2 s.t. x >= 1` → `x=1`
3. Multiplier converges to correct KKT dual value (`lambda* = 2`)

## Test plan

- [x] All 6 `TestAugmentedLagrangianOptimizer` tests pass (3 existing + 3 new)
- [x] All 49 optimization tests pass
- [x] All 45 decision engine tests pass (downstream consumers)
- [x] All pre-commit hooks pass (black, isort, mypy, pylint)