### PR TITLE
fix: implement true absorbing boundary condition (d²V/dx²=0) in HJB solver (#395)

### DIFF
--- a/ergodic_insurance/hjb_solver.py
+++ b/ergodic_insurance/hjb_solver.py
@@ -458,17 +458,29 @@ class HJBSolver:
             diagonals[1, -1] += diagonals[2, -1]
             diagonals[2, -1] = 0
         elif boundary_type == BoundaryCondition.ABSORBING:
-            # Absorbing boundaries: value is fixed at boundary
-            # First row: only main diagonal = 1
-            diagonals[1, 0] = 1
-            diagonals[2, 0] = 0  # No upper diagonal from first row
-            # Last row: only main diagonal = 1
-            # Note: For lower diagonal, element at index i goes to matrix[i+1, i]
-            # So to zero out matrix[n-1, n-2], we need diagonals[0, n-2]
-            diagonals[0, n - 2] = 0  # Zero out lower diagonal element going to last row
-            diagonals[1, n - 1] = 1  # Set main diagonal of last row to 1
+            # Absorbing boundary: enforce d²V/dx² = 0 (linear extrapolation)
+            # Lower boundary: V[0] - 2*V[1] + V[2] = 0
+            # Upper boundary: V[n-3] - 2*V[n-2] + V[n-1] = 0
+            # Row 0 needs entry at column 2 (offset +2), and row n-1 needs
+            # entry at column n-3 (offset -2), so we build as tridiagonal
+            # then add the extra entries.
+            coeff = 1.0 / (dx * dx)
+            # Row 0: [coeff, -2*coeff, 0, ..., 0] (tridiagonal part)
+            diagonals[1, 0] = coeff
+            diagonals[2, 0] = -2.0 * coeff
+            # Row n-1: [0, ..., 0, -2*coeff, coeff] (tridiagonal part)
+            diagonals[0, n - 2] = -2.0 * coeff
+            diagonals[1, n - 1] = coeff
 
         matrix = sparse.diags(diagonals, offsets=[-1, 0, 1], shape=(n, n))
+
+        if boundary_type == BoundaryCondition.ABSORBING:
+            # Add the off-tridiagonal entries for absorbing BCs
+            coeff = 1.0 / (dx * dx)
+            matrix = matrix.tolil()
+            matrix[0, 2] = coeff  # V[2] coefficient in lower boundary row
+            matrix[n - 1, n - 3] = coeff  # V[n-3] coefficient in upper boundary row
+            matrix = matrix.tocsr()
 
         return matrix
 
@@ -580,6 +592,47 @@ class HJBSolver:
             components.append(d2v)
 
         return np.stack(components, axis=-1)
+
+    def _apply_boundary_conditions(self, value: np.ndarray) -> np.ndarray:
+        """Enforce boundary conditions on the value function.
+
+        For absorbing boundaries (d²V/dx² = 0), linearly extrapolates the
+        value function from the interior so that the second derivative
+        vanishes at each boundary.
+
+        Args:
+            value: Value function on state grid
+
+        Returns:
+            Value function with boundary conditions enforced
+        """
+        ndim = self.problem.state_space.ndim
+        result = value.copy()
+
+        for dim in range(ndim):
+            sv = self.problem.state_space.state_variables[dim]
+
+            if sv.boundary_lower == BoundaryCondition.ABSORBING:
+                # V[0] = 2*V[1] - V[2] (linear extrapolation)
+                lo: List[Any] = [slice(None)] * ndim
+                p1: List[Any] = [slice(None)] * ndim
+                p2: List[Any] = [slice(None)] * ndim
+                lo[dim] = 0
+                p1[dim] = 1
+                p2[dim] = 2
+                result[tuple(lo)] = 2.0 * result[tuple(p1)] - result[tuple(p2)]
+
+            if sv.boundary_upper == BoundaryCondition.ABSORBING:
+                # V[-1] = 2*V[-2] - V[-3] (linear extrapolation)
+                hi: List[Any] = [slice(None)] * ndim
+                m1: List[Any] = [slice(None)] * ndim
+                m2: List[Any] = [slice(None)] * ndim
+                hi[dim] = -1
+                m1[dim] = -2
+                m2[dim] = -3
+                result[tuple(hi)] = 2.0 * result[tuple(m1)] - result[tuple(m2)]
+
+        return result
 
     def solve(self) -> Tuple[np.ndarray, Dict[str, np.ndarray]]:
         """Solve the HJB equation using policy iteration.
@@ -759,7 +812,8 @@ class HJBSolver:
                     rhs += self._apply_diffusion_term(old_v, sigma_sq)
                 new_v = old_v + dt * rhs
 
-            # Apply boundary conditions (skip for now to preserve terminal condition)
+            # Apply boundary conditions
+            new_v = self._apply_boundary_conditions(new_v)
 
             self.value_function = new_v
 

--- a/ergodic_insurance/tests/test_hjb_numerical.py
+++ b/ergodic_insurance/tests/test_hjb_numerical.py
@@ -70,12 +70,20 @@ class TestNumericalMethods:
                 assert mat_array is not None
                 assert np.all(np.isfinite(mat_array))
             elif bc == BoundaryCondition.ABSORBING:
-                # For absorbing BC, boundary values are fixed
-                # This is implemented as identity rows (diagonal = 1, others = 0)
-                expected_first_row = np.zeros(10)
-                expected_first_row[0] = 1.0
-                expected_last_row = np.zeros(10)
-                expected_last_row[-1] = 1.0
+                # For absorbing BC, boundary rows enforce d²V/dx² = 0
+                # Row 0: [1/dx², -2/dx², 1/dx², 0, ...]
+                # Row n-1: [..., 0, 1/dx², -2/dx², 1/dx²]
+                n = 10
+                dx = 1.0 / (n - 1)
+                coeff = 1.0 / (dx * dx)
+                expected_first_row = np.zeros(n)
+                expected_first_row[0] = coeff
+                expected_first_row[1] = -2.0 * coeff
+                expected_first_row[2] = coeff
+                expected_last_row = np.zeros(n)
+                expected_last_row[-3] = coeff
+                expected_last_row[-2] = -2.0 * coeff
+                expected_last_row[-1] = coeff
                 assert np.allclose(mat_array[0, :], expected_first_row)
                 assert np.allclose(mat_array[-1, :], expected_last_row)
 
@@ -304,6 +312,153 @@ class TestBoundaryConditions:
 
         # Check interior point is not boundary
         assert not mask_3d[1, 2, 1]
+
+    def test_absorbing_bc_second_derivative_zero(self):
+        """For V(x) = x², the absorbing BC matrix row should give d²V/dx² = 0.
+
+        Acceptance criterion: the second derivative operator applied at the
+        boundary should return 0 (not 1*V[0] as the old Dirichlet-like rows did).
+        """
+        n = 11
+        state_space = StateSpace([StateVariable("x", 0, 1, n)])
+        problem = HJBProblem(
+            state_space=state_space,
+            control_variables=[ControlVariable("u", 0, 1, 2)],
+            utility_function=LogUtility(),
+            dynamics=lambda x, u, t: np.zeros_like(x),
+            running_cost=lambda x, u, t: np.zeros(x.shape[0]),
+            time_horizon=1.0,
+        )
+        solver = HJBSolver(problem, HJBSolverConfig())
+        mat = solver._build_difference_matrix(0, BoundaryCondition.ABSORBING)
+
+        # V(x) = x² on uniform grid [0, 1]
+        grid = np.linspace(0, 1, n)
+        v = grid**2
+
+        result = mat @ v
+
+        # Interior points: d²(x²)/dx² = 2  (constant)
+        # Absorbing boundary rows: enforce V[0] - 2V[1] + V[2] = 0
+        # For x², V[0]-2V[1]+V[2] = 0 - 2*(1/100) + (4/100) = 2/100, then /dx²
+        # which equals the standard second derivative ≈ 2. So the boundary rows
+        # give the same result as interior for a smooth function.
+        # The key difference from the old code: the old code returned
+        # 1*V[0] = 0 at the lower boundary and 1*V[n-1] = 1 at the upper
+        # boundary, instead of the actual second derivative.
+        dx = 1.0 / (n - 1)
+        expected_d2v = 2.0  # d²(x²)/dx² = 2
+        # Boundary rows now compute the finite difference of d²V/dx²
+        assert abs(result[0] - expected_d2v) < 0.1
+        assert abs(result[-1] - expected_d2v) < 0.1
+
+    def test_absorbing_bc_boundary_changes_with_time(self):
+        """With absorbing BCs and diffusion, boundary values should evolve.
+
+        Acceptance criterion: For a parabolic PDE V_t = V_xx with absorbing
+        BCs, the boundary value should change with time (not stay fixed).
+        """
+        n = 21
+        sv = StateVariable(
+            "x",
+            0,
+            1,
+            n,
+            boundary_lower=BoundaryCondition.ABSORBING,
+            boundary_upper=BoundaryCondition.ABSORBING,
+        )
+        state_space = StateSpace([sv])
+
+        # Set up a pure diffusion problem V_t = V_xx
+        problem = HJBProblem(
+            state_space=state_space,
+            control_variables=[ControlVariable("u", 0, 1, 2)],
+            utility_function=ExpectedWealth(),
+            dynamics=lambda x, u, t: np.zeros_like(x),
+            running_cost=lambda x, u, t: np.zeros(x.shape[0]),
+            diffusion=lambda x, u, t: np.ones((x.shape[0], 1)),
+            terminal_value=lambda x: np.sin(np.pi * x[..., 0]),
+            time_horizon=0.5,
+        )
+
+        config = HJBSolverConfig(time_step=0.01, max_iterations=3, tolerance=1e-8, verbose=False)
+
+        # Solve with absorbing BCs
+        solver_abs = HJBSolver(problem, config)
+        value_abs, _ = solver_abs.solve()
+
+        # Solve with Dirichlet BCs for comparison
+        sv_dir = StateVariable(
+            "x",
+            0,
+            1,
+            n,
+            boundary_lower=BoundaryCondition.DIRICHLET,
+            boundary_upper=BoundaryCondition.DIRICHLET,
+        )
+        problem_dir = HJBProblem(
+            state_space=StateSpace([sv_dir]),
+            control_variables=[ControlVariable("u", 0, 1, 2)],
+            utility_function=ExpectedWealth(),
+            dynamics=lambda x, u, t: np.zeros_like(x),
+            running_cost=lambda x, u, t: np.zeros(x.shape[0]),
+            diffusion=lambda x, u, t: np.ones((x.shape[0], 1)),
+            terminal_value=lambda x: np.sin(np.pi * x[..., 0]),
+            time_horizon=0.5,
+        )
+        solver_dir = HJBSolver(problem_dir, config)
+        value_dir, _ = solver_dir.solve()
+
+        # With absorbing BCs, boundary values should differ from Dirichlet
+        # because absorbing linearly extrapolates from interior (allowing
+        # the boundary to evolve) while Dirichlet fixes boundary values.
+        # The terminal condition sin(pi*x) has V[0]=V[-1]=0.
+        # After diffusion with absorbing BCs, boundaries will be extrapolated
+        # from interior values and should differ from the fixed Dirichlet values.
+        assert not np.allclose(
+            value_abs, value_dir, atol=1e-6
+        ), "Absorbing and Dirichlet BCs produced identical solutions for diffusion problem"
+
+    def test_absorbing_vs_dirichlet_different_solutions(self):
+        """Absorbing and Dirichlet BCs should produce different solutions.
+
+        Acceptance criterion: Dirichlet and absorbing BCs produce different
+        solutions for the same PDE.
+        """
+        n = 15
+
+        def make_problem(bc_type):
+            sv = StateVariable(
+                "x",
+                0,
+                1,
+                n,
+                boundary_lower=bc_type,
+                boundary_upper=bc_type,
+            )
+            return HJBProblem(
+                state_space=StateSpace([sv]),
+                control_variables=[ControlVariable("u", 0, 1, 2)],
+                utility_function=ExpectedWealth(),
+                dynamics=lambda x, u, t: np.ones_like(x) * 0.5,
+                running_cost=lambda x, u, t: np.zeros(x.shape[0]),
+                diffusion=lambda x, u, t: np.ones((x.shape[0], 1)) * 0.1,
+                terminal_value=lambda x: x[..., 0] ** 2,
+                time_horizon=0.5,
+            )
+
+        config = HJBSolverConfig(time_step=0.05, max_iterations=5, tolerance=1e-8, verbose=False)
+
+        solver_absorbing = HJBSolver(make_problem(BoundaryCondition.ABSORBING), config)
+        value_absorbing, _ = solver_absorbing.solve()
+
+        solver_dirichlet = HJBSolver(make_problem(BoundaryCondition.DIRICHLET), config)
+        value_dirichlet, _ = solver_dirichlet.solve()
+
+        # Solutions should differ, especially at the boundaries
+        assert not np.allclose(
+            value_absorbing, value_dirichlet, atol=1e-6
+        ), "Absorbing and Dirichlet BCs produced identical solutions"
 
 
 class TestMultiDimensionalProblems:
@@ -1018,7 +1173,18 @@ class TestDiffusionTerm:
 
     def test_nonzero_diffusion_changes_value(self):
         """Test that non-zero diffusion produces different results."""
-        state_space = StateSpace([StateVariable("x", 1, 10, 15)])
+        # Use Dirichlet BCs so boundary-fixed values allow diffusion to
+        # affect the interior solution (absorbing BCs linearly extrapolate,
+        # which can make solutions converge to linear — where d²V/dx² = 0).
+        sv = StateVariable(
+            "x",
+            1,
+            10,
+            15,
+            boundary_lower=BoundaryCondition.DIRICHLET,
+            boundary_upper=BoundaryCondition.DIRICHLET,
+        )
+        state_space = StateSpace([sv])
 
         def dynamics(x, u, t):
             return x * 0.05
@@ -1109,7 +1275,15 @@ class TestDiffusionTerm:
 
     def test_control_dependent_diffusion_affects_value(self):
         """Test that control-dependent diffusion changes the value function."""
-        state_space = StateSpace([StateVariable("x", 1, 10, 10)])
+        sv = StateVariable(
+            "x",
+            1,
+            10,
+            10,
+            boundary_lower=BoundaryCondition.DIRICHLET,
+            boundary_upper=BoundaryCondition.DIRICHLET,
+        )
+        state_space = StateSpace([sv])
 
         def dynamics(x, u, t):
             return x * 0.05 * u[..., 0].reshape(x.shape)


### PR DESCRIPTION
## Summary
- Fixes the ABSORBING boundary condition in `_build_difference_matrix()` which was incorrectly implemented identically to Dirichlet (identity rows). Now enforces d²V/dx² = 0 via the [1, -2, 1]/dx² stencil at boundary rows.
- Adds `_apply_boundary_conditions()` method that enforces linear extrapolation (V[0] = 2V[1] - V[2]) on the value function after each policy evaluation step, so absorbing boundaries evolve rather than staying fixed.
- Updates two diffusion tests that implicitly relied on absorbing==Dirichlet behavior to use explicit Dirichlet BCs.

## Test plan
- [x] Existing `test_build_difference_matrix` updated to verify [1/dx², -2/dx², 1/dx²] stencil at boundary rows
- [x] New `test_absorbing_bc_second_derivative_zero`: applies D² matrix to V(x)=x², verifies d²V/dx²=2 at boundaries (not 1·V[0])
- [x] New `test_absorbing_bc_boundary_changes_with_time`: absorbing and Dirichlet produce different solutions for a diffusion PDE
- [x] New `test_absorbing_vs_dirichlet_different_solutions`: verifies absorbing and Dirichlet BCs produce distinct solutions
- [x] All 62 tests in `test_hjb_numerical.py` + `test_hjb_solver.py` pass
- [x] Pre-commit hooks (black, isort, mypy, pylint) all pass

Closes #395