### PR TITLE
fix: derive current/non-current claim split from development schedules (#466)

### DIFF
--- a/ergodic_insurance/docs/architecture/class_diagrams/data_models.md
+++ b/ergodic_insurance/docs/architecture/class_diagrams/data_models.md
@@ -464,7 +464,6 @@ classDiagram
         +include_percentages: bool
         +fiscal_year_end: int
         +consolidate_monthly: bool
-        +current_claims_ratio: float
     }
 
     FinancialStatementGenerator --> CashFlowStatement : delegates to

--- a/ergodic_insurance/manufacturer_metrics.py
+++ b/ergodic_insurance/manufacturer_metrics.py
@@ -64,6 +64,16 @@ class MetricsCalculationMixin:
         metrics["equity"] = self.equity + va
         metrics["net_assets"] = self.net_assets
         metrics["claim_liabilities"] = self.total_claim_liabilities
+
+        # Current/non-current claim split from development schedules (Issue #466, ASC 450)
+        current_claims = ZERO
+        for claim in self.claim_liabilities:
+            years_since = self.current_year - claim.year_incurred
+            next_year_payment = claim.get_payment(years_since + 1)
+            current_claims += min(next_year_payment, claim.remaining_amount)
+        metrics["current_claim_liabilities"] = current_claims
+        metrics["non_current_claim_liabilities"] = self.total_claim_liabilities - current_claims
+
         metrics["is_solvent"] = not self.is_ruined
 
         # Enhanced balance sheet components


### PR DESCRIPTION
## Summary
- Remove hardcoded `current_claims_ratio` from `FinancialStatementConfig` and compute current/non-current claim liabilities from actual development schedules per ASC 450-20-25
- Manufacturer now provides `current_claim_liabilities` (next-year scheduled payments) and `non_current_claim_liabilities` in metrics, computed from each claim's `ClaimDevelopment` factors
- Financial statements (`_build_liabilities_section` and reconciliation report) consume these metrics directly

Closes #466

## Test plan
- [x] Updated `test_configurable_current_claims_ratio` → `test_current_claims_from_development_schedule` to verify balance sheet uses manufacturer-provided split
- [x] All 40 financial statement tests pass
- [x] All 66 manufacturer tests pass
- [x] All 41 claim development tests pass
- [x] All 9 accrual integration tests pass
- [x] Pre-commit hooks pass (black, isort, mypy, pylint)