### PR TITLE
fix: warn on pre-cutoff balance queries and include pruned totals in verify_balance (#362)

### DIFF
--- a/ergodic_insurance/ledger.py
+++ b/ergodic_insurance/ledger.py
@@ -35,6 +35,7 @@ from decimal import Decimal
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, Union
 import uuid
+import warnings
 
 from .decimal_utils import ZERO, to_decimal
 
@@ -417,6 +418,9 @@ class Ledger:
         # Snapshot of balances at the prune point (Issue #315)
         self._pruned_balances: Dict[str, Decimal] = {}
         self._prune_cutoff: Optional[int] = None
+        # Aggregate debit/credit totals for pruned entries (Issue #362)
+        self._pruned_debits: Decimal = ZERO
+        self._pruned_credits: Decimal = ZERO
 
     def _update_balance_cache(self, entry: LedgerEntry) -> None:
         """Update running balance cache after recording an entry.
@@ -623,6 +627,15 @@ class Ledger:
         # O(1) lookup for current balance (Issue #259)
         if as_of_date is None:
             return self._balances.get(account_str, ZERO)
+
+        # Warn when querying dates in the pruned range (Issue #362)
+        if self._prune_cutoff is not None and as_of_date < self._prune_cutoff:
+            warnings.warn(
+                f"as_of_date {as_of_date} is before prune cutoff "
+                f"{self._prune_cutoff}; returned balance reflects the "
+                f"prune-point snapshot, not the true historical balance",
+                stacklevel=2,
+            )
 
         # Historical query: iterate through entries (less frequent use case)
         account_type = self.chart_of_accounts.get(account_str, AccountType.ASSET)
@@ -909,11 +922,11 @@ class Ledger:
                 if not balanced:
                     print(f"Warning: Ledger out of balance by ${diff:,.2f}")
         """
-        total_debits = sum(
+        total_debits = self._pruned_debits + sum(
             (e.amount for e in self.entries if e.entry_type == EntryType.DEBIT),
             ZERO,
         )
-        total_credits = sum(
+        total_credits = self._pruned_credits + sum(
             (e.amount for e in self.entries if e.entry_type == EntryType.CREDIT),
             ZERO,
         )
@@ -951,6 +964,15 @@ class Ledger:
                 for account, balance in sorted(self._balances.items())
                 if balance != ZERO
             }
+
+        # Warn when querying dates in the pruned range (Issue #362)
+        if self._prune_cutoff is not None and as_of_date < self._prune_cutoff:
+            warnings.warn(
+                f"as_of_date {as_of_date} is before prune cutoff "
+                f"{self._prune_cutoff}; returned balances reflect the "
+                f"prune-point snapshot, not true historical balances",
+                stacklevel=2,
+            )
 
         # O(N) single-pass: accumulate per-account balances in one iteration
         # Include any pruned snapshot balances as starting points
@@ -1009,6 +1031,10 @@ class Ledger:
         if self._pruned_balances:
             snapshot = dict(self._pruned_balances)
 
+        # Track aggregate debit/credit totals for verify_balance (Issue #362)
+        pruned_debits = self._pruned_debits
+        pruned_credits = self._pruned_credits
+
         kept: List[LedgerEntry] = []
         removed = 0
         for entry in self.entries:
@@ -1028,6 +1054,11 @@ class Ledger:
                         snapshot[account] += entry.amount
                     else:
                         snapshot[account] -= entry.amount
+                # Track raw debit/credit for verify_balance
+                if entry.entry_type == EntryType.DEBIT:
+                    pruned_debits += entry.amount
+                else:
+                    pruned_credits += entry.amount
                 removed += 1
             else:
                 kept.append(entry)
@@ -1035,6 +1066,8 @@ class Ledger:
         self.entries = kept
         self._pruned_balances = snapshot
         self._prune_cutoff = before_date
+        self._pruned_debits = pruned_debits
+        self._pruned_credits = pruned_credits
         return removed
 
     def clear(self) -> None:
@@ -1047,6 +1080,8 @@ class Ledger:
         self._balances.clear()
         self._pruned_balances.clear()
         self._prune_cutoff = None
+        self._pruned_debits = ZERO
+        self._pruned_credits = ZERO
 
     def __len__(self) -> int:
         """Return the number of entries in the ledger."""
@@ -1085,8 +1120,10 @@ class Ledger:
         # Deep copy balance cache
         result._balances = copy.deepcopy(self._balances, memo)
 
-        # Deep copy pruning state (Issue #315)
+        # Deep copy pruning state (Issue #315, #362)
         result._pruned_balances = copy.deepcopy(self._pruned_balances, memo)
         result._prune_cutoff = self._prune_cutoff
+        result._pruned_debits = self._pruned_debits
+        result._pruned_credits = self._pruned_credits
 
         return result


### PR DESCRIPTION
## Summary
- **`get_balance()`** and **`get_trial_balance()`** now emit a `warnings.warn()` when `as_of_date` falls before the prune cutoff, informing callers the returned value is approximate
- **`verify_balance()`** now includes pruned debit/credit totals (`_pruned_debits`, `_pruned_credits`) so the accounting equation check remains correct after pruning
- Updated `prune_entries()`, `clear()`, and `__deepcopy__()` to maintain the new fields

Closes #362

## Test plan
- [x] `test_get_balance_warns_before_prune_cutoff` — warning emitted for pre-cutoff queries
- [x] `test_get_balance_no_warning_at_cutoff` / `test_get_balance_no_warning_after_cutoff` — no false warnings
- [x] `test_get_balance_no_warning_without_pruning` — no warning on unpruned ledger
- [x] `test_get_trial_balance_warns_before_prune_cutoff` / `test_get_trial_balance_no_warning_at_cutoff`
- [x] `test_verify_balance_correct_after_pruning` — balanced after single prune
- [x] `test_verify_balance_correct_after_multiple_prunes` — balanced across successive prunes
- [x] `test_verify_balance_correct_after_pruning_all` — balanced when all entries pruned
- [x] `test_verify_balance_detects_imbalance_after_pruning` — imbalance preserved through prune
- [x] `test_pruned_state_reset_on_clear` — `clear()` resets new fields
- [x] `test_deepcopy_preserves_pruned_totals` — `deepcopy` copies new fields
- [x] All 8 existing `TestEntryPruning` tests still pass
- [x] All 19 `test_ledger_coverage.py` tests still pass