### PR TITLE
fix: reclassify insurance claim losses as operating expenses per ASC 944 (#364)

### DIFF
--- a/ergodic_insurance/financial_statements.py
+++ b/ergodic_insurance/financial_statements.py
@@ -1418,8 +1418,21 @@ class FinancialStatementGenerator:
         if insurance_premium > 0:
             data.append(("  Insurance Premiums", insurance_premium, "", ""))
 
+        # Insurance claim losses are operating expenses per ASC 944 (Issue #364)
+        # For a policyholder, claim losses from operational risks (property damage,
+        # liability, workers' comp) are inherently operational in nature.
+        insurance_claims = to_decimal(metrics.get("insurance_losses", ZERO))
+        if monthly:
+            insurance_claims = insurance_claims / 12
+        if insurance_claims > 0:
+            data.append(("  Insurance Claim Losses", insurance_claims, "", ""))
+
         total_operating_expenses = (
-            selling_expenses + general_admin + admin_depreciation + insurance_premium
+            selling_expenses
+            + general_admin
+            + admin_depreciation
+            + insurance_premium
+            + insurance_claims
         )
         data.append(("  Total Operating Expenses", total_operating_expenses, "", "subtotal"))
         data.append(("", "", "", ""))
@@ -1475,18 +1488,11 @@ class FinancialStatementGenerator:
         if monthly:
             interest_expense = interest_expense / 12
 
-        # Insurance claim losses (non-operating)
-        insurance_claims = to_decimal(metrics.get("insurance_losses", ZERO))
-        if monthly:
-            insurance_claims = insurance_claims / 12
-
         data.append(("  Interest Income", interest_income, "", ""))
         if interest_expense > 0:
             data.append(("  Interest Expense", -interest_expense, "", ""))
-        if insurance_claims > 0:
-            data.append(("  Insurance Claim Losses", -insurance_claims, "", ""))
 
-        total_non_operating = interest_income - interest_expense - insurance_claims
+        total_non_operating = interest_income - interest_expense
         data.append(("  Total Non-Operating", total_non_operating, "", "subtotal"))
         data.append(("", "", "", ""))
 


### PR DESCRIPTION
## Summary

- Move insurance claim losses from the non-operating section to operating expenses in the income statement, per ASC 944 and US GAAP classification guidance
- Insurance premiums and claim losses now appear together in the operating expenses section for clarity
- Operating income (EBIT) now reflects the full cost of operational risk
- Financial ratios (operating margin) automatically reflect the corrected classification
- Created follow-up issue #539 for future enhancement: splitting claim losses by type (property vs. liability)

### Key insight
The `manufacturer_income.py` calculation already correctly treated insurance losses as operating expenses — this change aligns the income statement **display** in `financial_statements.py` with the underlying calculation.

Closes #364

## Test plan
- [x] `test_financial_statements.py` — all 40 tests pass, including updated `test_income_statement_insurance_costs` which now verifies losses appear in operating section with positive values
- [x] `test_financial_statements_coverage.py` — all tests pass (no changes needed)
- [x] `test_tax_handling.py` — all tests pass (no downstream impact)
- [x] `test_manufacturer_methods.py` — all tests pass (no changes needed)
- [x] `test_manufacturer.py` — all 66 tests pass (no changes needed)