### PR TITLE
fix: correct trust-region fallback and gradient convergence check in optimization (#351)

### DIFF
--- a/ergodic_insurance/optimization.py
+++ b/ergodic_insurance/optimization.py
@@ -82,6 +82,9 @@ class ConvergenceMonitor:
             if obj_change < self.tolerance:
                 self.converged = True
                 self.convergence_message = f"Objective converged (change: {obj_change:.2e})"
+            elif 0 < gradient_norm < self.tolerance:
+                self.converged = True
+                self.convergence_message = f"Gradient converged (norm: {gradient_norm:.2e})"
         elif 0 < gradient_norm < self.tolerance:
             self.converged = True
             self.convergence_message = f"Gradient converged (norm: {gradient_norm:.2e})"
@@ -217,12 +220,14 @@ class TrustRegionOptimizer:
                     options={"maxiter": max_iter, "ftol": tol},
                 )
             else:
+                # trust-ncg requires a Hessian; fall back to BFGS when absent
+                method = "trust-ncg" if self.hessian_fn else "BFGS"
                 result = minimize(
                     self.objective_fn,
                     x0,
-                    method="trust-ncg" if self.hessian_fn else "trust-exact",
+                    method=method,
                     jac=self.gradient_fn,
-                    hess=self.hessian_fn,
+                    hess=self.hessian_fn if self.hessian_fn else None,
                     options={"maxiter": max_iter, "gtol": tol},
                 )
 


### PR DESCRIPTION
## Summary
- **Fix inverted trust-region method selection**: When `hessian_fn` is `None`, the old code selected `trust-exact` (which requires a Hessian and crashes). Now falls back to `BFGS`.
- **Fix dead gradient convergence check**: After 2+ iterations, the gradient-norm `elif` branch was unreachable because `len(objective_history) >= 2` was always true. Restructured to nest the gradient check inside the objective-change branch.
- **Update tests**: Coverage test now expects successful BFGS optimization instead of a crash; new test validates gradient convergence is detectable after multiple iterations.

Note: Bugs #1 (slack sign) and #2 (operator precedence) from the issue were already fixed in the current codebase with existing tests.

Closes #351

## Test plan
- [x] All 54 optimization tests pass (`test_optimization.py` + `test_optimization_coverage.py`)
- [x] All 55 downstream tests pass (`test_business_optimizer.py` + `test_optimal_control.py`)
- [x] All pre-commit hooks pass (black, isort, mypy, pylint)
- [x] `test_unconstrained_with_gradient_only_falls_back_to_bfgs` validates trust-region fix
- [x] `test_gradient_convergence_after_multiple_iterations` validates convergence fix