### PR TITLE
fix: use net PP&E in capex formula to prevent depreciation double-count (#354)

### DIFF
--- a/ergodic_insurance/tests/test_cash_flow_statement.py
+++ b/ergodic_insurance/tests/test_cash_flow_statement.py
@@ -32,6 +32,7 @@ class TestCashFlowStatement:
                 "accrued_expenses": 50000.0,
                 "claim_liabilities": 0.0,
                 "gross_ppe": 1000000.0,
+                "net_ppe": 900000.0,
                 "dividends_paid": 300000.0,  # 30% payout ratio
                 "assets": 2000000.0,
                 "equity": 1500000.0,
@@ -41,13 +42,13 @@ class TestCashFlowStatement:
                 # Cash flow calculation:
                 #   Operating: 1,200k NI + 110k Dep - 50k AR - 30k Inv - 5k Prepaid
                 #              + 20k AP + 10k Accrued + 50k Claims = 1,305k
-                #   Investing: -(200k PP&E change + 110k Dep) = -310k
+                #   Investing: -(90k net PP&E change + 110k Dep) = -200k
                 #   Financing: -360k dividends
-                #   Net: 1,305k - 310k - 360k = 635k
-                # Ending cash = 500k + 635k = 1,135k
+                #   Net: 1,305k - 200k - 360k = 745k
+                # Ending cash = 500k + 745k = 1,245k
                 "net_income": 1200000.0,
                 "depreciation_expense": 110000.0,
-                "cash": 1135000.0,  # Consistent with cash flow calculation
+                "cash": 1245000.0,  # Consistent with cash flow calculation
                 "accounts_receivable": 250000.0,  # Increased by 50k
                 "inventory": 180000.0,  # Increased by 30k
                 "prepaid_insurance": 25000.0,  # Increased by 5k
@@ -55,6 +56,7 @@ class TestCashFlowStatement:
                 "accrued_expenses": 60000.0,  # Increased by 10k
                 "claim_liabilities": 50000.0,  # New claims
                 "gross_ppe": 1200000.0,  # Increased by 200k
+                "net_ppe": 990000.0,
                 "dividends_paid": 360000.0,  # 30% of 1.2M
                 "assets": 2500000.0,
                 "equity": 1900000.0,
@@ -131,9 +133,9 @@ class TestCashFlowStatement:
 
         investing_cf = self.cash_flow._calculate_investing_cash_flow(current, prior, "annual")
 
-        # Capex = Change in PP&E + Depreciation
-        # (1,200,000 - 1,000,000) + 110,000 = 310,000
-        expected_capex = 310000
+        # Capex = Change in Net PP&E + Depreciation
+        # (990,000 - 900,000) + 110,000 = 200,000
+        expected_capex = 200000
         assert investing_cf["capital_expenditures"] == -expected_capex
         assert investing_cf["total"] == -expected_capex
 
@@ -167,8 +169,8 @@ class TestCashFlowStatement:
         # Beginning cash (Year 0) = 500,000
         assert values["beginning"] == 500000
 
-        # Ending cash (Year 1) = 1,135,000 (consistent with cash flow calculation)
-        assert values["ending"] == 1135000
+        # Ending cash (Year 1) = 1,245,000 (consistent with cash flow calculation)
+        assert values["ending"] == 1245000
 
         # The calculated cash flow must equal the actual cash change
         # This is a critical integrity check - no "plug" allowed
@@ -225,9 +227,9 @@ class TestCashFlowStatement:
 
         capex = self.cash_flow._calculate_capex(current, prior)
 
-        # Capex = (Ending PP&E - Beginning PP&E) + Depreciation
-        # (1,200,000 - 1,000,000) + 110,000 = 310,000
-        assert capex == 310000
+        # Capex = (Ending Net PP&E - Beginning Net PP&E) + Depreciation
+        # (990,000 - 900,000) + 110,000 = 200,000
+        assert capex == 200000
 
     def test_capex_with_no_prior_period(self):
         """Test capex calculation for first period."""
@@ -236,9 +238,9 @@ class TestCashFlowStatement:
 
         capex = self.cash_flow._calculate_capex(current, prior)
 
-        # First period capex = Current PP&E + Depreciation
-        # 1,000,000 + 100,000 = 1,100,000
-        assert capex == 1100000
+        # First period capex = Current Net PP&E + Depreciation
+        # 900,000 + 100,000 = 1,000,000
+        assert capex == 1000000
 
     def test_invalid_year_raises_error(self):
         """Test that invalid year raises IndexError."""
@@ -298,6 +300,7 @@ class TestCashFlowStatement:
                 "accrued_expenses": 50000.0,
                 "claim_liabilities": 0.0,
                 "gross_ppe": 1000000.0,
+                "net_ppe": 900000.0,
                 "assets": 2000000.0,
                 "equity": 1500000.0,
                 "insurance_premiums_paid": 200000.0,  # This should NOT appear in financing

--- a/ergodic_insurance/tests/test_financial_statements.py
+++ b/ergodic_insurance/tests/test_financial_statements.py
@@ -160,6 +160,7 @@ class TestFinancialStatementGenerator:
                     "asset_turnover": 0.5,
                     "gross_ppe": 7_000_000,
                     "accumulated_depreciation": 0,
+                    "net_ppe": 7_000_000,
                     "depreciation_expense": 700_000,  # 10-year useful life
                     "cash": 3_000_000,  # Current assets to make total = 10M
                 }
@@ -183,6 +184,7 @@ class TestFinancialStatementGenerator:
                     "asset_turnover": 0.5,
                     "gross_ppe": 7_200_000,
                     "accumulated_depreciation": 700_000,
+                    "net_ppe": 6_500_000,
                     "depreciation_expense": 720_000,
                     "cash": 3_300_000,  # Year 1: 3.3M cash + 6.5M net_ppe + 0.5M restricted
                 }
@@ -206,6 +208,7 @@ class TestFinancialStatementGenerator:
                     "asset_turnover": 0.5,
                     "gross_ppe": 7_400_000,
                     "accumulated_depreciation": 1_420_000,
+                    "net_ppe": 5_980_000,
                     "depreciation_expense": 740_000,
                     "cash": 4_429_000,  # Year 2: 4.429M cash + 5.98M net_ppe + 0.2M restricted
                 }

--- a/ergodic_insurance/tests/test_financial_statements_coverage.py
+++ b/ergodic_insurance/tests/test_financial_statements_coverage.py
@@ -50,6 +50,7 @@ def _full_metrics(overrides: Optional[dict] = None) -> dict:
         "roa": 0.03,
         "asset_turnover": 0.5,
         "gross_ppe": 7_000_000,
+        "net_ppe": 7_000_000,
         "accumulated_depreciation": 0,
         "depreciation_expense": 700_000,
         "cash": 3_000_000,
@@ -110,7 +111,7 @@ class TestCashFlowStatementMissingDepreciation:
         """Line 296: depreciation_expense missing in capex calculation."""
         cf = CashFlowStatement([{"net_income": 100_000}])
         with pytest.raises(ValueError, match="depreciation_expense missing"):
-            cf._calculate_capex({"gross_ppe": 100}, {"gross_ppe": 50})
+            cf._calculate_capex({"net_ppe": 100}, {"net_ppe": 50})
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

- **Bug**: `_calculate_capex` used `gross_ppe` (not reduced by depreciation), so adding depreciation back double-counted it — cash flow from investing was too negative by the full depreciation amount each period
- **Fix**: Switch to `net_ppe` (`gross_ppe − accumulated_depreciation`) which *is* reduced by depreciation, making `Capex = Δ(Net PP&E) + Depreciation` correct
- Updated all affected test fixtures (5 files) with `net_ppe` values and recalculated expected cash/capex amounts

Closes #354

## Test plan

- [x] `test_cash_flow_statement.py` — 18 tests pass (capex, investing CF, reconciliation)
- [x] `test_cash_reconciliation.py` — 9 tests pass (all reconciliation scenarios)
- [x] `test_financial_statements.py` — 37 tests pass (generator, balance sheet, income statement, cash flow)
- [x] `test_financial_statements_coverage.py` — 41 tests pass (coverage edge cases including capex missing-dep error)
- [x] `test_depreciation_tracking.py`, `test_balance_sheet_classification.py`, `test_working_capital_changes.py`, `test_dividend_phantom_payments.py` — 59 tests pass (no regressions)
- [x] `test_manufacturer_methods.py`, `test_manufacturer_coverage.py`, `test_roe_insurance.py`, `test_excel_reporter.py` — 94 tests pass (no regressions)
- [x] All pre-commit hooks pass (black, isort, mypy, pylint, conventional commit)