### PR TITLE
fix: use Welch's t-test instead of Student's t-test in compare_scenarios (#504)

### DIFF
--- a/ergodic_insurance/ergodic_analyzer.py
+++ b/ergodic_insurance/ergodic_analyzer.py
@@ -1683,10 +1683,10 @@ class ErgodicAnalyzer:
             - ``|t| < 1``: Small effect
 
         Assumptions and Limitations:
-            **t-test Assumptions**:
+            **t-test Assumptions** (Welch's t-test):
             1. Samples are independent
             2. Data approximately normally distributed (robust to violations with large n)
-            3. Equal variances (Welch's t-test used automatically if needed)
+            3. Variances need not be equal (Welch's t-test is used)
 
             **Handling of Infinite Values**: The method automatically excludes
             infinite values (from bankruptcy scenarios) using scipy's nan_policy='omit'.
@@ -1707,9 +1707,9 @@ class ErgodicAnalyzer:
             :meth:`check_convergence`: For determining adequate sample sizes
             scipy.stats.ttest_ind: Underlying statistical test implementation
         """
-        # Perform independent samples t-test
+        # Perform Welch's t-test (does not assume equal variances)
         t_stat, p_value = stats.ttest_ind(
-            sample1, sample2, alternative=test_type, nan_policy="omit"
+            sample1, sample2, equal_var=False, alternative=test_type, nan_policy="omit"
         )
 
         return t_stat, p_value


### PR DESCRIPTION
## Summary

- Fixes `significance_test()` in `ergodic_analyzer.py` to use Welch's t-test (`equal_var=False`) instead of Student's t-test (`equal_var=True`)
- Insurance inherently reduces volatility, so insured vs uninsured growth-rate distributions have unequal variances — Student's t-test assumption is violated
- Welch's t-test is valid regardless of variance equality and is the recommended default (Ruxton 2006)

## Changes

- **`ergodic_analyzer.py`**: Add `equal_var=False` to `stats.ttest_ind()` call; fix misleading docstring that claimed equal variances were assumed
- **`test_ergodic_analyzer.py`**: Add two regression tests — one verifying Welch's t-test is used (with unequal n and variances), one verifying results approximate Student's when variances are equal

Closes #504

## Test plan

- [x] New test `test_significance_test_uses_welch` confirms output matches `scipy.stats.ttest_ind(..., equal_var=False)` and differs from `equal_var=True`
- [x] New test `test_significance_test_welch_equals_student_when_variances_equal` confirms Welch's reduces to Student's when variances match
- [x] All 16 existing `TestErgodicAnalyzer` tests pass
- [x] All 3 `TestCompareScenariosNoValidData` / `TestCompareScenariosMixedPaths` tests pass
- [x] Pre-commit hooks (black, isort, mypy, pylint) all pass