### PR TITLE
fix: correct multiple mathematical errors in HJB solver

### DIFF
--- a/ergodic_insurance/optimal_control.py
+++ b/ergodic_insurance/optimal_control.py
@@ -819,19 +819,19 @@ def create_hjb_controller(  # pylint: disable=too-many-locals
         UtilityFunction,
     )
 
-    # Define state space (simplified 2D for demonstration)
+    # Define state space (2D: wealth × time)
     state_variables = [
-        StateVariable(name="wealth", min_value=1e6, max_value=1e8, num_points=10, log_scale=True),
+        StateVariable(name="wealth", min_value=1e6, max_value=1e8, num_points=30, log_scale=True),
         StateVariable(
-            name="time", min_value=0, max_value=simulation_years, num_points=5, log_scale=False
+            name="time", min_value=0, max_value=simulation_years, num_points=15, log_scale=False
         ),
     ]
     state_space = StateSpace(state_variables)
 
-    # Define control variables (single layer for simplicity)
+    # Define control variables (single layer)
     control_variables = [
-        ControlVariable(name="limit", min_value=1e6, max_value=5e7, num_points=5),
-        ControlVariable(name="retention", min_value=1e5, max_value=1e7, num_points=5),
+        ControlVariable(name="limit", min_value=1e6, max_value=5e7, num_points=10),
+        ControlVariable(name="retention", min_value=1e5, max_value=1e7, num_points=10),
     ]
 
     # Select utility function
@@ -900,7 +900,7 @@ def create_hjb_controller(  # pylint: disable=too-many-locals
     )
 
     # Solve HJB equation
-    config = HJBSolverConfig(time_step=0.1, max_iterations=10, tolerance=1e-3, verbose=False)
+    config = HJBSolverConfig(time_step=0.05, max_iterations=50, tolerance=1e-4, verbose=False)
 
     solver = HJBSolver(problem, config)
     logger.info("Solving HJB equation...")


### PR DESCRIPTION
## Summary

Fixes all 7 mathematical/algorithmic errors in the HJB solver identified in #300, making it produce correct optimal control policies for multi-dimensional problems.

### Changes

- **Grid spacing** (`_setup_operators`): Store full `np.diff(grid)` arrays instead of scalar `grid[1]-grid[0]`, enabling correct finite differences on non-uniform (e.g., log-scale) grids
- **Upwind scheme** (`_apply_upwind_scheme`): Remove `if dim == 0` guard so the scheme applies to all state dimensions; replace `np.roll` with boundary-aware slicing to eliminate wraparound artifacts
- **Value function gradient** (new `_compute_gradient`): Compute ∇V using `np.gradient` which handles non-uniform grids with 2nd-order central differences
- **Policy improvement** (`_policy_improvement`): Include `drift·∇V` in the Hamiltonian; vectorize over the full state grid to eliminate per-point combinatorial explosion
- **Infinite-horizon evaluation** (`_policy_evaluation`): Add drift/advection term that was previously omitted entirely
- **Multi-D drift** (`_apply_upwind_drift`): Delegate to `_apply_upwind_scheme` to fix 1D-only slicing
- **Grid resolution** (`create_hjb_controller`): Increase from 10×5 state / 5×5 control to 30×15 / 10×10 for meaningful results

### Files changed
- `ergodic_insurance/hjb_solver.py` — all core fixes
- `ergodic_insurance/optimal_control.py` — grid resolution increase
- `ergodic_insurance/tests/test_hjb_numerical.py` — updated assertions for corrected boundary behavior

## Test plan
- [x] All 21 `test_hjb_solver.py` tests pass
- [x] All 25 `test_hjb_numerical.py` tests pass (including the updated upwind and grid spacing assertions)
- [x] All 24 `test_optimal_control.py` tests pass (including slow `create_hjb_controller` tests)
- [x] All pre-commit hooks pass (black, isort, mypy, pylint)

Closes #300