### PR TITLE
fix: correct parallel executor partial failure, SharedMemory leaks, and compression sizing (#356)

### DIFF
--- a/ergodic_insurance/tests/test_parallel_executor.py
+++ b/ergodic_insurance/tests/test_parallel_executor.py
@@ -525,16 +525,21 @@ class TestParallelExecutor:
         assert len(results) == 100
 
     def test_error_handling(self):
-        """Test error handling in parallel execution."""
+        """Test error handling in parallel execution returns partial results."""
         executor = ParallelExecutor(n_workers=2)
 
-        with pytest.warns(UserWarning, match="Chunk execution failed"):
-            results = executor.map_reduce(
-                work_function=_test_failing_function, work_items=range(10), progress_bar=False
-            )
+        results = executor.map_reduce(
+            work_function=_test_failing_function, work_items=range(10), progress_bar=False
+        )
 
-        # Should still return partial results
+        # Should return all successful results (item 5 fails, so 9 results)
         assert results is not None
+        assert len(results) == 9
+        assert 5 not in results
+        # All non-failing items should be present
+        for i in range(10):
+            if i != 5:
+                assert i in results
 
     def test_context_manager(self):
         """Test context manager functionality."""


### PR DESCRIPTION
## Summary

Fixes three critical bugs in `parallel_executor.py` reported in #356:

- **Partial chunk failure discards all results**: `_execute_chunk` raised `RuntimeError` on any individual item failure, causing the caller to substitute an empty list and lose all successful results from that chunk. Now returns partial results with `None` for failed items, filtered out during flattening.
- **SharedMemory handle leaks**: `get_array()` opened handles without tracking them; `get_object()` never closed its handle; `_execute_chunk` never cleaned up the worker-side `SharedMemoryManager`. Added `_opened_handles` tracking, immediate close in `get_object`, and `try/finally` cleanup in workers.
- **Double serialization wrong size when compressed**: `_setup_shared_data` re-serialized objects (without compression) to compute size, producing the wrong byte count when compression was enabled. Now stores actual serialized size via `_object_sizes` dict in `share_object` and retrieves it with `get_object_size`.

## Test plan

- [x] `test_parallel_executor.py` - all 25 tests pass (6 skipped on Windows)
- [x] `test_parallel_executor_coverage.py` - all 34 tests pass (6 skipped on Windows)
- [x] `test_coverage_gaps_parallel_executor.py` - all 24 tests pass
- [x] Updated `test_error_handling` to verify 9/10 partial results when item 5 fails
- [x] Updated `test_execute_chunk_reports_errors` → `test_execute_chunk_returns_partial_results`
- [x] Added tests for: handle tracking, cleanup of opened handles, object size tracking, compressed size tracking, worker cleanup on success/failure, get_object closing handles

Closes #356