### PR TITLE
fix: remove time-average growth rate clamp that biased ergodic comparisons (#474)

### DIFF
--- a/ergodic_insurance/ergodic_analyzer.py
+++ b/ergodic_insurance/ergodic_analyzer.py
@@ -677,7 +677,8 @@ class ErgodicAnalyzer:
                 Special return values:
                 - -inf: Trajectory ended in bankruptcy (final value <= 0)
                 - 0.0: Single time point or zero time horizon
-                - Finite value: Calculated growth rate
+                - Finite value: Calculated growth rate (no artificial floor;
+                  near-ruin scenarios may produce values much less than -1.0)
 
         Examples:
             Calculate growth for successful trajectory::
@@ -776,9 +777,7 @@ class ErgodicAnalyzer:
         # Calculate growth rate
         if final_value > 0 and initial_value > 0 and time_horizon > 0:
             growth_rate = float((1.0 / time_horizon) * np.log(final_value / initial_value))
-            # LIMITED LIABILITY: Floor at -100% (-1.0) due to equity constraint
-            # Companies with limited liability cannot lose more than 100% of equity
-            return max(growth_rate, -1.0)
+            return growth_rate
 
         return 0.0 if time_horizon <= 0 else -np.inf
 


### PR DESCRIPTION
## Summary

- Remove `max(growth_rate, -1.0)` floor from `calculate_time_average_growth` that artificially capped log growth rates at -100%, biasing near-bankruptcy trajectories upward and understating the ergodic advantage of insurance
- Update docstring to document that finite growth rates are no longer floored
- Add 7 test cases covering near-bankruptcy scenarios (99%+, 99.9%+, 99.999% equity loss), `compare_scenarios` integration, and mean-of-growth-rates validation

Closes #474

## Impact

The clamp distorted the core quantity in ergodic economics. For example, a company going from $10M to $100 equity in one year has true g = ln(100/10M) = -11.5, but the clamp reported g = -1.0. This made uninsured scenarios look better than they are and reduced the apparent ergodic advantage of insurance.

Bankruptcy (final_value=0) continues to be handled separately as -inf (line 757). The `compare_scenarios` method already filters -inf values via `np.isfinite()`, so very negative finite growth rates flow through correctly to mean/median calculations.

## Test plan

- [x] All 14 existing `test_ergodic_analyzer.py` tests pass
- [x] All 47 `test_ergodic_analyzer_coverage.py` tests pass (40 existing + 7 new)
- [x] 2 ergodic integration tests pass
- [x] New tests verify growth rates below -1.0 are preserved for catastrophic loss scenarios
- [x] New test verifies `compare_scenarios` reports `time_average_mean < -1.0` for uninsured catastrophic losses