### PR TITLE
fix: set claim year_incurred to current_year instead of current_year - 1 (#491)

### DIFF
--- a/ergodic_insurance/manufacturer_claims.py
+++ b/ergodic_insurance/manufacturer_claims.py
@@ -288,13 +288,10 @@ class ClaimProcessingMixin:
                     description="Cash to restricted for insurance claim collateral",
                 )
 
-                year_incurred = (
-                    self.current_year - 1 if self.current_year > 0 else self.current_year
-                )
                 claim_liability = ClaimLiability(
                     original_amount=max_payable,
                     remaining_amount=max_payable,
-                    year_incurred=year_incurred,
+                    year_incurred=self.current_year,
                     is_insured=True,
                 )
                 self.claim_liabilities.append(claim_liability)
@@ -324,13 +321,10 @@ class ClaimProcessingMixin:
                 )
 
                 if max_liability > ZERO:
-                    year_incurred = (
-                        self.current_year - 1 if self.current_year > 0 else self.current_year
-                    )
                     unpayable_claim = ClaimLiability(
                         original_amount=max_liability,
                         remaining_amount=max_liability,
-                        year_incurred=year_incurred,
+                        year_incurred=self.current_year,
                         is_insured=False,
                     )
                     self.claim_liabilities.append(unpayable_claim)
@@ -472,11 +466,10 @@ class ClaimProcessingMixin:
         )
 
         if deferred_max_liability > ZERO:
-            year_incurred = self.current_year - 1 if self.current_year > 0 else self.current_year
             claim_liability = ClaimLiability(
                 original_amount=deferred_max_liability,
                 remaining_amount=deferred_max_liability,
-                year_incurred=year_incurred,
+                year_incurred=self.current_year,
                 is_insured=False,
             )
             self.claim_liabilities.append(claim_liability)
@@ -654,8 +647,6 @@ class ClaimProcessingMixin:
             development_pattern: Optional ClaimDevelopment strategy for payment timing.
         """
         amount = to_decimal(claim_amount)
-        year_incurred = self.current_year - 1 if self.current_year > 0 else self.current_year
-
         if development_pattern is not None:
             if isinstance(development_pattern, list):
                 development_pattern = ClaimDevelopment(
@@ -665,7 +656,7 @@ class ClaimProcessingMixin:
             new_claim = ClaimLiability(
                 original_amount=amount,
                 remaining_amount=amount,
-                year_incurred=year_incurred,
+                year_incurred=self.current_year,
                 is_insured=False,
                 development_strategy=development_pattern,
             )
@@ -673,7 +664,7 @@ class ClaimProcessingMixin:
             new_claim = ClaimLiability(
                 original_amount=amount,
                 remaining_amount=amount,
-                year_incurred=year_incurred,
+                year_incurred=self.current_year,
                 is_insured=False,
             )
         self.claim_liabilities.append(new_claim)


### PR DESCRIPTION
## Summary

- Fix off-by-one error where `year_incurred` was set to `current_year - 1` instead of `current_year` in all 4 claim creation paths in `manufacturer_claims.py`
- This violated ASC 944-40-25 (claims must be recorded in the period the loss event occurs), causing the first scheduled payment to appear one year early and distorting claim development patterns and reserve calculations
- Update integration tests in `TestClaimPaymentTiming` to assert the correct `year_incurred` values

## Test plan

- [x] All 4 occurrences of `year_incurred = current_year - 1` replaced with `self.current_year`
- [x] `test_manufacturer.py` — 66 passed
- [x] `test_manufacturer_methods.py` — 29 passed
- [x] `test_manufacturer_coverage.py` — 32 passed
- [x] `test_critical_integrations.py::TestClaimPaymentTiming` — 3 passed
- [x] `test_deep_copy.py` + `test_coverage_gaps_batch4.py` + `test_accrual_integration.py` — 87 passed
- [x] `test_balance_sheet_classification.py` + `test_recovery_accounting.py` + `test_execution_semantics.py` — 35 passed
- [x] `integration/test_insurance_stack.py` + `integration/test_financial_integration.py` — 19 passed
- [x] All pre-commit hooks pass (black, isort, mypy, pylint, conventional commit)

Closes #491