### PR TITLE
fix: add missing diffusion term (½σ²∇²V) to HJB solver (#447)

### DIFF
--- a/ergodic_insurance/hjb_solver.py
+++ b/ergodic_insurance/hjb_solver.py
@@ -341,6 +341,9 @@ class HJBProblem:
     terminal_value: Optional[Callable[[np.ndarray], np.ndarray]] = None
     discount_rate: float = 0.0
     time_horizon: Optional[float] = None
+    diffusion: Optional[Callable[[np.ndarray, np.ndarray, float], np.ndarray]] = None
+    """Optional callback returning σ²(x,u,t) with same shape as dynamics output.
+    When provided, the solver includes the ½σ²·∇²V diffusion term."""
 
     def __post_init__(self):
         """Validate problem specification."""
@@ -534,6 +537,43 @@ class HJBSolver:
 
         return np.stack(grad_components, axis=-1)
 
+    def _compute_second_derivatives(self, value: np.ndarray) -> np.ndarray:
+        """Compute second derivatives d²V/dx_i² for each dimension.
+
+        Uses central finite differences for interior points. Boundary
+        values default to zero (no diffusion contribution at boundaries).
+
+        Args:
+            value: Value function on state grid
+
+        Returns:
+            Array with shape state_shape + (ndim,) containing d²V/dx_i²
+        """
+        ndim = self.problem.state_space.ndim
+        components = []
+
+        for dim in range(ndim):
+            dx_array = self.dx[dim]
+            dx = float(np.mean(dx_array))
+
+            d2v = np.zeros_like(value)
+
+            # Interior: (V[i+1] - 2*V[i] + V[i-1]) / dx²
+            hi = [slice(None)] * ndim
+            mid = [slice(None)] * ndim
+            lo = [slice(None)] * ndim
+            hi[dim] = slice(2, None)
+            mid[dim] = slice(1, -1)
+            lo[dim] = slice(None, -2)
+
+            d2v[tuple(mid)] = (value[tuple(hi)] - 2 * value[tuple(mid)] + value[tuple(lo)]) / (
+                dx * dx
+            )
+
+            components.append(d2v)
+
+        return np.stack(components, axis=-1)
+
     def solve(self) -> Tuple[np.ndarray, Dict[str, np.ndarray]]:
         """Solve the HJB equation using policy iteration.
 
@@ -614,7 +654,32 @@ class HJBSolver:
             new_v = new_v + dt * advection
         return new_v
 
-    def _update_value_finite_horizon(self, old_v, cost, drift, dt):
+    def _apply_diffusion_term(
+        self,
+        value: np.ndarray,
+        sigma_sq: np.ndarray,
+    ) -> np.ndarray:
+        """Compute diffusion contribution ½σ²∇²V.
+
+        Args:
+            value: Value function on state grid
+            sigma_sq: Diffusion coefficients σ²(x,u) with shape state_shape + (ndim,)
+
+        Returns:
+            Diffusion term (scalar field, same shape as value)
+        """
+        d2v = self._compute_second_derivatives(value)
+
+        diffusion = np.zeros_like(value)
+        n_dims = min(sigma_sq.shape[-1], d2v.shape[-1])
+        for dim in range(n_dims):
+            if dim >= len(self.problem.state_space.state_variables):
+                continue
+            diffusion += 0.5 * sigma_sq[..., dim] * d2v[..., dim]
+
+        return diffusion
+
+    def _update_value_finite_horizon(self, old_v, cost, drift, dt, sigma_sq=None):
         """Update value function for finite horizon problems."""
         # Backward Euler scheme for parabolic PDE
         new_v = old_v + dt * cost
@@ -624,7 +689,13 @@ class HJBSolver:
             new_v -= dt * self.problem.discount_rate * old_v
 
         # Add drift term using upwind differencing
-        return self._apply_upwind_drift(new_v, drift, dt)
+        new_v = self._apply_upwind_drift(new_v, drift, dt)
+
+        # Add diffusion term: ½σ²∇²V
+        if sigma_sq is not None:
+            new_v += dt * self._apply_diffusion_term(old_v, sigma_sq)
+
+        return new_v
 
     def _policy_evaluation(self):
         """Evaluate current policy by solving linear PDE."""
@@ -656,13 +727,19 @@ class HJBSolver:
             drift = drift.reshape(self.problem.state_space.shape + (-1,))
             cost = self._reshape_cost(cost)
 
+            # Compute diffusion coefficient if specified
+            sigma_sq = None
+            if self.problem.diffusion is not None:
+                sigma_sq_raw = self.problem.diffusion(state_points, control_array, 0.0)
+                sigma_sq = sigma_sq_raw.reshape(self.problem.state_space.shape + (-1,))
+
             # Apply finite differences with upwind scheme
             # For finite horizon problems, integrate backwards from terminal condition
             if self.problem.time_horizon is not None:
-                new_v = self._update_value_finite_horizon(old_v, cost, drift, dt)
+                new_v = self._update_value_finite_horizon(old_v, cost, drift, dt, sigma_sq)
             else:
-                # For infinite horizon: 0 = -ρV + f(x,u) + drift·∇V
-                # Time-step: V_new = V_old + dt * (-ρ*V_old + cost + drift·∇V)
+                # For infinite horizon: 0 = -ρV + f(x,u) + drift·∇V + ½σ²·∇²V
+                # Time-step: V_new = V_old + dt * (-ρ*V_old + cost + drift·∇V + ½σ²·∇²V)
                 advection = np.zeros_like(old_v)
                 for dim in range(drift.shape[-1]):
                     if dim >= len(self.problem.state_space.state_variables):
@@ -670,7 +747,10 @@ class HJBSolver:
                     drift_component = drift[..., dim]
                     advection += self._apply_upwind_scheme(old_v, drift_component, dim)
 
-                new_v = old_v + dt * (-self.problem.discount_rate * old_v + cost + advection)
+                rhs = -self.problem.discount_rate * old_v + cost + advection
+                if sigma_sq is not None:
+                    rhs += self._apply_diffusion_term(old_v, sigma_sq)
+                new_v = old_v + dt * rhs
 
             # Apply boundary conditions (skip for now to preserve terminal condition)
 
@@ -681,7 +761,9 @@ class HJBSolver:
                 break
 
     def _policy_improvement(self):
-        """Improve policy by maximizing Hamiltonian H(x,u) = f(x,u) + drift(x,u)·∇V(x).
+        """Improve policy by maximizing the Hamiltonian.
+
+        H(x,u) = f(x,u) + drift(x,u)·∇V(x) + ½σ²(x,u)·∇²V(x)
 
         Vectorized over all state points for each control combination to avoid
         the combinatorial explosion of evaluating each state-control pair individually.
@@ -700,6 +782,12 @@ class HJBSolver:
         # Initialize tracking arrays
         best_values = np.full(n_states, -np.inf)
         best_controls = np.zeros((n_states, n_controls))
+
+        # Compute second derivatives for diffusion term (independent of control)
+        d2V_flat = None
+        if self.problem.diffusion is not None:
+            d2V = self._compute_second_derivatives(self.value_function)
+            d2V_flat = d2V.reshape(n_states, -1)
 
         # Get discrete control samples for each control variable
         control_samples = [cv.get_values() for cv in self.problem.control_variables]
@@ -730,8 +818,15 @@ class HJBSolver:
             # Match drift and gradient dimensions
             n_dims = min(drift_flat.shape[1], grad_V_flat.shape[1])
 
-            # Full Hamiltonian: H = f(x,u) + drift(x,u) · ∇V(x)
+            # Full Hamiltonian: H = f(x,u) + drift(x,u)·∇V(x) + ½σ²(x,u)·∇²V(x)
             hamiltonian = cost + np.sum(drift_flat[:, :n_dims] * grad_V_flat[:, :n_dims], axis=1)
+
+            # Add diffusion term to Hamiltonian
+            if self.problem.diffusion is not None and d2V_flat is not None:
+                sigma_sq = self.problem.diffusion(state_points, control_broadcast, 0.0)
+                sigma_sq = np.asarray(sigma_sq).reshape(n_states, -1)
+                n_diff = min(sigma_sq.shape[1], d2V_flat.shape[1], n_dims)
+                hamiltonian += 0.5 * np.sum(sigma_sq[:, :n_diff] * d2V_flat[:, :n_diff], axis=1)
 
             # Update best control where this combo improves the Hamiltonian
             improved = hamiltonian > best_values


### PR DESCRIPTION
## Summary

- Incorporates the missing ½σ²·∇²V diffusion term into the HJB PDE solver, fixing the omission where `_build_difference_matrix()` was constructed but never used during solves
- Adds an optional `diffusion` callback to `HJBProblem` returning σ²(x,u,t), with `None` default preserving full backward compatibility
- Updates `create_hjb_controller()` with a realistic loss-volatility model where insurance coverage reduces wealth volatility

Closes #447

## What Changed

**`hjb_solver.py`**
- `HJBProblem.diffusion`: new optional field for the σ²(x,u,t) callback
- `_compute_second_derivatives()`: central finite differences for d²V/dx² with zero-boundary handling
- `_apply_diffusion_term()`: computes ½σ²∇²V by combining per-dimension second derivatives with diffusion coefficients
- `_policy_evaluation()`: integrates diffusion into value function updates for both finite and infinite horizon
- `_policy_improvement()`: includes ½σ²∇²V in the Hamiltonian so control-dependent volatility affects optimal policy selection
- `_update_value_finite_horizon()`: accepts and applies diffusion term

**`optimal_control.py`**
- `create_hjb_controller()`: adds `diffusion_coeff` callback modeling 15% baseline loss volatility reduced by up to 70% with insurance coverage

**`tests/test_hjb_numerical.py`**
- 8 new tests in `TestDiffusionTerm` class covering exact second derivatives on quadratics (1D and 2D), ½σ² computation, σ=0 recovering deterministic behavior, nonzero diffusion changing value functions, 2D state spaces, control-dependent diffusion, and infinite horizon

## Test plan

- [x] All 54 HJB tests pass (33 numerical + 21 solver)
- [x] 8 new diffusion-specific tests all pass
- [x] All pre-commit hooks pass (black, isort, mypy, pylint)
- [x] σ=0 produces identical results to no-diffusion case (backward compatibility verified)
- [ ] Review that diffusion model in `create_hjb_controller` matches business requirements