### PR TITLE
ci: add pip dependency caching to GitHub Actions workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,6 +25,8 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.12'
+        cache: "pip"
+        cache-dependency-paths: pyproject.toml
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: "pip"
+          cache-dependency-paths: pyproject.toml
 
       - name: Install dependencies
         run: |
@@ -44,6 +46,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: "pip"
+          cache-dependency-paths: pyproject.toml
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- Add `cache: "pip"` with `cache-dependency-paths: pyproject.toml` to `actions/setup-python` in **tests.yml** (both `lint` and `test` jobs) and **docs.yml** (`build` job)
- Avoids re-downloading ~200MB+ of pip packages on every CI run
- Expected to save ~60-90 seconds on cache-hit runs

## Test plan
- [ ] Verify CI passes on this PR (first run will be a cache miss)
- [ ] Confirm subsequent runs show `Cache restored` in the setup-python step logs
- [ ] Validate no functional changes to lint, test, or docs build behavior

Closes #413