### PR TITLE
fix: use sample std (ddof=1) in Sharpe ratio calculation (#488)

### DIFF
--- a/ergodic_insurance/risk_metrics.py
+++ b/ergodic_insurance/risk_metrics.py
@@ -516,10 +516,18 @@ class RiskMetrics:
 
         if self.weights is None:
             mean_return = np.mean(returns)
-            std_return = np.std(returns)
+            std_return = np.std(returns, ddof=1)
         else:
             mean_return = np.average(returns, weights=self.weights)
             variance = np.average((returns - mean_return) ** 2, weights=self.weights)
+            # Bessel correction for reliability weights:
+            # corrected = pop_variance * V1^2 / (V1^2 - V2)
+            # where V1 = sum(w), V2 = sum(w^2)
+            v1 = np.sum(self.weights)
+            v2 = np.sum(self.weights**2)
+            denom = v1**2 - v2
+            if denom > 0:
+                variance = variance * v1**2 / denom
             std_return = np.sqrt(variance)
 
         # Sharpe ratio

--- a/ergodic_insurance/tests/test_risk_metrics_coverage.py
+++ b/ergodic_insurance/tests/test_risk_metrics_coverage.py
@@ -436,6 +436,120 @@ class TestSortinoDownsideDeviationFix:
 
 
 # ---------------------------------------------------------------------------
+# Issue #488: Sharpe ratio uses sample std (ddof=1)
+# ---------------------------------------------------------------------------
+
+
+class TestSharpeRatioSampleStd:
+    """Verify Sharpe ratio uses sample standard deviation (ddof=1).
+
+    SR = (R_bar - R_f) / s
+
+    where s = sqrt(sum((R_i - R_bar)^2) / (n-1)) is the sample std.
+
+    Reference: Sharpe, W. F. (1994). "The Sharpe Ratio."
+    Journal of Portfolio Management, 21(1), 49-58.
+    """
+
+    def test_unweighted_sharpe_hand_calculated(self):
+        """Issue #488 AC: hand-calculated Sharpe with known unweighted data."""
+        returns = np.array([0.10, 0.12, -0.05, 0.08, -0.03])
+        risk_free_rate = 0.02
+
+        # Hand calculation:
+        # mean = (0.10 + 0.12 - 0.05 + 0.08 - 0.03) / 5 = 0.044
+        mean_r = 0.044
+        # deviations from mean: [0.056, 0.076, -0.094, 0.036, -0.074]
+        # squared: [0.003136, 0.005776, 0.008836, 0.001296, 0.005476]
+        # sum = 0.02452
+        # sample variance (ddof=1) = 0.02452 / 4 = 0.00613
+        # sample std = sqrt(0.00613)
+        sample_std = np.sqrt(0.02452 / 4)
+        expected_sharpe = (mean_r - risk_free_rate) / sample_std
+
+        metrics = RiskMetrics(returns)
+        result = metrics.risk_adjusted_metrics(returns=returns, risk_free_rate=risk_free_rate)
+
+        assert result["sharpe_ratio"] == pytest.approx(expected_sharpe, rel=1e-10)
+        assert result["volatility"] == pytest.approx(sample_std, rel=1e-10)
+
+    def test_unweighted_sharpe_matches_numpy_ddof1(self):
+        """Sharpe volatility must equal np.std(returns, ddof=1)."""
+        np.random.seed(123)
+        returns = np.random.normal(0.05, 0.10, 50)
+        expected_std = np.std(returns, ddof=1)
+
+        metrics = RiskMetrics(returns)
+        result = metrics.risk_adjusted_metrics(returns=returns, risk_free_rate=0.0)
+
+        assert result["volatility"] == pytest.approx(expected_std, rel=1e-12)
+
+    def test_unweighted_sharpe_not_population_std(self):
+        """Sharpe volatility must NOT equal np.std(returns, ddof=0)."""
+        # Use small sample where ddof=0 vs ddof=1 difference is large
+        returns = np.array([0.10, 0.20, 0.30])
+        pop_std = np.std(returns, ddof=0)
+
+        metrics = RiskMetrics(returns)
+        result = metrics.risk_adjusted_metrics(returns=returns, risk_free_rate=0.0)
+
+        assert result["volatility"] != pytest.approx(pop_std, rel=1e-6)
+
+    def test_weighted_sharpe_hand_calculated(self):
+        """Issue #488 AC: hand-calculated Sharpe with known weighted data."""
+        returns = np.array([0.10, -0.05, 0.08, -0.03])
+        weights = np.array([1.0, 2.0, 1.0, 2.0])
+        risk_free_rate = 0.02
+
+        # Hand calculation:
+        # weighted mean = (1*0.10 + 2*(-0.05) + 1*0.08 + 2*(-0.03)) / 6
+        #               = (0.10 - 0.10 + 0.08 - 0.06) / 6 = 0.02 / 6
+        w_mean = np.average(returns, weights=weights)
+        # weighted population variance = sum(w_i*(x_i-mean)^2) / sum(w_i)
+        pop_var = np.average((returns - w_mean) ** 2, weights=weights)
+        # Bessel correction: V1^2 / (V1^2 - V2)
+        v1 = np.sum(weights)  # 6.0
+        v2 = np.sum(weights**2)  # 1+4+1+4 = 10.0
+        bessel = v1**2 / (v1**2 - v2)  # 36 / 26
+        sample_var = pop_var * bessel
+        sample_std = np.sqrt(sample_var)
+        expected_sharpe = (w_mean - risk_free_rate) / sample_std
+
+        metrics = RiskMetrics(returns, weights)
+        result = metrics.risk_adjusted_metrics(returns=returns, risk_free_rate=risk_free_rate)
+
+        assert result["sharpe_ratio"] == pytest.approx(expected_sharpe, rel=1e-10)
+        assert result["volatility"] == pytest.approx(sample_std, rel=1e-10)
+
+    def test_weighted_bessel_reduces_to_unweighted(self):
+        """Uniform weights must produce the same result as unweighted ddof=1."""
+        returns = np.array([0.10, 0.12, -0.05, 0.08, -0.03])
+        uniform_weights = np.ones(5)
+
+        metrics_unw = RiskMetrics(returns)
+        metrics_w = RiskMetrics(returns, uniform_weights)
+
+        result_unw = metrics_unw.risk_adjusted_metrics(returns=returns, risk_free_rate=0.02)
+        result_w = metrics_w.risk_adjusted_metrics(returns=returns, risk_free_rate=0.02)
+
+        assert result_w["sharpe_ratio"] == pytest.approx(result_unw["sharpe_ratio"], rel=1e-10)
+        assert result_w["volatility"] == pytest.approx(result_unw["volatility"], rel=1e-10)
+
+    def test_small_sample_ddof_difference_significant(self):
+        """For n=5, ddof=0 vs ddof=1 differs by ~12%, verifying correction matters."""
+        returns = np.array([0.10, 0.12, -0.05, 0.08, -0.03])
+        pop_std = np.std(returns, ddof=0)
+        sample_std = np.std(returns, ddof=1)
+
+        # Ratio should be sqrt(n/(n-1)) = sqrt(5/4) ≈ 1.118
+        assert sample_std / pop_std == pytest.approx(np.sqrt(5.0 / 4.0), rel=1e-10)
+
+        metrics = RiskMetrics(returns)
+        result = metrics.risk_adjusted_metrics(returns=returns, risk_free_rate=0.0)
+        assert result["volatility"] == pytest.approx(sample_std, rel=1e-10)
+
+
+# ---------------------------------------------------------------------------
 # Plot distribution with weighted data (lines 544, 574-584, 617)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Fix `np.std(returns)` (population, ddof=0) to `np.std(returns, ddof=1)` (sample) in `RiskMetrics.risk_adjusted_metrics`
- Apply Bessel correction for weighted variance: `V1^2 / (V1^2 - V2)` where V1=sum(w), V2=sum(w^2)
- Add 6 targeted tests verifying hand-calculated Sharpe ratios for both unweighted and weighted cases

## Details
The Sharpe ratio was inflated because the denominator (volatility) used population std instead of sample std. For small samples (n=10), this overestimates Sharpe by ~5.4%.

**Sortino ratio left unchanged** — it intentionally uses population variance (1/N) per Sortino & Price (1994), as validated by existing tests in `TestSortinoDownsideDeviationFix`.

Closes #488

## Test plan
- [x] 6 new tests in `TestSharpeRatioSampleStd` all pass
- [x] All 96 existing risk_metrics tests pass (no regressions)
- [x] All 7 Sortino-specific tests pass (formula unchanged)
- [x] All pre-commit hooks pass (black, isort, mypy, pylint)