### PR TITLE
fix: stop retained earnings from inflating operating cash flow (#370)

### DIFF
--- a/ergodic_insurance/ledger.py
+++ b/ergodic_insurance/ledger.py
@@ -198,6 +198,7 @@ class TransactionType(Enum):
     REVALUATION = "revaluation"  # Asset value adjustments
     LIQUIDATION = "liquidation"  # Bankruptcy/emergency liquidation
     TRANSFER = "transfer"  # Internal asset transfers (e.g., cash to restricted)
+    RETAINED_EARNINGS = "retained_earnings"  # Internal equity allocation
 
 
 @dataclass

--- a/ergodic_insurance/manufacturer_balance_sheet.py
+++ b/ergodic_insurance/manufacturer_balance_sheet.py
@@ -858,7 +858,7 @@ class BalanceSheetMixin:
                     debit_account=AccountName.CASH,
                     credit_account=AccountName.RETAINED_EARNINGS,
                     amount=total_retained,
-                    transaction_type=TransactionType.REVENUE,
+                    transaction_type=TransactionType.RETAINED_EARNINGS,
                     description=f"Year {self.current_year} retained earnings",
                     month=self.current_month,
                 )


### PR DESCRIPTION
## Summary
- Retained earnings were recorded with `TransactionType.REVENUE`, causing `get_cash_flows()` to double-count them as `cash_from_customers` in the direct-method cash flow statement
- Added a dedicated `RETAINED_EARNINGS` transaction type in the non-cash section of `TransactionType`, so the equity allocation is excluded from all cash flow line items
- Changed `manufacturer_balance_sheet.py:861` from `TransactionType.REVENUE` to `TransactionType.RETAINED_EARNINGS`

Closes #370

## Test plan
- [x] 3 new regression tests in `TestRetainedEarningsCashFlowClassification`
  - Verifies entries use `RETAINED_EARNINGS` type, not `REVENUE`
  - Verifies `cash_from_customers` is 0 when only retained earnings are recorded
  - Verifies all cash flow line items are 0 when only retained earnings are recorded
- [x] All 21 tests in `test_dividend_phantom_payments.py` pass
- [x] All 67 tests in `test_ledger.py` pass
- [x] All 15 tests in `test_cash_flow_statement.py` pass
- [x] All 95 tests in `test_manufacturer.py` + `test_manufacturer_methods.py` pass