### PR TITLE
fix: correct Sortino downside deviation to average over all observations (#386)

### DIFF
--- a/ergodic_insurance/decision_engine.py
+++ b/ergodic_insurance/decision_engine.py
@@ -1195,8 +1195,8 @@ class InsuranceDecisionEngine:
                 roe_volatility, 0.001
             )
             roe_data_arr = np.array(with_insurance_results["roe"])
-            below_mean = roe_data_arr[roe_data_arr < np.mean(roe_data_arr)]
-            roe_downside_dev = float(np.std(below_mean)) if len(below_mean) > 0 else 0.0
+            roe_mean = np.mean(roe_data_arr)
+            roe_downside_dev = float(np.sqrt(np.mean(np.minimum(roe_data_arr - roe_mean, 0) ** 2)))
             roe_1yr = np.mean(with_insurance_results["roe"])
             roe_3yr = np.mean(with_insurance_results["roe"])
             roe_5yr = np.mean(with_insurance_results["roe"])

--- a/ergodic_insurance/simulation.py
+++ b/ergodic_insurance/simulation.py
@@ -326,11 +326,9 @@ class SimulationResults:
         mean_roe = np.mean(valid_roe)
         std_roe = np.std(valid_roe, ddof=1)
 
-        # Downside deviation (only negative deviations from mean)
-        negative_deviations = valid_roe[valid_roe < mean_roe] - mean_roe
-        downside_dev = (
-            np.sqrt(np.mean(negative_deviations**2)) if len(negative_deviations) > 0 else 0.0
-        )
+        # Downside deviation (over all observations)
+        downside_deviations = np.minimum(valid_roe - mean_roe, 0)
+        downside_dev = np.sqrt(np.mean(downside_deviations**2))
 
         # Sharpe ratio equivalent for ROE
         risk_free_rate = DEFAULT_RISK_FREE_RATE


### PR DESCRIPTION
## Summary

- Fixes the Sortino ratio downside deviation formula in all 5 locations where it was computed incorrectly
- The denominator was averaging over only below-target observations instead of ALL N observations, which inflated the downside deviation and underestimated the Sortino ratio
- Correct formula per Sortino & Price (1994): `DD = sqrt((1/N) * sum(min(r_i - target, 0)^2))`

### Locations fixed
| File | Method | Issue |
|------|--------|-------|
| `risk_metrics.py` | `RiskMetrics.risk_adjusted_metrics()` | Used `np.std(below_target)` — wrong formula and wrong N |
| `risk_metrics.py` | `ROEAnalyzer.performance_ratios()` | Averaged squared deviations over n_below, not N |
| `risk_metrics.py` | `ROEAnalyzer.volatility_metrics()` | Used `np.std(below_mean)` — wrong formula and wrong N |
| `decision_engine.py` | `DecisionEngine._evaluate_decision()` fallback | Used `np.std(below_mean)` — same issue |
| `simulation.py` | `SimulationResults.calculate_roe_volatility()` | Averaged squared deviations over n_below, not N |

Closes #386

## Test plan

- [x] Hand-calculated acceptance criterion: returns=[10%,12%,-5%,8%,-3%], target=0% → DD=2.61%
- [x] Both Sortino locations (`RiskMetrics` and `ROEAnalyzer`) produce identical results for same input
- [x] Sortino ratio increases when proportion of positive returns increases
- [x] Downside deviation denominator uses all N observations (verified with 9:1 above:below ratio)
- [x] Weighted Sortino formula verified against manual calculation
- [x] All existing tests pass: `test_risk_metrics.py` (42/42), `test_risk_metrics_coverage.py` (39/39), `test_decision_engine.py` (33/33), `test_simulation.py` (15/15)