### PR TITLE
fix: make RiskMetrics.var() return consistent types (#461)

### DIFF
--- a/ergodic_insurance/tests/test_risk_metrics_coverage.py
+++ b/ergodic_insurance/tests/test_risk_metrics_coverage.py
@@ -98,17 +98,29 @@ class TestBootstrapVaRCIWeighted:
     """Test bootstrap VaR CI with weighted losses."""
 
     def test_bootstrap_ci_with_weights(self):
-        """Bootstrap CI with importance weights (lines 162-174)."""
+        """Bootstrap CI with importance weights via var_with_ci."""
         np.random.seed(42)
         losses = np.random.normal(1000, 100, 200)
         weights = np.random.uniform(0.5, 1.5, 200)
         metrics = RiskMetrics(losses, weights, seed=42)
 
-        result = metrics.var(0.95, bootstrap_ci=True, n_bootstrap=50)
+        result = metrics.var_with_ci(0.95, n_bootstrap=50)
         assert isinstance(result, RiskMetricsResult)
         assert result.confidence_interval is not None
         assert result.confidence_interval[0] < result.value
         assert result.value < result.confidence_interval[1]
+
+    def test_deprecated_bootstrap_ci_with_weights(self):
+        """Deprecated bootstrap_ci=True with weights still works."""
+        np.random.seed(42)
+        losses = np.random.normal(1000, 100, 200)
+        weights = np.random.uniform(0.5, 1.5, 200)
+        metrics = RiskMetrics(losses, weights, seed=42)
+
+        with pytest.warns(DeprecationWarning, match="bootstrap_ci.*deprecated"):
+            result = metrics.var(0.95, bootstrap_ci=True, n_bootstrap=50)
+        assert isinstance(result, RiskMetricsResult)
+        assert result.confidence_interval is not None
 
 
 # ---------------------------------------------------------------------------

--- a/ergodic_insurance/visualization/executive_plots.py
+++ b/ergodic_insurance/visualization/executive_plots.py
@@ -137,8 +137,7 @@ def plot_loss_distribution(  # pylint: disable=too-many-locals,too-many-statemen
 
         colors = [WSJ_COLORS["red"], WSJ_COLORS["orange"]]
         for i, level in enumerate(var_levels):
-            var = metrics.var(level)
-            var_value = var if isinstance(var, float) else var.value
+            var_value = metrics.var(level)
             ax1.axvline(
                 var_value,
                 color=colors[i % len(colors)],

--- a/ergodic_insurance/visualization_legacy.py
+++ b/ergodic_insurance/visualization_legacy.py
@@ -471,8 +471,7 @@ def plot_loss_distribution(  # pylint: disable=too-many-locals,too-many-statemen
 
         colors = [WSJ_COLORS["red"], WSJ_COLORS["orange"]]
         for i, level in enumerate(var_levels):
-            var = metrics.var(level)
-            var_value = var if isinstance(var, float) else var.value
+            var_value = metrics.var(level)
             ax1.axvline(
                 var_value,
                 color=colors[i % len(colors)],


### PR DESCRIPTION
## Summary
- `var()` now always returns `float`; the `bootstrap_ci` parameter is deprecated with a `DeprecationWarning` directing callers to the new `var_with_ci()` method
- New `var_with_ci()` returns `RiskMetricsResult` with bootstrap confidence intervals
- New `tvar_with_ci()` returns `RiskMetricsResult` with bootstrap confidence intervals  
- Added `@overload` signatures so mypy correctly narrows the return type based on `bootstrap_ci` value
- Removed all `isinstance(result, RiskMetricsResult)` guards from `tvar()`, `pml()`, `economic_capital()`, `plot_distribution()`, and visualization modules since `var()` now guarantees a `float` return

Closes #461

## Test plan
- [x] All 88 risk metrics tests pass (test_risk_metrics.py + test_risk_metrics_coverage.py)
- [x] Deprecated `bootstrap_ci=True` path emits `DeprecationWarning` and still returns `RiskMetricsResult`
- [x] New `var_with_ci()` and `tvar_with_ci()` tested with assertions on return type, CI bounds, and value accuracy
- [x] mypy passes with zero errors on all modified files
- [x] All pre-commit hooks pass (black, isort, mypy, pylint)
- [x] Downstream tests pass (test_properties, test_performance, test_critical_integrations)