### PR TITLE
fix: pass configured seed to bootstrap CI RNG (#400)

### DIFF
--- a/ergodic_insurance/ruin_probability.py
+++ b/ergodic_insurance/ruin_probability.py
@@ -165,6 +165,7 @@ class RuinProbabilityAnalyzer:
             config.time_horizons,
             config.n_bootstrap,
             config.bootstrap_confidence_level,
+            seed=config.seed,
         )
 
         # Check convergence
@@ -552,9 +553,10 @@ class RuinProbabilityAnalyzer:
         time_horizons: List[int],
         n_bootstrap: int,
         confidence_level: float,
+        seed: Optional[int] = None,
     ) -> np.ndarray:
         """Calculate bootstrap confidence intervals for ruin probabilities."""
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(seed)
         n_sims = len(bankruptcy_years)
         confidence_intervals = np.zeros((len(time_horizons), 2))
 

--- a/ergodic_insurance/tests/test_bootstrap_ci_seed_bug400.py
+++ b/ergodic_insurance/tests/test_bootstrap_ci_seed_bug400.py
@@ -1,0 +1,64 @@
+"""Regression tests for issue #400: Bootstrap CI ignores configured seed.
+
+Verifies that _calculate_bootstrap_ci uses the seed parameter so that
+bootstrap confidence intervals are reproducible when a seed is set.
+"""
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from ergodic_insurance.ruin_probability import RuinProbabilityAnalyzer
+
+
+@pytest.fixture
+def analyzer():
+    """Create a minimal RuinProbabilityAnalyzer for testing."""
+    return RuinProbabilityAnalyzer(
+        manufacturer=MagicMock(),
+        loss_generator=MagicMock(),
+        insurance_program=MagicMock(),
+        config=MagicMock(),
+    )
+
+
+@pytest.fixture
+def bankruptcy_years():
+    """Deterministic bankruptcy years for reproducible tests."""
+    return np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10] * 100)
+
+
+class TestBootstrapCISeed:
+    """Tests for issue #400: seed must be forwarded to bootstrap CI."""
+
+    def test_seed_produces_reproducible_ci(self, analyzer, bankruptcy_years):
+        """With seed=42, two identical calls produce identical bootstrap CIs."""
+        ci1 = analyzer._calculate_bootstrap_ci(
+            bankruptcy_years, [5, 10], n_bootstrap=200, confidence_level=0.95, seed=42
+        )
+        ci2 = analyzer._calculate_bootstrap_ci(
+            bankruptcy_years, [5, 10], n_bootstrap=200, confidence_level=0.95, seed=42
+        )
+        np.testing.assert_array_equal(ci1, ci2)
+
+    def test_no_seed_is_non_deterministic(self, analyzer, bankruptcy_years):
+        """With seed=None, CIs should (almost certainly) differ between runs."""
+        ci1 = analyzer._calculate_bootstrap_ci(
+            bankruptcy_years, [5], n_bootstrap=200, confidence_level=0.95, seed=None
+        )
+        ci2 = analyzer._calculate_bootstrap_ci(
+            bankruptcy_years, [5], n_bootstrap=200, confidence_level=0.95, seed=None
+        )
+        # Extremely unlikely that two unseeded runs produce identical CIs
+        assert not np.array_equal(ci1, ci2)
+
+    def test_different_seeds_produce_different_ci(self, analyzer, bankruptcy_years):
+        """Different seeds should produce different CIs."""
+        ci1 = analyzer._calculate_bootstrap_ci(
+            bankruptcy_years, [5, 10], n_bootstrap=200, confidence_level=0.95, seed=42
+        )
+        ci2 = analyzer._calculate_bootstrap_ci(
+            bankruptcy_years, [5, 10], n_bootstrap=200, confidence_level=0.95, seed=99
+        )
+        assert not np.array_equal(ci1, ci2)


### PR DESCRIPTION
## Summary
- Forward `config.seed` to `_calculate_bootstrap_ci` so `np.random.default_rng(seed)` produces reproducible bootstrap confidence intervals when a seed is configured
- Adds 3 regression tests verifying: same seed → identical CIs, no seed → non-deterministic, different seeds → different CIs

## Test plan
- [x] New regression tests in `test_bootstrap_ci_seed_bug400.py` (3/3 passing)
- [x] Existing `test_ruin_probability.py` suite (31/31 passing)
- [x] Existing `test_ruin_probability_coverage.py` suite (9/9 passing)
- [x] All pre-commit hooks pass (black, isort, mypy, pylint, conventional commit)

Closes #400