### PR TITLE
feat: add InsurancePolicy.from_simple() convenience constructor (#485)

### DIFF
--- a/ergodic_insurance/_run_analysis.py
+++ b/ergodic_insurance/_run_analysis.py
@@ -49,7 +49,7 @@ import pandas as pd
 
 from .config import Config, ManufacturerConfig
 from .ergodic_analyzer import ErgodicAnalyzer
-from .insurance import InsuranceLayer, InsurancePolicy
+from .insurance import InsurancePolicy
 from .loss_distributions import ManufacturingLossGenerator
 from .manufacturer import WidgetManufacturer
 from .simulation import Simulation, SimulationResults
@@ -446,12 +446,11 @@ def run_analysis(
     )
 
     # --- Build insurance policy ---
-    layer = InsuranceLayer(
-        attachment_point=deductible,
+    policy = InsurancePolicy.from_simple(
+        deductible=deductible,
         limit=coverage_limit,
-        rate=premium_rate,
+        premium_rate=premium_rate,
     )
-    policy = InsurancePolicy(layers=[layer], deductible=deductible)
 
     # --- Run insured simulations ---
     logger.info(

--- a/ergodic_insurance/docs/tutorials/03_configuring_insurance.md
+++ b/ergodic_insurance/docs/tutorials/03_configuring_insurance.md
@@ -17,24 +17,19 @@ Insurance is structured in **layers** stacked on top of one another, forming a *
 
 ## Creating a Simple Insurance Policy
 
-The `InsurancePolicy` and `InsuranceLayer` classes in `ergodic_insurance.insurance` are the building blocks you will use with the `Simulation` engine. Let us start NovaTech with a straightforward single-layer policy.
+The `InsurancePolicy` class in `ergodic_insurance.insurance` is the building block you will use with the `Simulation` engine. Let us start NovaTech with a straightforward single-layer policy.
 
 ```python
-from ergodic_insurance import InsurancePolicy, InsuranceLayer
+from ergodic_insurance import InsurancePolicy
 
-# NovaTech's first insurance layer:
+# NovaTech's first insurance policy:
 #   - $100K deductible (they retain the first $100K of any loss)
 #   - $5M of coverage above the deductible
 #   - 2.5% premium rate on the limit
-primary_layer = InsuranceLayer(
-    attachment_point=100_000,   # Coverage begins at $100K
-    limit=5_000_000,            # Maximum payout: $5M
-    rate=0.025                  # Annual premium = 2.5% x $5M = $125K
-)
-
-policy = InsurancePolicy(
-    layers=[primary_layer],
-    deductible=100_000          # Self-insured retention
+policy = InsurancePolicy.from_simple(
+    deductible=100_000,            # Self-insured retention
+    limit=5_000_000,               # Maximum payout: $5M
+    premium_rate=0.025             # Annual premium = 2.5% x $5M = $125K
 )
 
 print(f"Annual Premium: ${policy.calculate_premium():,.0f}")
@@ -153,7 +148,7 @@ Now for the central question: does insurance actually improve NovaTech's long-te
 ```python
 from ergodic_insurance import (
     ManufacturerConfig, WidgetManufacturer, ManufacturingLossGenerator,
-    Simulation, InsurancePolicy, InsuranceLayer,
+    Simulation, InsurancePolicy,
 )
 
 # -- NovaTech's financial profile --
@@ -166,12 +161,11 @@ novatech_config = ManufacturerConfig(
 )
 
 # -- Insurance policy: $5M xs $100K --
-layer = InsuranceLayer(
-    attachment_point=100_000,
+policy = InsurancePolicy.from_simple(
+    deductible=100_000,
     limit=5_000_000,
-    rate=0.025
+    premium_rate=0.025
 )
-policy = InsurancePolicy(layers=[layer], deductible=100_000)
 
 # -- Loss profile: moderate frequency, high severity variability --
 loss_gen = ManufacturingLossGenerator.create_simple(
@@ -448,12 +442,11 @@ for load in loadings:
     # Calculate premium rate that produces this loading
     adjusted_rate = (1 + load) * expected_annual_loss / 5_000_000
 
-    test_layer = InsuranceLayer(
-        attachment_point=100_000,
+    test_policy = InsurancePolicy.from_simple(
+        deductible=100_000,
         limit=5_000_000,
-        rate=adjusted_rate
+        premium_rate=adjusted_rate
     )
-    test_policy = InsurancePolicy(layers=[test_layer], deductible=100_000)
 
     test_loss_gen = ManufacturingLossGenerator.create_simple(
         frequency=0.15, severity_mean=1_000_000,

--- a/ergodic_insurance/docs/tutorials/05_analyzing_results.md
+++ b/ergodic_insurance/docs/tutorials/05_analyzing_results.md
@@ -48,7 +48,7 @@ We assume you have your manufacturer and loss generator configured (see Tutorial
 ```python
 from ergodic_insurance import (
     ManufacturerConfig, WidgetManufacturer, ManufacturingLossGenerator,
-    InsurancePolicy, InsuranceLayer, Simulation,
+    InsurancePolicy, Simulation,
 )
 
 # NovaTech's financial profile
@@ -61,9 +61,10 @@ config = ManufacturerConfig(
 )
 
 # NovaTech's proposed insurance program
-policy = InsurancePolicy(
-    layers=[InsuranceLayer(attachment_point=100_000, limit=5_000_000, rate=0.02)],
-    deductible=100_000
+policy = InsurancePolicy.from_simple(
+    deductible=100_000,
+    limit=5_000_000,
+    premium_rate=0.02
 )
 
 # Run paired simulations

--- a/ergodic_insurance/docs/user_guide/quick_start.rst
+++ b/ergodic_insurance/docs/user_guide/quick_start.rst
@@ -135,6 +135,20 @@ Visualizing Your Insurance Tower
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
                               Total Premium: $335K/year
 
+For quick single-layer policies in Python, use the convenience constructor:
+
+.. code-block:: python
+
+   from ergodic_insurance import InsurancePolicy
+
+   policy = InsurancePolicy.from_simple(
+       deductible=100_000,
+       limit=5_000_000,
+       premium_rate=0.015,
+   )
+
+For multi-layer towers and advanced structures, see ``docs/tutorials/03_configuring_insurance.md``.
+
 Step 4: Running Your First Simulation
 --------------------------------------
 


### PR DESCRIPTION
## Summary
- Add `InsurancePolicy.from_simple(deductible, limit, premium_rate)` class method for creating single-layer policies in one step
- Refactor `run_analysis()` to use `from_simple()` internally for clarity
- Update tutorials 03, 05 and quick_start.rst to use `from_simple()` as the recommended entry point for single-layer policies
- Add 11 tests covering equivalence to manual construction, claim processing, edge cases, kwargs forwarding, and validation

Closes #485

## Test plan
- [x] All 45 tests in `test_insurance.py` pass (11 new `TestFromSimple` tests)
- [x] All 25 tests in `test_run_analysis.py` pass (verifies `from_simple()` integration)
- [x] All pre-commit hooks pass (black, isort, mypy, pylint)
- [ ] Review documentation changes render correctly in tutorials 03, 05, and quick_start.rst