### PR TITLE
fix: add deferred tax liability and remove capex clamp (#367, #383)

### DIFF
--- a/ergodic_insurance/config/manufacturer.py
+++ b/ergodic_insurance/config/manufacturer.py
@@ -301,6 +301,18 @@ class ManufacturerConfig(BaseModel):
         "Noise shrinks proportionally to claim maturity.",
     )
 
+    # Accelerated tax depreciation configuration (Issue #367, ASC 740)
+    tax_depreciation_life_years: Optional[float] = Field(
+        default=None,
+        gt=0,
+        le=50,
+        description="Useful life for tax depreciation (MACRS proxy). "
+        "When shorter than ppe_useful_life_years in DepreciationConfig, "
+        "creates a deferred tax liability from the book-tax timing difference. "
+        "None = same as book useful life (no DTL). "
+        "Typical: 5-7 years for equipment under MACRS.",
+    )
+
     # Capital expenditure configuration (Issue #543)
     capex_to_depreciation_ratio: float = Field(
         default=1.0,

--- a/ergodic_insurance/financial_statements.py
+++ b/ergodic_insurance/financial_statements.py
@@ -264,14 +264,24 @@ class CashFlowStatement:
         Returns:
             Dictionary with investing cash flow components
         """
-        # Calculate capital expenditures
+        # Calculate capital expenditures (Issue #383: handle disposals)
         capex = self._calculate_capex(current, prior)
         if period == "monthly":
             capex = capex / 12
 
+        # Separate capital expenditures (outflows) from asset disposals (inflows)
+        # per ASC 230: investing activities must report inflows and outflows separately
+        if capex >= ZERO:
+            capital_expenditures = -capex  # Cash outflow (negative)
+            asset_sales = ZERO
+        else:
+            capital_expenditures = ZERO
+            asset_sales = -capex  # Disposal proceeds (positive)
+
         investing_items = {
-            "capital_expenditures": -capex,  # Cash outflow
-            "total": -capex,
+            "capital_expenditures": capital_expenditures,
+            "asset_sales": asset_sales,
+            "total": capital_expenditures + asset_sales,
         }
 
         return investing_items
@@ -307,10 +317,11 @@ class CashFlowStatement:
         # Capex = Change in Net PP&E + Depreciation
         # Net PP&E falls by depreciation each period, so adding depreciation
         # back recovers the actual capital expenditure (new asset purchases).
+        # A negative result indicates net asset disposals exceeded purchases
+        # (Issue #383: removed max(ZERO, ...) clamp that hid disposals).
         capex = (current_ppe - prior_ppe) + depreciation
 
-        # Capex should not be negative in normal operations
-        return max(ZERO, capex)
+        return capex
 
     def _calculate_financing_cash_flow(
         self, current: MetricsDict, prior: MetricsDict, period: str
@@ -583,7 +594,7 @@ class CashFlowStatement:
         # INVESTING ACTIVITIES SECTION
         cash_flow_data.append(("CASH FLOWS FROM INVESTING ACTIVITIES", "", ""))
         cash_flow_data.append(("  Capital Expenditures", investing["capital_expenditures"], ""))
-        if method == "direct" and investing.get("asset_sales", 0) != 0:
+        if investing.get("asset_sales", 0) != 0:
             cash_flow_data.append(("  Proceeds from Asset Sales", investing["asset_sales"], ""))
         cash_flow_data.append(
             ("  Net Cash Used in Investing Activities", investing["total"], "subtotal")
@@ -1082,6 +1093,13 @@ class FinancialStatementGenerator:
         data.append(("  Net Property, Plant & Equipment", net_ppe, "", "subtotal"))
         data.append(("", "", "", ""))
 
+        # Deferred Tax Assets (Issue #367, ASC 740)
+        deferred_tax_asset = metrics.get("deferred_tax_asset", 0)
+        if deferred_tax_asset > 0:
+            data.append(("Other Non-Current Assets", "", "", ""))
+            data.append(("  Deferred Tax Asset", deferred_tax_asset, "", ""))
+            data.append(("", "", "", ""))
+
         # Restricted Assets
         data.append(("Restricted Assets", "", "", ""))
         collateral = metrics.get("collateral", 0)
@@ -1159,11 +1177,16 @@ class FinancialStatementGenerator:
         data.append(("Non-Current Liabilities", "", "", ""))
         long_term_claims = claim_liabilities - current_claims
         data.append(("  Long-Term Claim Reserves", long_term_claims, "", ""))
-        data.append(("  Total Non-Current Liabilities", long_term_claims, "", "subtotal"))
+        # Deferred Tax Liability (Issue #367, ASC 740)
+        deferred_tax_liability = metrics.get("deferred_tax_liability", 0)
+        if deferred_tax_liability > 0:
+            data.append(("  Deferred Tax Liability", deferred_tax_liability, "", ""))
+        total_non_current = long_term_claims + to_decimal(deferred_tax_liability)
+        data.append(("  Total Non-Current Liabilities", total_non_current, "", "subtotal"))
         data.append(("", "", "", ""))
 
         # Total Liabilities
-        total_liabilities = total_current_liabilities + long_term_claims
+        total_liabilities = total_current_liabilities + total_non_current
         data.append(("TOTAL LIABILITIES", total_liabilities, "", "total"))
         data.append(("", "", "", ""))
         data.append(("", "", "", ""))
@@ -1543,7 +1566,7 @@ class FinancialStatementGenerator:
             # Calculate tax provision on positive income only
             tax_provision = max(ZERO, to_decimal(pretax_income) * tax_rate)
 
-        # Deferred tax from DTA changes (Issue #365: NOL carryforward per ASC 740)
+        # Deferred tax from DTA/DTL changes (Issue #365, #367: ASC 740)
         deferred_tax_expense = ZERO
         if (
             hasattr(self, "manufacturer")
@@ -1552,9 +1575,14 @@ class FinancialStatementGenerator:
             and self.manufacturer.ledger is not None
         ):
             # Positive DTA change = tax benefit (negative deferred expense)
-            deferred_tax_expense = -self.manufacturer.ledger.get_period_change(
+            dta_change = self.manufacturer.ledger.get_period_change(
                 AccountName.DEFERRED_TAX_ASSET, year
             )
+            # Positive DTL change = additional deferred expense (Issue #367)
+            dtl_change = self.manufacturer.ledger.get_period_change(
+                AccountName.DEFERRED_TAX_LIABILITY, year
+            )
+            deferred_tax_expense = -dta_change + dtl_change
 
         data.append(("INCOME TAX PROVISION", "", "", ""))
         data.append(("  Current Tax Expense", tax_provision, "", ""))

--- a/ergodic_insurance/ledger.py
+++ b/ergodic_insurance/ledger.py
@@ -122,6 +122,7 @@ class AccountName(Enum):
     ACCRUED_TAXES = "accrued_taxes"
     ACCRUED_INTEREST = "accrued_interest"
     CLAIM_LIABILITIES = "claim_liabilities"
+    DEFERRED_TAX_LIABILITY = "deferred_tax_liability"  # DTL from depreciation timing per ASC 740
     UNEARNED_REVENUE = "unearned_revenue"
 
     # Equity (credit normal balance)
@@ -181,6 +182,7 @@ class TransactionType(Enum):
     TAX_ACCRUAL = "tax_accrual"
     TAX_PAYMENT = "tax_payment"
     DTA_ADJUSTMENT = "dta_adjustment"  # Deferred tax asset recognition/reversal
+    DTL_ADJUSTMENT = "dtl_adjustment"  # Deferred tax liability recognition/reversal
     RESERVE_DEVELOPMENT = "reserve_development"  # Reserve re-estimation per ASC 944-40-25
     DEPRECIATION = "depreciation"
     WORKING_CAPITAL = "working_capital"
@@ -304,6 +306,7 @@ CHART_OF_ACCOUNTS: Dict[AccountName, AccountType] = {
     AccountName.ACCRUED_TAXES: AccountType.LIABILITY,
     AccountName.ACCRUED_INTEREST: AccountType.LIABILITY,
     AccountName.CLAIM_LIABILITIES: AccountType.LIABILITY,
+    AccountName.DEFERRED_TAX_LIABILITY: AccountType.LIABILITY,
     AccountName.UNEARNED_REVENUE: AccountType.LIABILITY,
     # Equity (credit normal balance)
     AccountName.RETAINED_EARNINGS: AccountType.EQUITY,

--- a/ergodic_insurance/manufacturer.py
+++ b/ergodic_insurance/manufacturer.py
@@ -673,6 +673,11 @@ class WidgetManufacturer(
             capex_amount = depreciation_expense * capex_ratio
             self.record_capex(capex_amount)
 
+        # Record deferred tax liability from depreciation timing differences (Issue #367)
+        # When tax_depreciation_life_years < book life, accelerated tax depreciation
+        # creates a temporary difference that generates a DTL per ASC 740.
+        self._record_dtl_from_depreciation(time_resolution)
+
         # Calculate operating income including depreciation
         operating_income = self.calculate_operating_income(revenue, depreciation_expense)
 
@@ -723,6 +728,74 @@ class WidgetManufacturer(
         self.reset_period_insurance_costs()
 
         return metrics
+
+    def _record_dtl_from_depreciation(self, time_resolution: str) -> None:
+        """Record deferred tax liability from book-tax depreciation timing difference.
+
+        When tax depreciation is accelerated relative to book depreciation
+        (tax_depreciation_life_years < ppe_useful_life_years), the cumulative
+        timing difference creates a DTL per ASC 740.  With ongoing capex, new
+        timing differences are perpetually created, making the DTL persistent
+        rather than transient (Issue #367).
+
+        Args:
+            time_resolution: "annual" or "monthly".
+        """
+        tax_life_cfg = self.config.tax_depreciation_life_years
+        if tax_life_cfg is None:
+            return  # No accelerated depreciation configured
+
+        book_life = 10.0  # Matches hardcoded book useful life in step()
+        if time_resolution == "monthly":
+            tax_life = tax_life_cfg * 12
+        else:
+            tax_life = tax_life_cfg
+
+        tax_life_decimal = to_decimal(tax_life)
+        if self.gross_ppe <= ZERO or tax_life_decimal <= ZERO:
+            return
+
+        # Calculate period tax depreciation (same pool approach as book)
+        tax_depr = self.gross_ppe / tax_life_decimal
+
+        # Cap at remaining tax basis (cannot depreciate below zero)
+        tax_net = self.gross_ppe - self.tax_handler.tax_accumulated_depreciation
+        if tax_net <= ZERO:
+            tax_depr = ZERO
+        else:
+            tax_depr = min(tax_depr, tax_net)
+
+        self.tax_handler.tax_accumulated_depreciation += tax_depr
+
+        # Compute desired DTL = (tax_accum - book_accum) * tax_rate
+        # Positive when tax depreciation is ahead of book depreciation
+        temp_diff = self.tax_handler.tax_accumulated_depreciation - self.accumulated_depreciation
+        desired_dtl = max(ZERO, temp_diff * to_decimal(self.config.tax_rate))
+        current_dtl = self.ledger.get_balance(AccountName.DEFERRED_TAX_LIABILITY)
+        dtl_change = desired_dtl - current_dtl
+
+        if dtl_change > ZERO:
+            # DTL increased: Dr TAX_EXPENSE, Cr DEFERRED_TAX_LIABILITY
+            self.ledger.record_double_entry(
+                date=self.current_year,
+                debit_account=AccountName.TAX_EXPENSE,
+                credit_account=AccountName.DEFERRED_TAX_LIABILITY,
+                amount=dtl_change,
+                transaction_type=TransactionType.DTL_ADJUSTMENT,
+                description=f"Year {self.current_year} DTL recognition from depreciation timing",
+                month=self.current_month,
+            )
+        elif dtl_change < ZERO:
+            # DTL decreased (reversal): Dr DEFERRED_TAX_LIABILITY, Cr TAX_EXPENSE
+            self.ledger.record_double_entry(
+                date=self.current_year,
+                debit_account=AccountName.DEFERRED_TAX_LIABILITY,
+                credit_account=AccountName.TAX_EXPENSE,
+                amount=abs(dtl_change),
+                transaction_type=TransactionType.DTL_ADJUSTMENT,
+                description=f"Year {self.current_year} DTL reversal from depreciation timing",
+                month=self.current_month,
+            )
 
     def reset(self) -> None:
         """Reset the manufacturer to initial state for new simulation.

--- a/ergodic_insurance/manufacturer_balance_sheet.py
+++ b/ergodic_insurance/manufacturer_balance_sheet.py
@@ -142,6 +142,15 @@ class BalanceSheetMixin:
         return self.ledger.get_balance(AccountName.DEFERRED_TAX_ASSET)
 
     @property
+    def deferred_tax_liability(self) -> Decimal:
+        """Deferred tax liability from depreciation timing differences per ASC 740 (Issue #367).
+
+        Returns:
+            Current deferred tax liability balance from the ledger.
+        """
+        return self.ledger.get_balance(AccountName.DEFERRED_TAX_LIABILITY)
+
+    @property
     def total_assets(self) -> Decimal:
         """Calculate total assets from all asset components.
 
@@ -199,7 +208,7 @@ class BalanceSheetMixin:
             (liability.remaining_amount for liability in self.claim_liabilities), ZERO
         )
 
-        return current_liabilities + claim_liability_total
+        return current_liabilities + claim_liability_total + self.deferred_tax_liability
 
     @property
     def equity(self) -> Decimal:

--- a/ergodic_insurance/manufacturer_metrics.py
+++ b/ergodic_insurance/manufacturer_metrics.py
@@ -115,6 +115,10 @@ class MetricsCalculationMixin:
         metrics["favorable_development"] = favorable_dev
         metrics["net_reserve_development"] = adverse_dev - favorable_dev
 
+        # Deferred tax balances (Issue #367, ASC 740)
+        metrics["deferred_tax_asset"] = self.deferred_tax_asset
+        metrics["deferred_tax_liability"] = self.deferred_tax_liability
+
         # Dividends and depreciation
         metrics["dividends_paid"] = self._last_dividends_paid
         metrics["depreciation_expense"] = annual_depreciation

--- a/ergodic_insurance/tax_handler.py
+++ b/ergodic_insurance/tax_handler.py
@@ -117,6 +117,7 @@ class TaxHandler:
     accrual_manager: "AccrualManager"
     nol_carryforward: Decimal = field(default_factory=lambda: Decimal("0"))
     nol_limitation_pct: float = 0.80
+    tax_accumulated_depreciation: Decimal = field(default_factory=lambda: Decimal("0"))
 
     @property
     def deferred_tax_asset(self) -> Decimal:

--- a/ergodic_insurance/tests/test_dta_dtl_and_capex.py
+++ b/ergodic_insurance/tests/test_dta_dtl_and_capex.py
@@ -1,0 +1,385 @@
+"""Tests for Issue #367 (DTA/DTL per ASC 740) and Issue #383 (capex clamping).
+
+Tests cover:
+- Negative capex (asset disposals) not suppressed
+- Asset disposals appear as separate line in investing activities
+- DTL computation from accelerated tax depreciation
+- DTL balance sheet inclusion
+- Deferred tax expense includes both DTA and DTL changes
+"""
+
+from decimal import Decimal
+from typing import List
+from unittest.mock import MagicMock
+
+import pytest
+
+from ergodic_insurance.config import ManufacturerConfig
+from ergodic_insurance.decimal_utils import ZERO, MetricsDict, to_decimal
+from ergodic_insurance.financial_statements import CashFlowStatement
+from ergodic_insurance.ledger import AccountName, TransactionType
+from ergodic_insurance.manufacturer import WidgetManufacturer
+
+# ============================================================================
+# Issue #383: _calculate_capex clamping
+# ============================================================================
+
+
+class TestCapexDisposals:
+    """Test that negative capex (asset disposals) is not suppressed."""
+
+    def test_negative_capex_not_clamped(self):
+        """Negative capex from asset disposals should be returned as-is."""
+        metrics: List[MetricsDict] = [
+            {
+                "net_income": 100000.0,
+                "depreciation_expense": 50000.0,
+                "cash": 500000.0,
+                "net_ppe": 1000000.0,
+                "gross_ppe": 1200000.0,
+                "dividends_paid": 0.0,
+                "assets": 1500000.0,
+                "equity": 1000000.0,
+            },
+            {
+                "net_income": 100000.0,
+                "depreciation_expense": 50000.0,
+                "cash": 800000.0,
+                # Net PP&E dropped significantly (disposal)
+                "net_ppe": 700000.0,
+                "gross_ppe": 900000.0,
+                "dividends_paid": 0.0,
+                "assets": 1500000.0,
+                "equity": 1000000.0,
+            },
+        ]
+        cf = CashFlowStatement(metrics)
+        # Capex = (700k - 1000k) + 50k = -250k
+        capex = cf._calculate_capex(metrics[1], metrics[0])
+        assert capex == Decimal("-250000")
+
+    def test_positive_capex_unchanged(self):
+        """Positive capex should still work normally."""
+        metrics: List[MetricsDict] = [
+            {
+                "net_income": 100000.0,
+                "depreciation_expense": 50000.0,
+                "cash": 500000.0,
+                "net_ppe": 900000.0,
+                "gross_ppe": 1000000.0,
+                "dividends_paid": 0.0,
+                "assets": 1500000.0,
+                "equity": 1000000.0,
+            },
+            {
+                "net_income": 100000.0,
+                "depreciation_expense": 60000.0,
+                "cash": 500000.0,
+                "net_ppe": 1000000.0,
+                "gross_ppe": 1200000.0,
+                "dividends_paid": 0.0,
+                "assets": 1500000.0,
+                "equity": 1000000.0,
+            },
+        ]
+        cf = CashFlowStatement(metrics)
+        # Capex = (1000k - 900k) + 60k = 160k
+        capex = cf._calculate_capex(metrics[1], metrics[0])
+        assert capex == Decimal("160000")
+
+    def test_investing_cf_splits_disposal_from_capex(self):
+        """Negative capex should appear as asset_sales, not capital_expenditures."""
+        metrics: List[MetricsDict] = [
+            {
+                "net_income": 100000.0,
+                "depreciation_expense": 50000.0,
+                "cash": 500000.0,
+                "net_ppe": 1000000.0,
+                "gross_ppe": 1200000.0,
+                "dividends_paid": 0.0,
+                "assets": 1500000.0,
+                "equity": 1000000.0,
+            },
+            {
+                "net_income": 100000.0,
+                "depreciation_expense": 50000.0,
+                "cash": 800000.0,
+                "net_ppe": 700000.0,
+                "gross_ppe": 900000.0,
+                "dividends_paid": 0.0,
+                "assets": 1500000.0,
+                "equity": 1000000.0,
+            },
+        ]
+        cf = CashFlowStatement(metrics)
+        investing = cf._calculate_investing_cash_flow(metrics[1], metrics[0], "annual")
+
+        # Disposal: capex = -250k
+        # capital_expenditures should be 0 (no purchases)
+        # asset_sales should be +250k (disposal proceeds)
+        assert investing["capital_expenditures"] == ZERO
+        assert investing["asset_sales"] == Decimal("250000")
+        assert investing["total"] == Decimal("250000")
+
+    def test_investing_cf_positive_capex(self):
+        """Positive capex should appear as capital_expenditures with zero asset_sales."""
+        metrics: List[MetricsDict] = [
+            {
+                "net_income": 100000.0,
+                "depreciation_expense": 50000.0,
+                "cash": 500000.0,
+                "net_ppe": 900000.0,
+                "gross_ppe": 1000000.0,
+                "dividends_paid": 0.0,
+                "assets": 1500000.0,
+                "equity": 1000000.0,
+            },
+            {
+                "net_income": 100000.0,
+                "depreciation_expense": 60000.0,
+                "cash": 500000.0,
+                "net_ppe": 1000000.0,
+                "gross_ppe": 1200000.0,
+                "dividends_paid": 0.0,
+                "assets": 1500000.0,
+                "equity": 1000000.0,
+            },
+        ]
+        cf = CashFlowStatement(metrics)
+        investing = cf._calculate_investing_cash_flow(metrics[1], metrics[0], "annual")
+
+        # Capex = 160k (positive)
+        assert investing["capital_expenditures"] == Decimal("-160000")
+        assert investing["asset_sales"] == ZERO
+        assert investing["total"] == Decimal("-160000")
+
+    def test_disposal_renders_in_indirect_method(self):
+        """Asset sales should appear in indirect method output (not just direct)."""
+        metrics: List[MetricsDict] = [
+            {
+                "net_income": 100000.0,
+                "depreciation_expense": 50000.0,
+                "cash": 500000.0,
+                "net_ppe": 1000000.0,
+                "gross_ppe": 1200000.0,
+                "accounts_receivable": 0.0,
+                "inventory": 0.0,
+                "prepaid_insurance": 0.0,
+                "accounts_payable": 0.0,
+                "accrued_expenses": 0.0,
+                "claim_liabilities": 0.0,
+                "dividends_paid": 0.0,
+                "assets": 1500000.0,
+                "equity": 1000000.0,
+            },
+            {
+                "net_income": 100000.0,
+                "depreciation_expense": 50000.0,
+                "cash": 850000.0,
+                "net_ppe": 700000.0,
+                "gross_ppe": 900000.0,
+                "accounts_receivable": 0.0,
+                "inventory": 0.0,
+                "prepaid_insurance": 0.0,
+                "accounts_payable": 0.0,
+                "accrued_expenses": 0.0,
+                "claim_liabilities": 0.0,
+                "dividends_paid": 0.0,
+                "assets": 1500000.0,
+                "equity": 1000000.0,
+            },
+        ]
+        cf = CashFlowStatement(metrics)
+        df = cf.generate_statement(year=1, period="annual", method="indirect")
+        items = df["Item"].values
+        assert any("Proceeds from Asset Sales" in str(item) for item in items)
+
+
+# ============================================================================
+# Issue #367: DTA/DTL per ASC 740
+# ============================================================================
+
+
+class TestDTLFromDepreciation:
+    """Test deferred tax liability from accelerated tax depreciation."""
+
+    @pytest.fixture
+    def config_with_dtl(self):
+        """Config with accelerated tax depreciation (5-year vs 10-year book)."""
+        return ManufacturerConfig(
+            initial_assets=10_000_000,
+            tax_rate=0.25,
+            nol_carryforward_enabled=True,
+            capex_to_depreciation_ratio=1.0,
+            tax_depreciation_life_years=5.0,
+        )
+
+    @pytest.fixture
+    def config_no_dtl(self):
+        """Config with no accelerated depreciation (default)."""
+        return ManufacturerConfig(
+            initial_assets=10_000_000,
+            tax_rate=0.25,
+            nol_carryforward_enabled=True,
+            capex_to_depreciation_ratio=1.0,
+        )
+
+    def test_dtl_created_with_accelerated_depreciation(self, config_with_dtl):
+        """DTL should be created when tax_depreciation_life_years < book life."""
+        mfg = WidgetManufacturer(config_with_dtl)
+        mfg.step(growth_rate=0.0, time_resolution="annual")
+
+        dtl = mfg.deferred_tax_liability
+        assert dtl > ZERO, "DTL should be positive with accelerated tax depreciation"
+
+    def test_no_dtl_with_default_config(self, config_no_dtl):
+        """No DTL should be created when tax_depreciation_life_years == book life."""
+        mfg = WidgetManufacturer(config_no_dtl)
+        mfg.step(growth_rate=0.0, time_resolution="annual")
+
+        dtl = mfg.deferred_tax_liability
+        assert dtl == ZERO, "DTL should be zero with default config"
+
+    def test_dtl_equals_timing_difference_times_tax_rate(self, config_with_dtl):
+        """DTL = (tax_accum_depr - book_accum_depr) * tax_rate."""
+        mfg = WidgetManufacturer(config_with_dtl)
+        mfg.step(growth_rate=0.0, time_resolution="annual")
+
+        tax_accum = mfg.tax_handler.tax_accumulated_depreciation
+        book_accum = mfg.accumulated_depreciation
+        tax_rate = to_decimal(config_with_dtl.tax_rate)
+
+        expected_dtl = max(ZERO, (tax_accum - book_accum) * tax_rate)
+        actual_dtl = mfg.deferred_tax_liability
+
+        assert actual_dtl == expected_dtl
+
+    def test_dtl_in_total_liabilities(self, config_with_dtl):
+        """DTL should be included in total_liabilities."""
+        mfg = WidgetManufacturer(config_with_dtl)
+        mfg.step(growth_rate=0.0, time_resolution="annual")
+
+        dtl = mfg.deferred_tax_liability
+        total_liabilities = mfg.total_liabilities
+        assert dtl > ZERO
+        assert total_liabilities >= dtl
+
+    def test_dtl_reduces_equity(self, config_with_dtl, config_no_dtl):
+        """DTL should reduce equity compared to no-DTL scenario."""
+        mfg_with = WidgetManufacturer(config_with_dtl)
+        mfg_without = WidgetManufacturer(config_no_dtl)
+
+        mfg_with.step(growth_rate=0.0, time_resolution="annual")
+        mfg_without.step(growth_rate=0.0, time_resolution="annual")
+
+        # The DTL journal entry Dr TAX_EXPENSE, Cr DTL
+        # means liabilities go up → equity (A - L) goes down
+        assert mfg_with.equity < mfg_without.equity
+
+    def test_dtl_in_metrics(self, config_with_dtl):
+        """DTL should appear in calculate_metrics output."""
+        mfg = WidgetManufacturer(config_with_dtl)
+        metrics = mfg.step(growth_rate=0.0, time_resolution="annual")
+
+        assert "deferred_tax_liability" in metrics
+        assert metrics["deferred_tax_liability"] > ZERO
+
+    def test_dta_in_metrics(self, config_no_dtl):
+        """DTA should appear in calculate_metrics output."""
+        mfg = WidgetManufacturer(config_no_dtl)
+        metrics = mfg.step(growth_rate=0.0, time_resolution="annual")
+
+        assert "deferred_tax_asset" in metrics
+
+    def test_dtl_multi_period_growth(self, config_with_dtl):
+        """DTL should grow over multiple periods when tax depreciation is faster."""
+        mfg = WidgetManufacturer(config_with_dtl)
+
+        dtl_values = []
+        for _ in range(3):
+            mfg.step(growth_rate=0.0, time_resolution="annual")
+            dtl_values.append(mfg.deferred_tax_liability)
+
+        # DTL should be positive and growing (tax depr outpaces book depr)
+        assert all(dtl > ZERO for dtl in dtl_values)
+
+    def test_dtl_reverses_after_tax_basis_exhausted(self):
+        """DTL should reverse when tax depreciation basis is exhausted."""
+        config = ManufacturerConfig(
+            initial_assets=10_000_000,
+            tax_rate=0.25,
+            nol_carryforward_enabled=True,
+            capex_to_depreciation_ratio=0.0,  # No capex → PP&E eventually fully depreciated
+            tax_depreciation_life_years=3.0,  # Very fast tax depreciation
+        )
+        mfg = WidgetManufacturer(config)
+
+        dtl_values = []
+        for _ in range(12):
+            mfg.step(growth_rate=0.0, time_resolution="annual")
+            dtl_values.append(mfg.deferred_tax_liability)
+
+        # DTL should peak somewhere then reverse as book catches up
+        peak_dtl = max(dtl_values)
+        final_dtl = dtl_values[-1]
+        assert peak_dtl > ZERO, "DTL should peak above zero"
+        # After tax fully depreciated but book still running, DTL should decrease
+        assert final_dtl < peak_dtl, "DTL should reverse after tax basis exhausted"
+
+    def test_accounting_equation_holds_with_dtl(self, config_with_dtl):
+        """Accounting equation (debits = credits) must hold with DTL."""
+        mfg = WidgetManufacturer(config_with_dtl)
+
+        for _ in range(5):
+            mfg.step(growth_rate=0.0, time_resolution="annual")
+
+        is_balanced, difference = mfg.ledger.verify_balance()
+        assert is_balanced, f"Accounting equation violated: difference = {difference}"
+
+    def test_config_default_no_tax_depreciation(self):
+        """Default config should have no accelerated tax depreciation."""
+        config = ManufacturerConfig()
+        assert config.tax_depreciation_life_years is None
+
+    def test_config_tax_depreciation_validation(self):
+        """Config should validate tax_depreciation_life_years bounds."""
+        # Valid values
+        ManufacturerConfig(tax_depreciation_life_years=5.0)
+        ManufacturerConfig(tax_depreciation_life_years=50.0)
+
+        # Invalid: <= 0
+        with pytest.raises(Exception):
+            ManufacturerConfig(tax_depreciation_life_years=0.0)
+        with pytest.raises(Exception):
+            ManufacturerConfig(tax_depreciation_life_years=-1.0)
+
+    def test_ledger_has_dtl_account(self):
+        """DEFERRED_TAX_LIABILITY should exist in ledger AccountName."""
+        assert hasattr(AccountName, "DEFERRED_TAX_LIABILITY")
+        assert AccountName.DEFERRED_TAX_LIABILITY.value == "deferred_tax_liability"
+
+    def test_ledger_has_dtl_adjustment_transaction(self):
+        """DTL_ADJUSTMENT should exist in TransactionType."""
+        assert hasattr(TransactionType, "DTL_ADJUSTMENT")
+        assert TransactionType.DTL_ADJUSTMENT.value == "dtl_adjustment"
+
+
+class TestDTLMonthly:
+    """Test DTL with monthly time resolution."""
+
+    def test_dtl_monthly_accumulation(self):
+        """DTL should accumulate correctly with monthly time resolution."""
+        config = ManufacturerConfig(
+            initial_assets=10_000_000,
+            tax_rate=0.25,
+            capex_to_depreciation_ratio=1.0,
+            tax_depreciation_life_years=5.0,
+        )
+        mfg = WidgetManufacturer(config)
+
+        # Run 12 monthly steps (1 year)
+        for _ in range(12):
+            mfg.step(growth_rate=0.0, time_resolution="monthly")
+
+        dtl = mfg.deferred_tax_liability
+        assert dtl > ZERO, "DTL should be positive after 12 monthly steps"


### PR DESCRIPTION
## Summary

- **Issue #367**: Implement deferred tax liability (DTL) from accelerated tax depreciation per ASC 740. Now that capex (#543) is implemented, ongoing capital expenditures create perpetual book-tax timing differences that make DTL a persistent balance sheet item.
- **Issue #383**: Remove `max(ZERO, capex)` clamp in `_calculate_capex()` that suppressed asset disposals. Negative capex now flows through as "Proceeds from Asset Sales" per ASC 230.

### Issue #367 Changes
- Add `DEFERRED_TAX_LIABILITY` account and `DTL_ADJUSTMENT` transaction type to ledger
- Add `tax_depreciation_life_years` config parameter (defaults to `None` = no DTL for backward compat)
- Track cumulative tax depreciation in `TaxHandler.tax_accumulated_depreciation`
- Compute DTL = `max(0, (tax_accum_depr - book_accum_depr) * tax_rate)` each period
- Include DTL in `total_liabilities` and balance sheet non-current liabilities section
- Update deferred tax expense on income statement to include both DTA and DTL changes
- Add DTA line item to balance sheet assets section when positive
- Add `deferred_tax_asset` and `deferred_tax_liability` to metrics output

### Issue #383 Changes
- Remove `max(ZERO, capex)` clamp that hid asset disposals
- Split signed capex into separate `capital_expenditures` (outflows) and `asset_sales` (inflows)
- Show "Proceeds from Asset Sales" in indirect method output (was previously restricted to direct method only)

## Test plan
- [x] 20 new tests covering both issues (all pass)
- [x] Negative capex correctly returns signed value
- [x] Asset disposals appear as separate line in investing activities
- [x] DTL created with accelerated tax depreciation config
- [x] No DTL with default config (backward compatible)
- [x] DTL = timing_difference * tax_rate
- [x] DTL included in total_liabilities and reduces equity
- [x] DTL reverses after tax basis is exhausted
- [x] Accounting equation (debits = credits) holds with DTL
- [x] Monthly time resolution works correctly
- [x] All 281 existing related tests pass (capex, cash flow, NOL, financial statements, manufacturer)

Closes #367
Closes #383