### PR TITLE
fix: use sample std (ddof=1) in parametric VaR (#389)

### DIFF
--- a/ergodic_insurance/risk_metrics.py
+++ b/ergodic_insurance/risk_metrics.py
@@ -204,7 +204,7 @@ class RiskMetrics:
         """Calculate parametric VaR assuming normal distribution."""
         mean = np.average(self.losses, weights=self.weights)
         if self.weights is None:
-            std = np.std(self.losses)
+            std = np.std(self.losses, ddof=1)
         else:
             variance = np.average((self.losses - mean) ** 2, weights=self.weights)
             std = np.sqrt(variance)


### PR DESCRIPTION
## Summary
- Fix `_parametric_var()` to use `np.std(self.losses, ddof=1)` (sample std) instead of `np.std(self.losses)` (population std, ddof=0)
- The population std underestimates VaR — the dangerous direction for risk management
- For small samples (n=10), the old code underestimated VaR by ~5.4%

## Test plan
- [x] Exact acceptance test: losses=[1,2,3,4,5] uses std=sqrt(2.5), not sqrt(2.0)
- [x] Negative test: result does NOT equal the population-std VaR
- [x] Backward compatibility: for n=10000, difference from old behavior < 0.1%
- [x] All 90 risk_metrics tests pass
- [x] Pre-commit hooks (black, isort, mypy, pylint) pass

Closes #389