### PR TITLE
ci: post coverage report as PR comment and job summary

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     needs: lint
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 
@@ -55,9 +58,36 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Run tests
+        id: tests
         working-directory: ergodic_insurance
         run: |
           python -m pytest --override-ini="addopts=-v --cov=ergodic_insurance --cov-config=.coveragerc --cov-report=term-missing --cov-report=markdown:coverage.md --cov-fail-under=80 --strict-markers --tb=short" -n auto
+
+      - name: Build coverage summary
+        if: always()
+        run: |
+          SUMMARY=ergodic_insurance/coverage-summary.md
+          echo "## Coverage Report" > "$SUMMARY"
+          echo "" >> "$SUMMARY"
+          if [ -f ergodic_insurance/coverage.md ]; then
+            cat ergodic_insurance/coverage.md >> "$SUMMARY"
+            echo "" >> "$SUMMARY"
+            if [ '${{ steps.tests.outcome }}' == 'success' ]; then
+              echo "> **Coverage threshold (80%): PASSED**" >> "$SUMMARY"
+            else
+              echo "> **Coverage threshold (80%): FAILED**" >> "$SUMMARY"
+            fi
+          else
+            echo "Coverage report was not generated." >> "$SUMMARY"
+          fi
+          cat "$SUMMARY" >> $GITHUB_STEP_SUMMARY
+
+      - name: Post coverage comment on PR
+        if: always() && github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: coverage-report
+          path: ergodic_insurance/coverage-summary.md
 
       - name: Upload coverage report
         if: always()


### PR DESCRIPTION
## Summary

Closes #420

- Add coverage report to GitHub Actions **job summary** (`$GITHUB_STEP_SUMMARY`) so results are visible in every workflow run
- Post coverage as a **sticky PR comment** via `marocchino/sticky-pull-request-comment@v2` — updated in-place on re-runs, no comment spam
- Include clear **pass/fail indicator** for the 80% coverage threshold
- Add `pull-requests: write` permission (scoped to `test` job only) for comment posting
- Preserve existing artifact upload as fallback

## Acceptance Criteria from #420

- [x] Coverage percentage is visible without downloading artifacts
- [x] Coverage changes are easy to review on PRs
- [x] Coverage threshold (80%) pass/fail is clearly indicated

## Test plan

- [ ] Verify YAML syntax is valid (validated locally via `yaml.safe_load`)
- [ ] Merge and observe that the next PR run posts a coverage comment
- [ ] Verify job summary shows coverage report with pass/fail status
- [ ] Confirm sticky comment updates on re-runs instead of creating duplicates