### PR TITLE
feat: add periodic reserve re-estimation per ASC 944-40-25 (#470)

### DIFF
--- a/ergodic_insurance/config/manufacturer.py
+++ b/ergodic_insurance/config/manufacturer.py
@@ -285,6 +285,22 @@ class ManufacturerConfig(BaseModel):
         "the lowest cash point and triggers insolvency if it goes negative.",
     )
 
+    # Reserve re-estimation configuration (Issue #470, ASC 944-40-25)
+    enable_reserve_development: bool = Field(
+        default=False,
+        description="Enable stochastic reserve re-estimation per ASC 944-40-25. "
+        "When True, claim reserves start as noisy estimates that converge "
+        "toward the true ultimate over the claim's life. Default off.",
+    )
+    reserve_noise_std: float = Field(
+        default=0.20,
+        ge=0.0,
+        le=1.0,
+        description="Std dev of initial reserve estimation noise as fraction of "
+        "true ultimate (typically 0.15-0.40 depending on line of business). "
+        "Noise shrinks proportionally to claim maturity.",
+    )
+
     @model_validator(mode="after")
     def set_default_ppe_ratio(self):
         """Set default PPE ratio based on operating margin if not provided."""

--- a/ergodic_insurance/ledger.py
+++ b/ergodic_insurance/ledger.py
@@ -145,6 +145,7 @@ class AccountName(Enum):
     INTEREST_EXPENSE = "interest_expense"
     COLLATERAL_EXPENSE = "collateral_expense"
     WAGE_EXPENSE = "wage_expense"
+    RESERVE_DEVELOPMENT = "reserve_development"
 
 
 class EntryType(Enum):
@@ -180,6 +181,7 @@ class TransactionType(Enum):
     TAX_ACCRUAL = "tax_accrual"
     TAX_PAYMENT = "tax_payment"
     DTA_ADJUSTMENT = "dta_adjustment"  # Deferred tax asset recognition/reversal
+    RESERVE_DEVELOPMENT = "reserve_development"  # Reserve re-estimation per ASC 944-40-25
     DEPRECIATION = "depreciation"
     WORKING_CAPITAL = "working_capital"
 
@@ -322,6 +324,7 @@ CHART_OF_ACCOUNTS: Dict[AccountName, AccountType] = {
     AccountName.INTEREST_EXPENSE: AccountType.EXPENSE,
     AccountName.COLLATERAL_EXPENSE: AccountType.EXPENSE,
     AccountName.WAGE_EXPENSE: AccountType.EXPENSE,
+    AccountName.RESERVE_DEVELOPMENT: AccountType.EXPENSE,
 }
 
 # String-keyed version for backward compatibility and internal lookups

--- a/ergodic_insurance/manufacturer_claims.py
+++ b/ergodic_insurance/manufacturer_claims.py
@@ -8,7 +8,8 @@ claim processing, payments, recovery, and accrual methods.
 
 from decimal import Decimal
 import logging
-from typing import TYPE_CHECKING, Dict, Optional, Union
+import random
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 try:
     from ergodic_insurance.claim_development import ClaimDevelopment
@@ -114,6 +115,8 @@ class ClaimProcessingMixin:
         """Reset period insurance cost tracking for new period."""
         self.period_insurance_premiums = ZERO
         self.period_insurance_losses = ZERO
+        self.period_adverse_development = ZERO
+        self.period_favorable_development = ZERO
 
     @property
     def total_claim_liabilities(self) -> Decimal:
@@ -294,12 +297,13 @@ class ClaimProcessingMixin:
                     year_incurred=self.current_year,
                     is_insured=True,
                 )
+                self._apply_reserve_noise(claim_liability)
                 self.claim_liabilities.append(claim_liability)
                 self.ledger.record_double_entry(
                     date=self.current_year,
                     debit_account=AccountName.INSURANCE_LOSS,
                     credit_account=AccountName.CLAIM_LIABILITIES,
-                    amount=max_payable,
+                    amount=claim_liability.original_amount,
                     transaction_type=TransactionType.INSURANCE_CLAIM,
                     description="Recognize insured claim liability (company portion)",
                 )
@@ -327,12 +331,13 @@ class ClaimProcessingMixin:
                         year_incurred=self.current_year,
                         is_insured=False,
                     )
+                    self._apply_reserve_noise(unpayable_claim)
                     self.claim_liabilities.append(unpayable_claim)
                     self.ledger.record_double_entry(
                         date=self.current_year,
                         debit_account=AccountName.INSURANCE_LOSS,
                         credit_account=AccountName.CLAIM_LIABILITIES,
-                        amount=max_liability,
+                        amount=unpayable_claim.original_amount,
                         transaction_type=TransactionType.INSURANCE_CLAIM,
                         description="Recognize unpayable claim liability",
                     )
@@ -431,18 +436,19 @@ class ClaimProcessingMixin:
                         year_incurred=self.current_year,
                         is_insured=False,
                     )
+                    self._apply_reserve_noise(claim_liability)
                     self.claim_liabilities.append(claim_liability)
                     self.ledger.record_double_entry(
                         date=self.current_year,
                         debit_account=AccountName.INSURANCE_LOSS,
                         credit_account=AccountName.CLAIM_LIABILITIES,
-                        amount=max_liability,
+                        amount=claim_liability.original_amount,
                         transaction_type=TransactionType.INSURANCE_CLAIM,
                         description="Recognize uninsured claim liability (shortfall)",
                     )
                     logger.info(
                         f"LIMITED LIABILITY: Immediate payment ${actual_payment:,.2f}, "
-                        f"created liability for ${max_liability:,.2f} (total claim: ${claim:,.2f})"
+                        f"created liability for ${claim_liability.original_amount:,.2f} (total claim: ${claim:,.2f})"
                     )
 
                 truly_unpayable = shortfall - max_liability
@@ -472,17 +478,18 @@ class ClaimProcessingMixin:
                 year_incurred=self.current_year,
                 is_insured=False,
             )
+            self._apply_reserve_noise(claim_liability)
             self.claim_liabilities.append(claim_liability)
             self.ledger.record_double_entry(
                 date=self.current_year,
                 debit_account=AccountName.INSURANCE_LOSS,
                 credit_account=AccountName.CLAIM_LIABILITIES,
-                amount=deferred_max_liability,
+                amount=claim_liability.original_amount,
                 transaction_type=TransactionType.INSURANCE_CLAIM,
                 description="Recognize uninsured deferred claim liability",
             )
             logger.info(
-                f"Created uninsured claim liability: ${deferred_max_liability:,.2f} (no collateral required)"
+                f"Created uninsured claim liability: ${claim_liability.original_amount:,.2f} (no collateral required)"
             )
 
         unpayable = claim - deferred_max_liability
@@ -667,6 +674,7 @@ class ClaimProcessingMixin:
                 year_incurred=self.current_year,
                 is_insured=False,
             )
+        self._apply_reserve_noise(new_claim)
         self.claim_liabilities.append(new_claim)
 
         pattern_name = (
@@ -678,3 +686,99 @@ class ClaimProcessingMixin:
             f"Created claim liability via record_claim_accrual: ${amount:,.2f} "
             f"with pattern {pattern_name}"
         )
+
+    def _apply_reserve_noise(self, claim: ClaimLiability) -> None:
+        """Apply initial estimation noise to a claim when reserve development is enabled.
+
+        Stores the true ultimate amount and replaces original/remaining with
+        a noisy estimate. No-op if reserve development is disabled.
+
+        Args:
+            claim: The ClaimLiability to apply noise to (modified in place).
+        """
+        if not getattr(self, "_enable_reserve_development", False):
+            return
+        rng = getattr(self, "_reserve_rng", None)
+        if rng is None:
+            return
+        noise_std = getattr(self.config, "reserve_noise_std", 0.20)
+        true_amount = claim.original_amount
+        claim.true_ultimate = true_amount
+        claim._noise_std = noise_std
+        noise_factor = 1.0 + rng.gauss(0.0, noise_std)
+        noisy_estimate = to_decimal(max(float(true_amount) * noise_factor, 0.0))
+        claim.original_amount = noisy_estimate
+        claim.remaining_amount = noisy_estimate
+
+    def re_estimate_reserves(self) -> None:
+        """Re-estimate all outstanding claim reserves per ASC 944-40-25.
+
+        Iterates over claim liabilities, skips current-year claims, and
+        applies stochastic re-estimation. Tracks adverse and favorable
+        development separately and records ledger entries.
+        """
+        if not getattr(self, "_enable_reserve_development", False):
+            return
+        rng = getattr(self, "_reserve_rng", None)
+        if rng is None:
+            return
+
+        for claim in self.claim_liabilities:
+            # Skip current-year claims (not yet re-estimated)
+            if claim.year_incurred >= self.current_year:
+                continue
+            change = claim.re_estimate(self.current_year, rng)
+            if change > ZERO:
+                # Adverse development: reserve increased
+                self.period_adverse_development += change
+                self.ledger.record_double_entry(
+                    date=self.current_year,
+                    debit_account=AccountName.RESERVE_DEVELOPMENT,
+                    credit_account=AccountName.CLAIM_LIABILITIES,
+                    amount=change,
+                    transaction_type=TransactionType.RESERVE_DEVELOPMENT,
+                    description="Adverse reserve development",
+                    month=self.current_month,
+                )
+            elif change < ZERO:
+                # Favorable development: reserve decreased
+                favorable = abs(change)
+                self.period_favorable_development += favorable
+                self.ledger.record_double_entry(
+                    date=self.current_year,
+                    debit_account=AccountName.CLAIM_LIABILITIES,
+                    credit_account=AccountName.RESERVE_DEVELOPMENT,
+                    amount=favorable,
+                    transaction_type=TransactionType.RESERVE_DEVELOPMENT,
+                    description="Favorable reserve development",
+                    month=self.current_month,
+                )
+
+    def get_reserve_reconciliation(self) -> Dict[str, Union[Decimal, int]]:
+        """Generate a reserve reconciliation report.
+
+        Returns:
+            Dict with total_booked_reserves, total_true_residual,
+            total_redundancy, total_deficiency, and claim_count.
+        """
+        total_booked = ZERO
+        total_true_residual = ZERO
+        count = 0
+        for claim in self.claim_liabilities:
+            total_booked += claim.remaining_amount
+            if claim.true_ultimate is not None:
+                true_residual = max(claim.true_ultimate - claim._total_paid, ZERO)
+                total_true_residual += true_residual
+            else:
+                total_true_residual += claim.remaining_amount
+            count += 1
+
+        redundancy = max(total_booked - total_true_residual, ZERO)
+        deficiency = max(total_true_residual - total_booked, ZERO)
+        return {
+            "total_booked_reserves": total_booked,
+            "total_true_residual": total_true_residual,
+            "total_redundancy": redundancy,
+            "total_deficiency": deficiency,
+            "claim_count": count,
+        }

--- a/ergodic_insurance/manufacturer_income.py
+++ b/ergodic_insurance/manufacturer_income.py
@@ -85,11 +85,17 @@ class IncomeCalculationMixin:
 
         base_operating_income = revenue_decimal * to_decimal(self.base_operating_margin)
 
+        # Net reserve development: adverse increases expense, favorable decreases it
+        net_reserve_development = getattr(self, "period_adverse_development", ZERO) - getattr(
+            self, "period_favorable_development", ZERO
+        )
+
         actual_operating_income = (
             base_operating_income
             - self.period_insurance_premiums
             - self.period_insurance_losses
             - depreciation_decimal
+            - net_reserve_development
         )
 
         logger.debug(

--- a/ergodic_insurance/manufacturer_metrics.py
+++ b/ergodic_insurance/manufacturer_metrics.py
@@ -110,6 +110,13 @@ class MetricsCalculationMixin:
             self.period_insurance_premiums + self.period_insurance_losses
         )
 
+        # Reserve development metrics (Issue #470)
+        adverse_dev: Decimal = getattr(self, "period_adverse_development", ZERO)
+        favorable_dev: Decimal = getattr(self, "period_favorable_development", ZERO)
+        metrics["adverse_development"] = adverse_dev
+        metrics["favorable_development"] = favorable_dev
+        metrics["net_reserve_development"] = adverse_dev - favorable_dev
+
         # Dividends and depreciation
         metrics["dividends_paid"] = self._last_dividends_paid
         metrics["depreciation_expense"] = annual_depreciation

--- a/ergodic_insurance/tests/test_reserve_development.py
+++ b/ergodic_insurance/tests/test_reserve_development.py
@@ -1,0 +1,532 @@
+"""Unit and integration tests for reserve re-estimation (Issue #470, ASC 944-40-25).
+
+Tests cover:
+- ClaimLiability.re_estimate() behavior
+- Noise applied at claim creation
+- re_estimate_reserves() integration with manufacturer
+- Income statement flow-through
+- Reserve reconciliation report
+- Full step() integration and backward compatibility
+"""
+
+import copy
+from decimal import Decimal
+import random
+
+import pytest
+
+from ergodic_insurance.claim_development import ClaimDevelopment
+from ergodic_insurance.claim_liability import ClaimLiability
+from ergodic_insurance.config import ManufacturerConfig
+from ergodic_insurance.decimal_utils import ZERO, to_decimal
+from ergodic_insurance.ledger import AccountName, TransactionType
+from ergodic_insurance.manufacturer import WidgetManufacturer
+
+
+class TestClaimLiabilityReEstimate:
+    """Unit tests for ClaimLiability.re_estimate()."""
+
+    def test_noop_when_true_ultimate_is_none(self):
+        """re_estimate returns ZERO when reserve development is off."""
+        claim = ClaimLiability(
+            original_amount=to_decimal(100_000),
+            remaining_amount=to_decimal(100_000),
+            year_incurred=1,
+        )
+        rng = random.Random(42)
+        change = claim.re_estimate(current_year=2, rng=rng)
+        assert change == ZERO
+        assert claim.remaining_amount == to_decimal(100_000)
+
+    def test_noop_when_remaining_is_zero(self):
+        """re_estimate returns ZERO when claim is fully paid."""
+        claim = ClaimLiability(
+            original_amount=to_decimal(100_000),
+            remaining_amount=ZERO,
+            year_incurred=1,
+            true_ultimate=to_decimal(100_000),
+        )
+        claim._noise_std = 0.20
+        rng = random.Random(42)
+        change = claim.re_estimate(current_year=2, rng=rng)
+        assert change == ZERO
+
+    def test_convergence_at_maturity(self):
+        """At full maturity, estimate snaps to true residual."""
+        # 10-year pattern, 10 years elapsed -> maturity = 1.0
+        claim = ClaimLiability(
+            original_amount=to_decimal(120_000),
+            remaining_amount=to_decimal(120_000),
+            year_incurred=0,
+            true_ultimate=to_decimal(100_000),
+        )
+        claim._noise_std = 0.20
+        rng = random.Random(42)
+        change = claim.re_estimate(current_year=10, rng=rng)
+        # true_residual = 100_000 - 0 paid = 100_000
+        assert claim.remaining_amount == to_decimal(100_000)
+        expected_change = to_decimal(100_000) - to_decimal(120_000)
+        assert change == expected_change
+
+    def test_remaining_always_non_negative(self):
+        """re_estimate never sets remaining_amount below zero."""
+        claim = ClaimLiability(
+            original_amount=to_decimal(10_000),
+            remaining_amount=to_decimal(10_000),
+            year_incurred=0,
+            true_ultimate=to_decimal(1),  # Very small true amount
+        )
+        claim._noise_std = 0.90  # High noise
+        rng = random.Random(99)
+        for year in range(1, 15):
+            claim.re_estimate(current_year=year, rng=rng)
+            assert claim.remaining_amount >= ZERO
+
+    def test_reproducibility_with_same_seed(self):
+        """Same seed produces identical re-estimation results."""
+
+        def run_re_estimate(seed):
+            claim = ClaimLiability(
+                original_amount=to_decimal(100_000),
+                remaining_amount=to_decimal(100_000),
+                year_incurred=0,
+                true_ultimate=to_decimal(80_000),
+            )
+            claim._noise_std = 0.20
+            rng = random.Random(seed)
+            change = claim.re_estimate(current_year=3, rng=rng)
+            return change, claim.remaining_amount
+
+        change1, rem1 = run_re_estimate(42)
+        change2, rem2 = run_re_estimate(42)
+        assert change1 == change2
+        assert rem1 == rem2
+
+    def test_early_maturity_has_more_noise(self):
+        """Claims early in development have larger noise variance than late ones."""
+        results_early = []
+        results_late = []
+        for seed in range(100):
+            # Early: year 1 of 10
+            claim_early = ClaimLiability(
+                original_amount=to_decimal(100_000),
+                remaining_amount=to_decimal(100_000),
+                year_incurred=0,
+                true_ultimate=to_decimal(100_000),
+            )
+            claim_early._noise_std = 0.30
+            rng_early = random.Random(seed)
+            change_early = claim_early.re_estimate(current_year=1, rng=rng_early)
+            results_early.append(float(change_early))
+
+            # Late: year 8 of 10
+            claim_late = ClaimLiability(
+                original_amount=to_decimal(100_000),
+                remaining_amount=to_decimal(100_000),
+                year_incurred=0,
+                true_ultimate=to_decimal(100_000),
+            )
+            claim_late._noise_std = 0.30
+            rng_late = random.Random(seed)
+            change_late = claim_late.re_estimate(current_year=8, rng=rng_late)
+            results_late.append(float(change_late))
+
+        # Variance of early changes should be larger
+        import statistics
+
+        var_early = statistics.variance(results_early)
+        var_late = statistics.variance(results_late)
+        assert var_early > var_late
+
+    def test_total_paid_tracked_correctly(self):
+        """_total_paid accumulates across make_payment calls."""
+        claim = ClaimLiability(
+            original_amount=to_decimal(100_000),
+            remaining_amount=to_decimal(100_000),
+            year_incurred=0,
+            true_ultimate=to_decimal(100_000),
+        )
+        claim._noise_std = 0.20
+        claim.make_payment(to_decimal(30_000))
+        assert claim._total_paid == to_decimal(30_000)
+        claim.make_payment(to_decimal(20_000))
+        assert claim._total_paid == to_decimal(50_000)
+
+
+class TestReserveNoiseAtCreation:
+    """Test that noise is applied at claim creation when feature is enabled."""
+
+    def _make_manufacturer(self, enable=True, noise_std=0.20):
+        config = ManufacturerConfig(
+            initial_assets=10_000_000,
+            enable_reserve_development=enable,
+            reserve_noise_std=noise_std,
+        )
+        return WidgetManufacturer(config)
+
+    def test_noise_applied_when_enabled(self):
+        """Claims get noisy estimates when reserve development is on."""
+        mfr = self._make_manufacturer(enable=True, noise_std=0.20)
+        mfr.current_year = 1
+        mfr.process_uninsured_claim(500_000)
+
+        assert len(mfr.claim_liabilities) == 1
+        claim = mfr.claim_liabilities[0]
+        assert claim.true_ultimate == to_decimal(500_000)
+        # Noisy estimate should differ from true (almost surely with std=0.20)
+        # We can't guarantee it's different due to randomness, but true_ultimate is set
+        assert claim._noise_std == 0.20
+
+    def test_no_noise_when_disabled(self):
+        """Claims use exact amounts when feature is off."""
+        mfr = self._make_manufacturer(enable=False)
+        mfr.current_year = 1
+        mfr.process_uninsured_claim(500_000)
+
+        assert len(mfr.claim_liabilities) == 1
+        claim = mfr.claim_liabilities[0]
+        assert claim.true_ultimate is None
+        assert claim._noise_std == 0.0
+
+    def test_noisy_estimate_clamped_non_negative(self):
+        """Noisy estimates never go below zero."""
+        mfr = self._make_manufacturer(enable=True, noise_std=0.99)
+        # Create many claims to test clamping
+        for i in range(50):
+            mfr.current_year = i
+            mfr.process_uninsured_claim(1000)
+        for claim in mfr.claim_liabilities:
+            assert claim.original_amount >= ZERO
+            assert claim.remaining_amount >= ZERO
+
+    def test_noise_applied_to_insured_claim(self):
+        """Noise is applied to insured claims from process_insurance_claim."""
+        mfr = self._make_manufacturer(enable=True, noise_std=0.15)
+        mfr.current_year = 1
+        mfr.process_insurance_claim(
+            claim_amount=200_000,
+            deductible_amount=50_000,
+            insurance_limit=200_000,
+        )
+        # Find the insured claim
+        insured = [c for c in mfr.claim_liabilities if c.is_insured]
+        if insured:
+            assert insured[0].true_ultimate is not None
+            assert insured[0]._noise_std == 0.15
+
+    def test_noise_applied_in_record_claim_accrual(self):
+        """Noise is applied via record_claim_accrual."""
+        mfr = self._make_manufacturer(enable=True)
+        mfr.current_year = 1
+        mfr.record_claim_accrual(300_000)
+
+        claim = mfr.claim_liabilities[-1]
+        assert claim.true_ultimate == to_decimal(300_000)
+        assert claim._noise_std == 0.20
+
+
+class TestReEstimateReservesIntegration:
+    """Integration tests for re_estimate_reserves() with manufacturer."""
+
+    def _make_manufacturer(self, noise_std=0.20):
+        config = ManufacturerConfig(
+            initial_assets=10_000_000,
+            enable_reserve_development=True,
+            reserve_noise_std=noise_std,
+        )
+        return WidgetManufacturer(config)
+
+    def test_skips_current_year_claims(self):
+        """re_estimate_reserves skips claims from the current year."""
+        mfr = self._make_manufacturer()
+        mfr.current_year = 5
+        # Create claim in year 5 (current year)
+        mfr.record_claim_accrual(100_000)
+        original_remaining = mfr.claim_liabilities[0].remaining_amount
+
+        mfr.re_estimate_reserves()
+        # Should be unchanged
+        assert mfr.claim_liabilities[0].remaining_amount == original_remaining
+
+    def test_reestimates_prior_year_claims(self):
+        """re_estimate_reserves processes claims from prior years."""
+        mfr = self._make_manufacturer()
+        mfr.current_year = 1
+        mfr.record_claim_accrual(500_000)
+        mfr.current_year = 3
+        # Now re-estimate - claim from year 1 should be processed
+        mfr.re_estimate_reserves()
+        # Development amounts should be tracked (could be zero in rare cases)
+        assert mfr.period_adverse_development >= ZERO
+        assert mfr.period_favorable_development >= ZERO
+
+    def test_ledger_entries_recorded(self):
+        """re_estimate_reserves records proper double-entry ledger entries."""
+        mfr = self._make_manufacturer(noise_std=0.50)
+        mfr.current_year = 1
+        mfr.record_claim_accrual(1_000_000)
+        entries_before = len(mfr.ledger.entries)
+
+        mfr.current_year = 3
+        mfr.re_estimate_reserves()
+
+        # Should have at least 2 new entries (debit + credit) if change != 0
+        new_entries = mfr.ledger.get_entries(transaction_type=TransactionType.RESERVE_DEVELOPMENT)
+        if mfr.period_adverse_development > ZERO or mfr.period_favorable_development > ZERO:
+            assert len(new_entries) >= 2
+
+    def test_adverse_development_entries(self):
+        """Adverse development: Dr RESERVE_DEVELOPMENT, Cr CLAIM_LIABILITIES."""
+        # Use a claim where remaining is far below true ultimate to force adverse
+        mfr = self._make_manufacturer(noise_std=0.01)
+        mfr.current_year = 1
+        mfr.record_claim_accrual(500_000)
+        claim = mfr.claim_liabilities[0]
+        # Force the estimate way below true
+        claim.remaining_amount = to_decimal(200_000)
+        claim.true_ultimate = to_decimal(500_000)
+        claim._noise_std = 0.01
+
+        mfr.current_year = 2
+        mfr.re_estimate_reserves()
+
+        if mfr.period_adverse_development > ZERO:
+            dev_entries = mfr.ledger.get_entries(
+                transaction_type=TransactionType.RESERVE_DEVELOPMENT
+            )
+            debit_entries = [
+                e for e in dev_entries if e.account == AccountName.RESERVE_DEVELOPMENT.value
+            ]
+            credit_entries = [
+                e for e in dev_entries if e.account == AccountName.CLAIM_LIABILITIES.value
+            ]
+            assert len(debit_entries) > 0 or len(credit_entries) > 0
+
+    def test_period_tracking_reset(self):
+        """reset_period_insurance_costs clears development trackers."""
+        mfr = self._make_manufacturer()
+        mfr.period_adverse_development = to_decimal(50_000)
+        mfr.period_favorable_development = to_decimal(30_000)
+        mfr.reset_period_insurance_costs()
+        assert mfr.period_adverse_development == ZERO
+        assert mfr.period_favorable_development == ZERO
+
+
+class TestIncomeStatementFlow:
+    """Test that development flows through operating income."""
+
+    def test_adverse_development_reduces_income(self):
+        """Net adverse development reduces operating income."""
+        config = ManufacturerConfig(
+            initial_assets=10_000_000,
+            enable_reserve_development=True,
+        )
+        mfr = WidgetManufacturer(config)
+        mfr.period_adverse_development = to_decimal(100_000)
+        mfr.period_favorable_development = ZERO
+
+        revenue = mfr.calculate_revenue()
+        oi_with_dev = mfr.calculate_operating_income(revenue)
+
+        # Compare to what it would be without development
+        mfr.period_adverse_development = ZERO
+        oi_without_dev = mfr.calculate_operating_income(revenue)
+
+        assert oi_with_dev < oi_without_dev
+        assert oi_without_dev - oi_with_dev == to_decimal(100_000)
+
+    def test_favorable_development_increases_income(self):
+        """Net favorable development increases operating income."""
+        config = ManufacturerConfig(
+            initial_assets=10_000_000,
+            enable_reserve_development=True,
+        )
+        mfr = WidgetManufacturer(config)
+        mfr.period_adverse_development = ZERO
+        mfr.period_favorable_development = to_decimal(80_000)
+
+        revenue = mfr.calculate_revenue()
+        oi_with_dev = mfr.calculate_operating_income(revenue)
+
+        mfr.period_favorable_development = ZERO
+        oi_without_dev = mfr.calculate_operating_income(revenue)
+
+        assert oi_with_dev > oi_without_dev
+        assert oi_with_dev - oi_without_dev == to_decimal(80_000)
+
+    def test_zero_development_no_impact(self):
+        """Zero development has no impact on operating income."""
+        config = ManufacturerConfig(initial_assets=10_000_000)
+        mfr = WidgetManufacturer(config)
+
+        revenue = mfr.calculate_revenue()
+        oi = mfr.calculate_operating_income(revenue)
+
+        # These should default to ZERO
+        assert getattr(mfr, "period_adverse_development", ZERO) == ZERO
+        assert getattr(mfr, "period_favorable_development", ZERO) == ZERO
+
+        # Recalculate - should be identical
+        oi2 = mfr.calculate_operating_income(revenue)
+        assert oi == oi2
+
+
+class TestReserveReconciliation:
+    """Test get_reserve_reconciliation() accuracy."""
+
+    def test_reconciliation_with_reserve_development(self):
+        """Reconciliation correctly reports booked vs true residual."""
+        config = ManufacturerConfig(
+            initial_assets=10_000_000,
+            enable_reserve_development=True,
+            reserve_noise_std=0.20,
+        )
+        mfr = WidgetManufacturer(config)
+        mfr.current_year = 1
+        mfr.record_claim_accrual(500_000)
+        mfr.record_claim_accrual(300_000)
+
+        recon = mfr.get_reserve_reconciliation()
+        assert recon["claim_count"] == 2
+        assert recon["total_booked_reserves"] > ZERO
+        assert recon["total_true_residual"] > ZERO
+        # Redundancy or deficiency should be non-negative
+        assert recon["total_redundancy"] >= ZERO
+        assert recon["total_deficiency"] >= ZERO
+        # Only one of redundancy/deficiency can be positive
+        assert ZERO in (recon["total_redundancy"], recon["total_deficiency"])
+
+    def test_reconciliation_without_reserve_development(self):
+        """Without reserve development, booked == true residual."""
+        config = ManufacturerConfig(
+            initial_assets=10_000_000,
+            enable_reserve_development=False,
+        )
+        mfr = WidgetManufacturer(config)
+        mfr.current_year = 1
+        mfr.record_claim_accrual(500_000)
+
+        recon = mfr.get_reserve_reconciliation()
+        assert recon["total_booked_reserves"] == recon["total_true_residual"]
+        assert recon["total_redundancy"] == ZERO
+        assert recon["total_deficiency"] == ZERO
+
+    def test_reconciliation_after_payment(self):
+        """Reconciliation accounts for payments made."""
+        config = ManufacturerConfig(
+            initial_assets=10_000_000,
+            enable_reserve_development=True,
+            reserve_noise_std=0.01,  # Very small noise for predictability
+        )
+        mfr = WidgetManufacturer(config)
+        mfr.current_year = 1
+        mfr.record_claim_accrual(100_000)
+
+        claim = mfr.claim_liabilities[0]
+        claim.make_payment(to_decimal(20_000))
+
+        recon = mfr.get_reserve_reconciliation()
+        # true_residual should account for payments
+        assert claim.true_ultimate is not None
+        expected_true_residual = max(claim.true_ultimate - claim._total_paid, ZERO)
+        assert recon["total_true_residual"] == expected_true_residual
+
+
+class TestStepIntegration:
+    """Test full step() integration with reserve development."""
+
+    def test_step_with_feature_enabled(self):
+        """step() runs without errors when reserve development is on."""
+        config = ManufacturerConfig(
+            initial_assets=10_000_000,
+            enable_reserve_development=True,
+            reserve_noise_std=0.20,
+        )
+        mfr = WidgetManufacturer(config)
+
+        # Create some claims
+        mfr.process_uninsured_claim(200_000)
+
+        # Run a step
+        metrics = mfr.step(letter_of_credit_rate=0.015, growth_rate=0.03)
+        assert metrics is not None
+        assert "adverse_development" in metrics
+        assert "favorable_development" in metrics
+        assert "net_reserve_development" in metrics
+
+    def test_step_backward_compatibility(self):
+        """step() produces identical output with feature off vs before."""
+        config = ManufacturerConfig(
+            initial_assets=10_000_000,
+            enable_reserve_development=False,
+        )
+        mfr = WidgetManufacturer(config)
+        metrics = mfr.step(letter_of_credit_rate=0.015, growth_rate=0.03)
+
+        assert metrics["adverse_development"] == ZERO
+        assert metrics["favorable_development"] == ZERO
+        assert metrics["net_reserve_development"] == ZERO
+
+    def test_multi_year_simulation(self):
+        """Multi-year simulation with reserve development produces valid results."""
+        config = ManufacturerConfig(
+            initial_assets=10_000_000,
+            enable_reserve_development=True,
+            reserve_noise_std=0.25,
+        )
+        mfr = WidgetManufacturer(config)
+
+        for year in range(5):
+            if year % 2 == 0:
+                mfr.process_uninsured_claim(100_000)
+            metrics = mfr.step(letter_of_credit_rate=0.015, growth_rate=0.02)
+            assert not mfr.is_ruined or metrics["is_solvent"] is False
+
+    def test_reset_clears_reserve_state(self):
+        """reset() properly clears all reserve development state."""
+        config = ManufacturerConfig(
+            initial_assets=10_000_000,
+            enable_reserve_development=True,
+            reserve_noise_std=0.20,
+        )
+        mfr = WidgetManufacturer(config)
+        mfr.process_uninsured_claim(200_000)
+        mfr.step(letter_of_credit_rate=0.015)
+        mfr.reset()
+
+        assert mfr.period_adverse_development == ZERO
+        assert mfr.period_favorable_development == ZERO
+        assert len(mfr.claim_liabilities) == 0
+
+    def test_deepcopy_preserves_reserve_fields(self):
+        """Deep copy preserves all reserve development state."""
+        claim = ClaimLiability(
+            original_amount=to_decimal(120_000),
+            remaining_amount=to_decimal(110_000),
+            year_incurred=1,
+            true_ultimate=to_decimal(100_000),
+        )
+        claim._total_paid = to_decimal(10_000)
+        claim._noise_std = 0.25
+
+        copied = copy.deepcopy(claim)
+        assert copied.true_ultimate == to_decimal(100_000)
+        assert copied._total_paid == to_decimal(10_000)
+        assert copied._noise_std == 0.25
+        assert copied.remaining_amount == to_decimal(110_000)
+
+        # Verify independence
+        copied.remaining_amount = to_decimal(90_000)
+        assert claim.remaining_amount == to_decimal(110_000)
+
+    def test_metrics_include_development(self):
+        """Metrics dictionary includes reserve development fields."""
+        config = ManufacturerConfig(
+            initial_assets=10_000_000,
+            enable_reserve_development=True,
+        )
+        mfr = WidgetManufacturer(config)
+        metrics = mfr.calculate_metrics()
+        assert "adverse_development" in metrics
+        assert "favorable_development" in metrics
+        assert "net_reserve_development" in metrics


### PR DESCRIPTION
## Summary
- Add stochastic reserve re-estimation gated behind `enable_reserve_development` config flag (default off) per ASC 944-40-25
- When enabled, claim reserves start as noisy estimates that converge toward the true ultimate over the claim's life, with noise proportional to `(1 - maturity) * reserve_noise_std`
- Adverse/favorable development flows through operating income and is tracked in metrics with proper double-entry ledger accounting

## Changes

| File | Change |
|------|--------|
| `config/manufacturer.py` | Added `enable_reserve_development` (default `False`) and `reserve_noise_std` (default `0.20`) fields |
| `claim_liability.py` | Added `true_ultimate`, `_total_paid`, `_noise_std` fields; `re_estimate()` method; updated `get_payment()`, `make_payment()`, `__deepcopy__()` |
| `ledger.py` | Added `RESERVE_DEVELOPMENT` to `AccountName`, `TransactionType`, and `CHART_OF_ACCOUNTS` |
| `manufacturer_claims.py` | Added `_apply_reserve_noise()`, `re_estimate_reserves()`, `get_reserve_reconciliation()`; noise applied at all 6 claim creation points |
| `manufacturer.py` | Added period tracking fields, `_reserve_rng`; calls `re_estimate_reserves()` in `step()`; resets in `reset()` |
| `manufacturer_income.py` | Net reserve development flows through `calculate_operating_income()` |
| `manufacturer_metrics.py` | Exposed `adverse_development`, `favorable_development`, `net_reserve_development` metrics |
| `tests/test_reserve_development.py` | **New** — 29 tests across 6 test classes |

## Test plan
- [x] `pytest ergodic_insurance/tests/test_reserve_development.py -v` — 29/29 pass
- [x] `pytest ergodic_insurance/tests/test_claim_development.py -v` — 27/27 pass (existing tests unchanged)
- [x] `pytest ergodic_insurance/tests/test_manufacturer.py -v` — 66/66 pass (backward compatibility)
- [x] `pytest ergodic_insurance/tests/test_financial_statements.py -v` — 40/40 pass
- [x] All pre-commit hooks pass (black, isort, mypy, pylint)
- [x] With `enable_reserve_development=False`, output is identical to before (default off)