### PR TITLE
feat: extract ~30 hardcoded parameters into configurable arguments (#517)

### DIFF
--- a/ergodic_insurance/config/optimizer.py
+++ b/ergodic_insurance/config/optimizer.py
@@ -8,7 +8,8 @@ Since:
     Version 0.9.0 (Issue #314, #458)
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Dict, Tuple
 
 
 @dataclass
@@ -97,3 +98,14 @@ class DecisionEngineConfig:
     """Maximum volatility reduction (15%)."""
     growth_benefit_factor: float = 0.5
     """Simplified growth benefit multiplier."""
+
+    loss_cv: float = 0.5
+    """Default coefficient of variation for loss severity."""
+
+    default_optimization_weights: Dict[str, float] = field(
+        default_factory=lambda: {"growth": 0.4, "risk": 0.4, "cost": 0.2}
+    )
+    """Default objective function weights."""
+
+    layer_attachment_thresholds: Tuple[float, float] = (5_000_000, 25_000_000)
+    """Attachment thresholds: (primary_ceiling, first_excess_ceiling)."""

--- a/ergodic_insurance/decision_engine.py
+++ b/ergodic_insurance/decision_engine.py
@@ -246,7 +246,7 @@ class InsuranceDecisionEngine:
             Optimal insurance decision
         """
         if weights is None:
-            weights = {"growth": 0.4, "risk": 0.4, "cost": 0.2}
+            weights = self.engine_config.default_optimization_weights.copy()
 
         if _attempted_methods is None:
             _attempted_methods = set()
@@ -839,12 +839,13 @@ class InsuranceDecisionEngine:
         total_premium = 0
         current_attachment = retained_limit
 
+        primary_ceiling, excess_ceiling = self.engine_config.layer_attachment_thresholds
         for limit in layer_limits:
             if limit > 1000:  # Minimum meaningful layer
                 # Use pricing scenario rates
-                if current_attachment < 5_000_000:
+                if current_attachment < primary_ceiling:
                     rate = self.current_scenario.primary_layer_rate
-                elif current_attachment < 25_000_000:
+                elif current_attachment < excess_ceiling:
                     rate = self.current_scenario.first_excess_rate
                 else:
                     rate = self.current_scenario.higher_excess_rate
@@ -886,8 +887,7 @@ class InsuranceDecisionEngine:
             expected_loss = 0.0
 
         # Compute effective loss volatility (σ of loss/assets ratio)
-        # Use CV=0.5 as default coefficient of variation for loss severity
-        loss_cv = 0.5
+        loss_cv = self.engine_config.loss_cv
         loss_std = expected_loss * loss_cv
 
         # Without insurance: full loss volatility hits the balance sheet
@@ -911,11 +911,12 @@ class InsuranceDecisionEngine:
         # Premium drag on growth
         premium = 0.0
         current_attachment = retained_limit
+        primary_ceiling, excess_ceiling = self.engine_config.layer_attachment_thresholds
         for limit in layer_limits:
             if limit > 1000:
-                if current_attachment < 5_000_000:
+                if current_attachment < primary_ceiling:
                     rate = self.current_scenario.primary_layer_rate
-                elif current_attachment < 25_000_000:
+                elif current_attachment < excess_ceiling:
                     rate = self.current_scenario.first_excess_rate
                 else:
                     rate = self.current_scenario.higher_excess_rate
@@ -968,12 +969,13 @@ class InsuranceDecisionEngine:
         layers = []
         current_attachment = retained_limit
 
+        primary_ceiling, excess_ceiling = self.engine_config.layer_attachment_thresholds
         for limit in layer_limits:
             if limit > 1000:  # Minimum meaningful layer
                 # Determine rate based on attachment
-                if current_attachment < 5_000_000:
+                if current_attachment < primary_ceiling:
                     rate = self.current_scenario.primary_layer_rate
-                elif current_attachment < 25_000_000:
+                elif current_attachment < excess_ceiling:
                     rate = self.current_scenario.first_excess_rate
                 else:
                     rate = self.current_scenario.higher_excess_rate
@@ -1054,12 +1056,13 @@ class InsuranceDecisionEngine:
         layers = []
         current_attachment = retained_limit
 
+        primary_ceiling, excess_ceiling = self.engine_config.layer_attachment_thresholds
         for limit in layer_limits:
             if limit > 1000:  # Minimum meaningful layer
                 # Determine rate based on attachment
-                if current_attachment < 5_000_000:
+                if current_attachment < primary_ceiling:
                     rate = self.current_scenario.primary_layer_rate
-                elif current_attachment < 25_000_000:
+                elif current_attachment < excess_ceiling:
                     rate = self.current_scenario.first_excess_rate
                 else:
                     rate = self.current_scenario.higher_excess_rate

--- a/ergodic_insurance/monte_carlo.py
+++ b/ergodic_insurance/monte_carlo.py
@@ -303,8 +303,13 @@ class SimulationConfig:
     # Periodic ruin evaluation options
     ruin_evaluation: Optional[List[int]] = None
     # Insolvency tolerance
+    # NOTE: insolvency_tolerance is also referenced in _simulate_path_enhanced()
+    # via shared["insolvency_tolerance"]. Keep defaults in sync.
     insolvency_tolerance: float = 10_000  # Company is insolvent when equity <= this threshold
     # Simulation step parameters (passed to manufacturer.step())
+    # NOTE: letter_of_credit_rate and growth_rate defaults are coupled with
+    # _simulate_path_enhanced() shared-data defaults and run_chunk_standalone().
+    # If you change these defaults, update those functions accordingly.
     letter_of_credit_rate: float = 0.015  # Annual LoC rate for collateral costs
     growth_rate: float = 0.0  # Revenue growth rate per period
     time_resolution: str = "annual"  # "annual" or "monthly"

--- a/ergodic_insurance/tests/test_decision_engine.py
+++ b/ergodic_insurance/tests/test_decision_engine.py
@@ -938,3 +938,29 @@ class TestEnhancedOptimizationMethods:
         # Method might have changed due to fallback — any method is acceptable
         valid_methods = [m.value for m in OptimizationMethod]
         assert decision.optimization_method in valid_methods
+
+
+class TestDecisionEngineConfigNewFields:
+    """Test new DecisionEngineConfig fields from Issue #517."""
+
+    def test_new_defaults(self):
+        """Test that new fields have correct default values."""
+        from ergodic_insurance.config.optimizer import DecisionEngineConfig
+
+        cfg = DecisionEngineConfig()
+        assert cfg.loss_cv == 0.5
+        assert cfg.default_optimization_weights == {"growth": 0.4, "risk": 0.4, "cost": 0.2}
+        assert cfg.layer_attachment_thresholds == (5_000_000, 25_000_000)
+
+    def test_custom_new_fields(self):
+        """Test that new fields can be overridden."""
+        from ergodic_insurance.config.optimizer import DecisionEngineConfig
+
+        cfg = DecisionEngineConfig(
+            loss_cv=0.8,
+            default_optimization_weights={"growth": 0.6, "risk": 0.3, "cost": 0.1},
+            layer_attachment_thresholds=(3_000_000, 20_000_000),
+        )
+        assert cfg.loss_cv == 0.8
+        assert cfg.default_optimization_weights == {"growth": 0.6, "risk": 0.3, "cost": 0.1}
+        assert cfg.layer_attachment_thresholds == (3_000_000, 20_000_000)

--- a/ergodic_insurance/tests/test_hjb_solver.py
+++ b/ergodic_insurance/tests/test_hjb_solver.py
@@ -8,6 +8,9 @@ import numpy as np
 import pytest
 
 from ergodic_insurance.hjb_solver import (
+    _DRIFT_THRESHOLD,
+    _GAMMA_TOLERANCE,
+    _MARGINAL_UTILITY_FLOOR,
     BoundaryCondition,
     ControlVariable,
     ExpectedWealth,
@@ -492,3 +495,35 @@ class TestHJBSolver:
 
             assert value_function is not None
             assert policy is not None
+
+
+class TestHJBSolverConfigExtensions:
+    """Test new HJBSolverConfig fields from Issue #517."""
+
+    def test_inner_iteration_defaults(self):
+        """Test default values for inner iteration fields."""
+        config = HJBSolverConfig()
+        assert config.inner_max_iterations == 100
+        assert config.inner_tolerance_factor == 0.1
+
+    def test_custom_inner_iterations(self):
+        """Test custom inner iteration values are stored."""
+        config = HJBSolverConfig(inner_max_iterations=200, inner_tolerance_factor=0.05)
+        assert config.inner_max_iterations == 200
+        assert config.inner_tolerance_factor == 0.05
+
+
+class TestModuleConstants:
+    """Test module-level named constants from Issue #517."""
+
+    def test_drift_threshold_exists(self):
+        """Verify _DRIFT_THRESHOLD constant exists and has expected value."""
+        assert _DRIFT_THRESHOLD == 1e-10
+
+    def test_marginal_utility_floor_exists(self):
+        """Verify _MARGINAL_UTILITY_FLOOR constant exists and has expected value."""
+        assert _MARGINAL_UTILITY_FLOOR == 1e-10
+
+    def test_gamma_tolerance_exists(self):
+        """Verify _GAMMA_TOLERANCE constant exists and has expected value."""
+        assert _GAMMA_TOLERANCE == 1e-10


### PR DESCRIPTION
## Summary

- Extract ~30 hardcoded numeric literals from 7 modules into configurable dataclass fields and keyword arguments with backward-compatible defaults
- Add `HJBControllerConfig` (22 fields) and `PremiumEstimationConfig` (5 fields) dataclasses to `optimal_control.py`
- Add module-level named constants (`_DRIFT_THRESHOLD`, `_MARGINAL_UTILITY_FLOOR`, `_GAMMA_TOLERANCE`) to `hjb_solver.py`
- Extend `HJBSolverConfig`, `DecisionEngineConfig`, `CashFlowProjector`, and `ManufacturingLossGenerator.create_simple()` with new configurable parameters

## Files changed (12)

**Source (7):** `hjb_solver.py`, `optimal_control.py`, `config/optimizer.py`, `decision_engine.py`, `claim_development.py`, `loss_distributions.py`, `monte_carlo.py`

**Tests (5):** `test_hjb_solver.py`, `test_optimal_control.py`, `test_decision_engine.py`, `test_claim_development.py`, `test_loss_distributions.py`

## Test plan

- [x] 21 new tests added across 5 test files
- [x] 176/176 tests pass (155 existing + 21 new), 0 regressions
- [x] All pre-commit hooks pass (black, isort, mypy, pylint, conventional commit)
- [x] CI pipeline passes on GitHub

Closes #517