### PR TITLE
fix: document CV=1.0 default and log info when loss_severity_std is omitted (#463)

### DIFF
--- a/ergodic_insurance/_run_analysis.py
+++ b/ergodic_insurance/_run_analysis.py
@@ -389,7 +389,11 @@ def run_analysis(
             (Poisson lambda).
         loss_severity_mean: Mean loss size in dollars.
         loss_severity_std: Standard deviation of loss size.
-            Defaults to *loss_severity_mean* if not provided.
+            Defaults to *loss_severity_mean* if not provided, implying a
+            coefficient of variation (CV) of 1.0.  Typical CV ranges by
+            line of business: property 0.5–1.5, general liability 1.0–3.0,
+            workers' compensation 1.0–2.0.  Set explicitly when your loss
+            data suggests a different CV.
         deductible: Self-insured retention in dollars.
         coverage_limit: Maximum insurance payout per occurrence.
         premium_rate: Annual premium as a fraction of
@@ -435,6 +439,10 @@ def run_analysis(
     """
     if loss_severity_std is None:
         loss_severity_std = loss_severity_mean
+        logger.info(
+            "loss_severity_std not provided; defaulting to loss_severity_mean " "(CV=1.0): %.2f",
+            loss_severity_std,
+        )
 
     # --- Build configuration ---
     config = Config.from_company(

--- a/ergodic_insurance/tests/test_run_analysis.py
+++ b/ergodic_insurance/tests/test_run_analysis.py
@@ -121,6 +121,38 @@ class TestRunAnalysis:
         )
         assert len(results.insured_results) == 2
 
+    def test_default_severity_std_logs_info(self, caplog):
+        """Omitting loss_severity_std emits an info-level log (#463)."""
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="ergodic_insurance._run_analysis"):
+            run_analysis(
+                loss_severity_mean=1_000_000,
+                n_simulations=2,
+                time_horizon=3,
+                seed=0,
+                compare_uninsured=False,
+            )
+        assert any(
+            "loss_severity_std not provided" in rec.message and "CV=1.0" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_explicit_severity_std_no_warning(self, caplog):
+        """Providing loss_severity_std explicitly should NOT emit the default log."""
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="ergodic_insurance._run_analysis"):
+            run_analysis(
+                loss_severity_mean=1_000_000,
+                loss_severity_std=500_000,
+                n_simulations=2,
+                time_horizon=3,
+                seed=0,
+                compare_uninsured=False,
+            )
+        assert not any("loss_severity_std not provided" in rec.message for rec in caplog.records)
+
     def test_config_preserved(self):
         results = run_analysis(
             initial_assets=7_000_000,


### PR DESCRIPTION
## Summary
- Expands the `loss_severity_std` docstring with CV=1.0 explanation and typical CV ranges by line of business (property 0.5–1.5, GL 1.0–3.0, WC 1.0–2.0)
- Emits `logger.info` when `loss_severity_std` defaults to `loss_severity_mean`
- Adds two tests: one verifying the log is emitted on default, one verifying it is NOT emitted when the parameter is provided explicitly

## Test plan
- [x] `test_default_severity_std_logs_info` — confirms info log with "CV=1.0" is emitted when `loss_severity_std` is omitted
- [x] `test_explicit_severity_std_no_warning` — confirms no default log when `loss_severity_std` is provided
- [x] All 27 tests in `test_run_analysis.py` pass

Closes #463