### PR TITLE
fix: clip BCa bias proportion to prevent -inf/+inf (#482)

### DIFF
--- a/ergodic_insurance/bootstrap_analysis.py
+++ b/ergodic_insurance/bootstrap_analysis.py
@@ -398,7 +398,10 @@ class BootstrapAnalyzer:
         Returns:
             Bias correction value.
         """
-        return float(stats.norm.ppf(np.mean(bootstrap_dist < original_stat)))
+        n = len(bootstrap_dist)
+        proportion = np.mean(bootstrap_dist < original_stat)
+        proportion = np.clip(proportion, 1 / (2 * n), 1 - 1 / (2 * n))
+        return float(stats.norm.ppf(proportion))
 
     def _calculate_acceleration(
         self, data: np.ndarray, statistic: Callable[[np.ndarray], float]

--- a/ergodic_insurance/tests/test_bootstrap.py
+++ b/ergodic_insurance/tests/test_bootstrap.py
@@ -95,6 +95,30 @@ class TestBootstrapAnalyzer:
         assert result.acceleration is not None
         assert result.confidence_interval[0] < np.mean(data) < result.confidence_interval[1]
 
+    def test_bca_extreme_statistic_no_nan(self):
+        """Test BCa CI with extreme statistic that previously produced NaN (#482)."""
+        np.random.seed(42)
+        data = np.random.uniform(0, 10, 200)
+
+        analyzer = BootstrapAnalyzer(n_bootstrap=2000, seed=42, show_progress=False)
+        result = analyzer.confidence_interval(data, np.max, method="bca")
+
+        assert np.isfinite(result.confidence_interval[0]), "Lower CI bound is not finite"
+        assert np.isfinite(result.confidence_interval[1]), "Upper CI bound is not finite"
+        assert isinstance(result.confidence_interval[0], float)
+        assert isinstance(result.confidence_interval[1], float)
+
+    def test_bca_small_sample_no_nan(self):
+        """Test BCa CI with small skewed sample produces finite bounds (#482)."""
+        np.random.seed(42)
+        data = np.random.exponential(scale=5.0, size=10)
+
+        analyzer = BootstrapAnalyzer(n_bootstrap=2000, seed=42, show_progress=False)
+        result = analyzer.confidence_interval(data, np.mean, method="bca")
+
+        assert np.isfinite(result.confidence_interval[0]), "Lower CI bound is not finite"
+        assert np.isfinite(result.confidence_interval[1]), "Upper CI bound is not finite"
+
     def test_parallel_bootstrap(self):
         """Test parallel bootstrap computation."""
         np.random.seed(42)


### PR DESCRIPTION
## Summary
- **Fix**: Clip the proportion in `_calculate_bias()` to `[1/(2n), 1-1/(2n)]` before passing to `stats.norm.ppf()`, preventing `-inf`/`+inf` when all bootstrap samples fall on one side of the original statistic. This is the standard Winsorization approach from Efron & Tibshirani (1993).
- **Tests**: Add two regression tests covering extreme statistics (`np.max`) and small skewed samples (n=10) with BCa method.

## Test plan
- [x] `test_bca_extreme_statistic_no_nan` — verifies finite CI bounds when statistic is at distribution extreme
- [x] `test_bca_small_sample_no_nan` — verifies finite CI bounds with small skewed sample
- [x] Existing `test_bca_confidence_interval` still passes

Closes #482