### PR TITLE
feat: Config() with no args and Config.from_company() factory (#369)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,23 +148,19 @@ pre-commit install
 
 ```python
 # test_installation.py
+from ergodic_insurance.config import Config
 from ergodic_insurance.manufacturer import WidgetManufacturer
-from ergodic_insurance.loss_distributions import ManufacturingLossGenerator
-from ergodic_insurance.config import ManufacturerConfig
 
 print("Framework imported successfully!")
 
-# Create configuration
-config = ManufacturerConfig(
-    initial_assets=10_000_000,
-    asset_turnover_ratio=1.0,
-    base_operating_margin=0.08,
-    tax_rate=0.25,
-    retention_ratio=0.7
-)
+# Create a default configuration — $10M manufacturer, sensible defaults
+config = Config()
+
+# Or customize from basic company info:
+# config = Config.from_company(initial_assets=50_000_000, operating_margin=0.12)
 
 # Create a simple manufacturer
-company = WidgetManufacturer(config)
+company = WidgetManufacturer(config.manufacturer)
 
 print(f"Created company with ${company.assets:,.0f} in assets")
 print("Installation successful!")

--- a/ergodic_insurance/__init__.py
+++ b/ergodic_insurance/__init__.py
@@ -15,13 +15,20 @@ Key Features:
     - Comprehensive visualization and reporting
 
 Examples:
-    Basic simulation::
+    Quick start with defaults (creates a $10M manufacturer, 50-year horizon)::
 
-        from ergodic_insurance import Simulation, Config
+        from ergodic_insurance import Config
 
-        config = Config()
-        sim = Simulation(config)
-        results = sim.run(years=50)
+        config = Config()  # All defaults — just works
+
+    From basic company info::
+
+        from ergodic_insurance import Config
+
+        config = Config.from_company(
+            initial_assets=50_000_000,
+            operating_margin=0.12,
+        )
 
     Business optimization::
 

--- a/ergodic_insurance/config.py
+++ b/ergodic_insurance/config.py
@@ -18,32 +18,38 @@ Key Features:
     - Cross-field validation for consistency
 
 Examples:
-    Basic configuration setup::
+    Quick start with defaults::
+
+        from ergodic_insurance.config import Config
+
+        # All defaults — $10M manufacturer, 50-year horizon
+        config = Config()
+
+    From basic company info::
+
+        config = Config.from_company(
+            initial_assets=50_000_000,
+            operating_margin=0.12,
+            industry="manufacturing",
+        )
+
+    Full control::
 
         from ergodic_insurance.config import Config, ManufacturerConfig
 
-        # Create manufacturer config
-        manufacturer = ManufacturerConfig(
-            initial_assets=10_000_000,
-            asset_turnover_ratio=0.8,
-            base_operating_margin=0.08,
-            tax_rate=0.25,
-            retention_ratio=0.7
-        )
-
-        # Create master config
         config = Config(
-            manufacturer=manufacturer,
-            simulation_years=50
+            manufacturer=ManufacturerConfig(
+                initial_assets=10_000_000,
+                asset_turnover_ratio=0.8,
+                base_operating_margin=0.08,
+                tax_rate=0.25,
+                retention_ratio=0.7,
+            )
         )
 
     Loading from file::
 
-        # Load from JSON
-        config = Config.from_json('config.json')
-
-        # Load from environment
-        config = Config.from_env()
+        config = Config.from_yaml(Path('config.yaml'))
 
 Note:
     All monetary values are in nominal dollars unless otherwise specified.
@@ -209,14 +215,19 @@ class ManufacturerConfig(BaseModel):
         Actual operating margins will be lower when insurance costs are included.
     """
 
-    initial_assets: float = Field(gt=0, description="Starting asset value in dollars")
-    asset_turnover_ratio: float = Field(gt=0, le=5, description="Revenue per dollar of assets")
+    initial_assets: float = Field(
+        default=10_000_000, gt=0, description="Starting asset value in dollars"
+    )
+    asset_turnover_ratio: float = Field(
+        default=0.8, gt=0, le=5, description="Revenue per dollar of assets"
+    )
     base_operating_margin: float = Field(
+        default=0.08,
         gt=-1,
         lt=1,
         description="Core operating margin before insurance costs (EBIT before insurance / Revenue)",
     )
-    tax_rate: float = Field(ge=0, le=1, description="Corporate tax rate")
+    tax_rate: float = Field(default=0.25, ge=0, le=1, description="Corporate tax rate")
     nol_carryforward_enabled: bool = Field(
         default=True,
         description="Enable NOL carryforward tracking per IRC §172. "
@@ -230,7 +241,9 @@ class ManufacturerConfig(BaseModel):
         "Set to 0.80 per IRC §172(a)(2) post-TCJA. "
         "Set to 1.0 for pre-2018 NOLs or non-US jurisdictions.",
     )
-    retention_ratio: float = Field(ge=0, le=1, description="Portion of earnings retained")
+    retention_ratio: float = Field(
+        default=0.7, ge=0, le=1, description="Portion of earnings retained"
+    )
     ppe_ratio: Optional[float] = Field(
         default=None,
         ge=0,
@@ -373,7 +386,7 @@ class WorkingCapitalConfig(BaseModel):
     """
 
     percent_of_sales: float = Field(
-        ge=0, le=1, description="Working capital as percentage of sales"
+        default=0.20, ge=0, le=1, description="Working capital as percentage of sales"
     )
 
     @field_validator("percent_of_sales")
@@ -435,7 +448,9 @@ class GrowthConfig(BaseModel):
     type: Literal["deterministic", "stochastic"] = Field(
         default="deterministic", description="Growth model type"
     )
-    annual_growth_rate: float = Field(ge=-0.5, le=1.0, description="Annual growth rate")
+    annual_growth_rate: float = Field(
+        default=0.05, ge=-0.5, le=1.0, description="Annual growth rate"
+    )
     volatility: float = Field(
         ge=0, le=1, default=0.0, description="Growth rate volatility (std dev)"
     )
@@ -491,9 +506,15 @@ class DebtConfig(BaseModel):
         bankruptcy risk during adverse claim events.
     """
 
-    interest_rate: float = Field(ge=0, le=0.5, description="Annual interest rate on debt")
-    max_leverage_ratio: float = Field(ge=0, le=10, description="Maximum debt-to-equity ratio")
-    minimum_cash_balance: float = Field(ge=0, description="Minimum cash balance to maintain")
+    interest_rate: float = Field(
+        default=0.05, ge=0, le=0.5, description="Annual interest rate on debt"
+    )
+    max_leverage_ratio: float = Field(
+        default=2.0, ge=0, le=10, description="Maximum debt-to-equity ratio"
+    )
+    minimum_cash_balance: float = Field(
+        default=500_000, ge=0, description="Minimum cash balance to maintain"
+    )
 
 
 class SimulationConfig(BaseModel):
@@ -549,7 +570,9 @@ class SimulationConfig(BaseModel):
     time_resolution: Literal["annual", "monthly"] = Field(
         default="annual", description="Simulation time step"
     )
-    time_horizon_years: int = Field(gt=0, le=1000, description="Simulation horizon in years")
+    time_horizon_years: int = Field(
+        default=50, gt=0, le=1000, description="Simulation horizon in years"
+    )
     max_horizon_years: int = Field(
         default=1000, ge=100, le=10000, description="Maximum supported horizon"
     )
@@ -634,15 +657,122 @@ class Config(BaseModel):
 
     This is the main configuration class that combines all sub-configurations
     and provides methods for loading, saving, and manipulating configurations.
+
+    All sub-configs have sensible defaults, so ``Config()`` with no arguments
+    creates a valid configuration for a $10M widget manufacturer.
+
+    Examples:
+        Minimal usage::
+
+            config = Config()
+
+        Override specific parameters::
+
+            config = Config(
+                manufacturer=ManufacturerConfig(initial_assets=20_000_000)
+            )
+
+        From basic company info::
+
+            config = Config.from_company(initial_assets=50_000_000, operating_margin=0.12)
     """
 
-    manufacturer: ManufacturerConfig
-    working_capital: WorkingCapitalConfig
-    growth: GrowthConfig
-    debt: DebtConfig
-    simulation: SimulationConfig
-    output: OutputConfig
-    logging: LoggingConfig
+    manufacturer: ManufacturerConfig = Field(default_factory=ManufacturerConfig)
+    working_capital: WorkingCapitalConfig = Field(default_factory=WorkingCapitalConfig)
+    growth: GrowthConfig = Field(default_factory=GrowthConfig)
+    debt: DebtConfig = Field(default_factory=DebtConfig)
+    simulation: SimulationConfig = Field(default_factory=SimulationConfig)
+    output: OutputConfig = Field(default_factory=OutputConfig)
+    logging: LoggingConfig = Field(default_factory=LoggingConfig)
+
+    @classmethod
+    def from_company(
+        cls,
+        initial_assets: float = 10_000_000,
+        operating_margin: float = 0.08,
+        industry: str = "manufacturing",
+        tax_rate: float = 0.25,
+        growth_rate: float = 0.05,
+        time_horizon_years: int = 50,
+        **kwargs,
+    ) -> "Config":
+        """Create a Config from basic company information.
+
+        This factory derives reasonable sub-config defaults from a small number
+        of intuitive business parameters, so actuaries and risk managers can get
+        started quickly without understanding every sub-config class.
+
+        Args:
+            initial_assets: Starting asset value in dollars.
+            operating_margin: Base operating margin (e.g. 0.08 for 8%).
+            industry: Industry type for deriving defaults.
+                Supported values: "manufacturing", "service", "retail".
+            tax_rate: Corporate tax rate.
+            growth_rate: Annual growth rate.
+            time_horizon_years: Simulation horizon in years.
+            **kwargs: Additional overrides passed to sub-configs.
+
+        Returns:
+            Config object with parameters derived from company info.
+
+        Examples:
+            Minimal::
+
+                config = Config.from_company(initial_assets=50_000_000)
+
+            With industry defaults::
+
+                config = Config.from_company(
+                    initial_assets=25_000_000,
+                    operating_margin=0.15,
+                    industry="service",
+                )
+        """
+        # Industry-specific defaults
+        industry_defaults = {
+            "manufacturing": {
+                "asset_turnover_ratio": 0.8,
+                "retention_ratio": 0.7,
+                "percent_of_sales": 0.20,
+                "minimum_cash_balance": initial_assets * 0.05,
+            },
+            "service": {
+                "asset_turnover_ratio": 1.2,
+                "retention_ratio": 0.6,
+                "percent_of_sales": 0.15,
+                "minimum_cash_balance": initial_assets * 0.03,
+            },
+            "retail": {
+                "asset_turnover_ratio": 1.5,
+                "retention_ratio": 0.5,
+                "percent_of_sales": 0.25,
+                "minimum_cash_balance": initial_assets * 0.04,
+            },
+        }
+
+        defaults = industry_defaults.get(industry, industry_defaults["manufacturing"])
+
+        return cls(
+            manufacturer=ManufacturerConfig(
+                initial_assets=initial_assets,
+                asset_turnover_ratio=kwargs.get(
+                    "asset_turnover_ratio", defaults["asset_turnover_ratio"]
+                ),
+                base_operating_margin=operating_margin,
+                tax_rate=tax_rate,
+                retention_ratio=kwargs.get("retention_ratio", defaults["retention_ratio"]),
+            ),
+            working_capital=WorkingCapitalConfig(
+                percent_of_sales=kwargs.get("percent_of_sales", defaults["percent_of_sales"]),
+            ),
+            growth=GrowthConfig(annual_growth_rate=growth_rate),
+            debt=DebtConfig(
+                minimum_cash_balance=kwargs.get(
+                    "minimum_cash_balance", defaults["minimum_cash_balance"]
+                ),
+            ),
+            simulation=SimulationConfig(time_horizon_years=time_horizon_years),
+        )
 
     @classmethod
     def from_yaml(cls, path: Path) -> "Config":

--- a/ergodic_insurance/docs/tutorials/01_getting_started.md
+++ b/ergodic_insurance/docs/tutorials/01_getting_started.md
@@ -62,7 +62,7 @@ Let's run a simple simulation to see the framework in action.
 ### Step 1: Import the Core Components
 
 ```python
-from ergodic_insurance import Config, ManufacturerConfig
+from ergodic_insurance import Config
 from ergodic_insurance.manufacturer import WidgetManufacturer
 from ergodic_insurance.loss_distributions import ManufacturingLossGenerator
 from ergodic_insurance.simulation import Simulation
@@ -70,20 +70,32 @@ from ergodic_insurance.simulation import Simulation
 
 ### Step 2: Configure a Manufacturer
 
-Create a configuration for a widget manufacturing company:
+Create a configuration for a widget manufacturing company. The simplest way is to use the defaults:
 
 ```python
-# Define manufacturer financial parameters
-manufacturer_config = ManufacturerConfig(
+# Option A: Use defaults — $10M manufacturer, 8% margin, 50-year horizon
+config = Config()
+
+# Option B: Customize from basic company info
+config = Config.from_company(
     initial_assets=10_000_000,      # $10M starting assets
-    asset_turnover_ratio=1.0,       # Revenue = 1x assets
-    base_operating_margin=0.08,     # 8% operating margin
-    tax_rate=0.25,                  # 25% corporate tax rate
-    retention_ratio=1.0             # Retain all earnings (no dividends)
+    operating_margin=0.08,          # 8% operating margin
+)
+
+# Option C: Full control over individual parameters
+from ergodic_insurance import ManufacturerConfig
+config = Config(
+    manufacturer=ManufacturerConfig(
+        initial_assets=10_000_000,
+        asset_turnover_ratio=1.0,
+        base_operating_margin=0.08,
+        tax_rate=0.25,
+        retention_ratio=1.0,
+    )
 )
 
 # Create the manufacturer instance
-manufacturer = WidgetManufacturer(manufacturer_config)
+manufacturer = WidgetManufacturer(config.manufacturer)
 
 print(f"Initial Equity: ${manufacturer.equity:,.0f}")
 print(f"Initial Cash: ${manufacturer.cash:,.0f}")

--- a/ergodic_insurance/docs/tutorials/02_basic_simulation.md
+++ b/ergodic_insurance/docs/tutorials/02_basic_simulation.md
@@ -14,27 +14,29 @@ The framework models a manufacturing business with the following financial dynam
 ### Creating a Manufacturer
 
 ```python
-from ergodic_insurance import ManufacturerConfig
+from ergodic_insurance import Config, ManufacturerConfig
 from ergodic_insurance.manufacturer import WidgetManufacturer
 
-# Create configuration with detailed parameters
-config = ManufacturerConfig(
-    initial_assets=10_000_000,      # Starting capital
-    asset_turnover_ratio=1.0,       # Revenue efficiency
-    base_operating_margin=0.08,     # 8% margin before insurance
-    tax_rate=0.25,                  # 25% tax rate
-    retention_ratio=1.0,            # 100% earnings retained
-    ppe_ratio=0.5,                  # 50% in property/plant/equipment
-    insolvency_tolerance=10_000     # Bankruptcy threshold
-)
+# Quick start — use defaults ($10M assets, 8% margin, 50-year horizon)
+config = Config()
+manufacturer = WidgetManufacturer(config.manufacturer)
 
-# Instantiate the manufacturer
-manufacturer = WidgetManufacturer(config)
+# Or customize specific parameters
+config = Config(
+    manufacturer=ManufacturerConfig(
+        initial_assets=10_000_000,
+        asset_turnover_ratio=1.0,
+        base_operating_margin=0.08,
+        retention_ratio=1.0,
+        ppe_ratio=0.5,
+    )
+)
+manufacturer = WidgetManufacturer(config.manufacturer)
 
 # Check initial state
 print(f"Assets: ${manufacturer.assets:,.0f}")
 print(f"Equity: ${manufacturer.equity:,.0f}")
-print(f"Expected Revenue: ${manufacturer.assets * config.asset_turnover_ratio:,.0f}")
+print(f"Expected Revenue: ${manufacturer.assets * config.manufacturer.asset_turnover_ratio:,.0f}")
 ```
 
 ## Running a Year Step-by-Step

--- a/ergodic_insurance/docs/user_guide/quick_start.rst
+++ b/ergodic_insurance/docs/user_guide/quick_start.rst
@@ -143,19 +143,18 @@ Now let's run a basic simulation using Python:
 .. code-block:: python
    :caption: first_simulation.py
 
-   from ergodic_insurance.config import ManufacturerConfig
+   from ergodic_insurance.config import Config
    from ergodic_insurance.manufacturer import WidgetManufacturer
    from ergodic_insurance.insurance_program import InsuranceProgram, EnhancedInsuranceLayer
    from ergodic_insurance.loss_distributions import ManufacturingLossGenerator
    from ergodic_insurance.monte_carlo import MonteCarloEngine, SimulationConfig
 
-   # Create manufacturer with your parameters
-   mfg_config = ManufacturerConfig(
+   # Create a config with defaults — or use Config.from_company() for customization
+   config = Config.from_company(
        initial_assets=10_000_000,
-       asset_turnover_ratio=1.5,        # Revenue = 1.5x assets = $15M
-       base_operating_margin=0.08
+       operating_margin=0.08,
    )
-   manufacturer = WidgetManufacturer(mfg_config)
+   manufacturer = WidgetManufacturer(config.manufacturer)
 
    # Define insurance program
    insurance = InsuranceProgram(


### PR DESCRIPTION
## Summary
- Add sensible defaults to all sub-config classes so `Config()` with no arguments creates a valid $10M widget manufacturer configuration
- Add `Config.from_company()` factory method for quick setup from basic company info (initial_assets, operating_margin, industry)
- Simplify documentation examples across tutorials, user guide, README, and docstrings

Closes #369

## Changes

### Core (`ergodic_insurance/config.py`)
- **ManufacturerConfig**: Add defaults for `initial_assets` ($10M), `asset_turnover_ratio` (0.8), `base_operating_margin` (8%), `tax_rate` (25%), `retention_ratio` (70%)
- **WorkingCapitalConfig**: Add default for `percent_of_sales` (20%)
- **GrowthConfig**: Add default for `annual_growth_rate` (5%)
- **DebtConfig**: Add defaults for `interest_rate` (5%), `max_leverage_ratio` (2.0), `minimum_cash_balance` ($500K)
- **SimulationConfig**: Add default for `time_horizon_years` (50)
- **Config**: Use `default_factory` for all sub-configs; add `from_company()` classmethod with industry-specific defaults (manufacturing, service, retail)

### Tests (`ergodic_insurance/tests/test_config.py`)
- `TestConfigDefaults`: 4 tests — no-args Config, sub-config defaults, partial overrides, backward compatibility
- `TestConfigFromCompany`: 9 tests — minimal, no-args, custom margin, service/retail/unknown industry, kwargs override, time horizon, override chaining

### Documentation
- `__init__.py`: Updated module docstring examples
- `README.md`: Simplified "Verify Installation" section
- `tutorials/01_getting_started.md`: Show Options A/B/C (defaults, from_company, full control)
- `tutorials/02_basic_simulation.md`: Show quick-start with Config()
- `user_guide/quick_start.rst`: Use Config.from_company() in example

## Test plan
- [x] All 42 tests in `test_config.py` pass (including 13 new tests)
- [x] All 123 tests across config-related test files pass (config_v2, config_compat, config_validation, industry_configs, config_loader)
- [x] All 44 tests in additional config files pass (config_manager_coverage, config_v2_integration, monte_carlo_worker_config)
- [x] `Config()` with no args verified in Python REPL
- [x] `Config.from_company(initial_assets=50e6, industry="service")` verified in REPL
- [x] Pre-commit hooks pass (black, isort, mypy, pylint)
- [x] Backward compatibility: existing explicit Config instantiation works unchanged