### PR TITLE
fix: resolve insurance coverage calculation inconsistencies (#361)

### DIFF
--- a/ergodic_insurance/insurance.py
+++ b/ergodic_insurance/insurance.py
@@ -279,18 +279,19 @@ class InsurancePolicy:
 
         # Company pays the deductible
         company_payment = min(claim_amount, self.deductible)
-        remaining_loss = claim_amount - company_payment
+        remaining_insurable = claim_amount - company_payment
 
         # Process through insurance layers
         insurance_recovery = 0.0
         for layer in self.layers:
-            if remaining_loss <= 0:
+            if remaining_insurable <= 0:
                 break
 
             # Calculate recovery from this layer
             layer_recovery = layer.calculate_recovery(claim_amount)
+            layer_recovery = min(layer_recovery, remaining_insurable)
             insurance_recovery += layer_recovery
-            remaining_loss -= layer_recovery
+            remaining_insurable -= layer_recovery
 
         # Guard: total insurance recovery cannot exceed (claim - deductible)
         max_recoverable = claim_amount - min(claim_amount, self.deductible)
@@ -325,11 +326,14 @@ class InsurancePolicy:
             return 0.0
 
         # Process through insurance layers
+        remaining_insurable = claim_amount - self.deductible
         insurance_recovery = 0.0
         for layer in self.layers:
             # Calculate recovery from this layer
             layer_recovery = layer.calculate_recovery(claim_amount)
+            layer_recovery = min(layer_recovery, remaining_insurable)
             insurance_recovery += layer_recovery
+            remaining_insurable -= layer_recovery
 
         # Guard: total recovery cannot exceed (claim - deductible)
         max_recoverable = claim_amount - self.deductible
@@ -440,7 +444,7 @@ class InsurancePolicy:
             layer_top = layer.attachment_point + layer.limit
             max_coverage = max(max_coverage, layer_top)
 
-        return max_coverage - self.deductible
+        return max(0.0, max_coverage - self.deductible)
 
     def to_enhanced_program(self) -> Optional["InsuranceProgram"]:
         """Convert to enhanced InsuranceProgram for advanced features.

--- a/ergodic_insurance/insurance_program.py
+++ b/ergodic_insurance/insurance_program.py
@@ -80,6 +80,7 @@ class EnhancedInsuranceLayer:
     premium_rate_exposure: Optional["ExposureBase"] = (
         None  # Exposure object for dynamic premium scaling
     )
+    exhausted: float = field(default=0.0, init=False)
 
     def __post_init__(self):
         """Validate layer parameters."""
@@ -87,8 +88,6 @@ class EnhancedInsuranceLayer:
             raise ValueError(f"Attachment point must be non-negative, got {self.attachment_point}")
         if self.limit <= 0:
             raise ValueError(f"Limit must be positive, got {self.limit}")
-        # Initialize exhausted tracking
-        self.exhausted = 0.0
         if self.base_premium_rate < 0:
             raise ValueError(
                 f"Base premium rate must be non-negative, got {self.base_premium_rate}"
@@ -716,7 +715,7 @@ class InsuranceProgram:
         # Find highest exhaustion point
         max_coverage = max(layer.attachment_point + layer.limit for layer in self.layers)
 
-        return max_coverage
+        return max(0.0, max_coverage - self.deductible)
 
     def _get_default_manufacturer_profile(self) -> Dict[str, Any]:
         """Get default manufacturer profile."""

--- a/ergodic_insurance/simulation.py
+++ b/ergodic_insurance/simulation.py
@@ -1114,12 +1114,11 @@ class Simulation:
             survival_rate = float(np.mean(final_assets > 0)) if len(final_assets) > 0 else 0.0
             mean_final = float(np.mean(final_assets)) if len(final_assets) > 0 else 0.0
             std_final = float(np.std(final_assets, ddof=1)) if len(final_assets) > 1 else 0.0
-            positive_rates = growth_rates[growth_rates > 0]
-            geo_mean = (
-                float(np.exp(np.mean(np.log(positive_rates))) - 1)
-                if len(positive_rates) > 0
-                else 0.0
-            )
+            if len(growth_rates) > 0:
+                growth_factors = np.maximum(1 + growth_rates, 1e-10)
+                geo_mean = float(np.exp(np.mean(np.log(growth_factors))) - 1)
+            else:
+                geo_mean = 0.0
             arith_mean = float(np.mean(growth_rates)) if len(growth_rates) > 0 else 0.0
             p95 = float(np.percentile(final_assets, 95)) if len(final_assets) > 0 else 0.0
             p99 = float(np.percentile(final_assets, 99)) if len(final_assets) > 0 else 0.0


### PR DESCRIPTION
## Summary
- **Bug 1**: Clamp `InsurancePolicy.get_total_coverage()` with `max(0.0, ...)` to prevent negative return values used as divisors downstream
- **Bug 2**: Align `InsuranceProgram.get_total_coverage()` to subtract deductible, making it consistent with `InsurancePolicy`
- **Bug 3**: Promote `EnhancedInsuranceLayer.exhausted` from dynamic attribute to dataclass field so it participates in `asdict()` and `__eq__`
- **Bug 4**: Fix geometric mean in `compare_insurance_strategies` to use all growth rates via growth factors (`np.maximum(1 + rates, 1e-10)`) instead of filtering to positive-only (selection bias)
- **Bug 5**: Cap per-layer recovery at remaining insurable loss in both `process_claim()` and `calculate_recovery()` to prevent over-allocation when layers overlap the deductible region

## Files changed
| File | Changes |
|------|---------|
| `ergodic_insurance/insurance.py` | Bugs 1 & 5 |
| `ergodic_insurance/insurance_program.py` | Bugs 2 & 3 |
| `ergodic_insurance/simulation.py` | Bug 4 |
| `ergodic_insurance/tests/test_insurance.py` | 2 new tests |
| `ergodic_insurance/tests/test_insurance_program.py` | 4 new tests |
| `ergodic_insurance/tests/test_simulation_coverage.py` | 1 updated + 1 new test |

## Test plan
- [x] All 135 tests pass in `test_insurance.py`, `test_insurance_program.py`, `test_simulation_coverage.py`
- [x] All 82 tests pass in `test_insurance_coverage.py`, `test_insurance_program_coverage.py`, `integration/test_insurance_stack.py`
- [x] Pre-commit hooks pass (black, isort, mypy, pylint, conventional commit)
- [ ] Verify no downstream regressions in Monte Carlo / simulation workflows