### PR TITLE
fix: apply tax to MC simulation net income per ASC 740 (#500)

### DIFF
--- a/ergodic_insurance/decision_engine.py
+++ b/ergodic_insurance/decision_engine.py
@@ -1349,10 +1349,13 @@ class InsuranceDecisionEngine:
                         if remaining_loss <= 0:
                             break
 
-                # Calculate net income
+                # Calculate net income with tax per ASC 740 (Issue #500)
                 operating_income = revenue * self.manufacturer.base_operating_margin
                 net_losses = retained_losses + max(annual_losses - decision.total_coverage, 0)
-                net_income = operating_income - net_losses - decision.total_premium
+                income_before_tax = operating_income - net_losses - decision.total_premium
+                tax_rate = getattr(self.manufacturer, "tax_rate", 0.25)
+                tax_expense = max(0.0, income_before_tax * tax_rate)
+                net_income = income_before_tax - tax_expense
 
                 # Calculate ROE before updating equity
                 if equity > 0:


### PR DESCRIPTION
## Summary
- Apply `manufacturer.tax_rate` to positive `income_before_tax` inside `_run_simulation()` so ROE, growth rates, and bankruptcy probabilities reflect after-tax economics
- Tax expense is zero for loss years (negative income), consistent with simplified ASC 740 treatment
- Tax rate is sourced from manufacturer config via `getattr` with 0.25 default fallback

Closes #500

## Test plan
- [x] `test_tax_reduces_simulation_growth_rates` — higher tax rate → lower growth
- [x] `test_tax_reduces_simulation_roe` — higher tax rate → lower ROE
- [x] `test_zero_tax_matches_pretax_income` — zero tax gives higher terminal equity
- [x] `test_tax_not_applied_to_losses` — negative income → no tax expense
- [x] `test_tax_rate_sourced_from_manufacturer` — custom rate produces distinct results
- [x] `test_tax_increases_bankruptcy_probability` — tax can increase bankruptcy risk
- [x] All 41 existing `test_decision_engine.py` tests pass
- [x] All 80 tests across `test_decision_engine*.py` and `test_tax_handling.py` pass