### PR TITLE
fix: skip unparseable commits in changelog templates

### DIFF
--- a/templates/.release_notes.md.j2
+++ b/templates/.release_notes.md.j2
@@ -10,7 +10,7 @@
 {%- elif type in ["perf", "refactor", "docs", "style", "ci", "build", "chore", "test"] %}
 {%- set ns.changed = ns.changed + commits %}
 {%- else %}
-{%- set ns.changed = ns.changed + commits %}
+{# Skip non-conventional commits that cannot be parsed #}
 {%- endif %}
 {%- endfor %}
 {%- if ns.added %}

--- a/templates/CHANGELOG.md.j2
+++ b/templates/CHANGELOG.md.j2
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 {%- elif type in ["perf", "refactor", "docs", "style", "ci", "build", "chore", "test"] %}
 {%- set ns.changed = ns.changed + commits %}
 {%- else %}
-{%- set ns.changed = ns.changed + commits %}
+{# Skip non-conventional commits that cannot be parsed #}
 {%- endif %}
 {%- endfor %}
 {%- if ns.added %}
@@ -84,7 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 {%- elif type in ["perf", "refactor", "docs", "style", "ci", "build", "chore", "test"] %}
 {%- set ns.changed = ns.changed + commits %}
 {%- else %}
-{%- set ns.changed = ns.changed + commits %}
+{# Skip non-conventional commits that cannot be parsed #}
 {%- endif %}
 {%- endfor %}
 {%- if ns.added %}


### PR DESCRIPTION
## Summary
- Non-conventional commit messages (e.g. `Release: develop to main...`) produce `ParseError` objects in python-semantic-release that lack the `.descriptions` attribute
- The changelog templates' `else` clause was adding these to `ns.changed`, crashing template rendering with: `'ParseError object' has no attribute 'descriptions'`
- Changed the `else` clause to skip unparseable commits instead — all valid conventional commit types are already handled by preceding conditions

Fixes the release failure in [run #21776942240](https://github.com/AlexFiliakov/Ergodic-Insurance-Limits/actions/runs/21776942240/job/62834927229).

## Test plan
- [ ] Merge to `develop`, then merge `develop` → `main` with title `fix: skip unparseable commits in changelog templates`
- [ ] Verify semantic-release succeeds and produces v0.5.0