### PR TITLE
fix: replace bare print() warnings with logging/warnings module (#382)

### DIFF
--- a/ergodic_insurance/__init__.py
+++ b/ergodic_insurance/__init__.py
@@ -127,6 +127,11 @@ __all__ = [
     "EntryType",
     "AccountType",
     "AccountName",
+    # Warning classes
+    "ErgodicInsuranceWarning",
+    "ConfigurationWarning",
+    "DataQualityWarning",
+    "ExportWarning",
 ]
 
 
@@ -316,6 +321,20 @@ def __getattr__(name):
             Ledger,
             LedgerEntry,
             TransactionType,
+        )
+
+        return locals()[name]
+    if name in (
+        "ErgodicInsuranceWarning",
+        "ConfigurationWarning",
+        "DataQualityWarning",
+        "ExportWarning",
+    ):
+        from ._warnings import (  # pylint: disable=import-outside-toplevel,possibly-unused-variable
+            ConfigurationWarning,
+            DataQualityWarning,
+            ErgodicInsuranceWarning,
+            ExportWarning,
         )
 
         return locals()[name]

--- a/ergodic_insurance/_warnings.py
+++ b/ergodic_insurance/_warnings.py
@@ -1,0 +1,49 @@
+"""Custom warning classes for the Ergodic Insurance package.
+
+These warning classes allow users to programmatically filter, suppress,
+or capture warnings using Python's standard ``warnings`` module.
+
+Example:
+    Suppress all configuration warnings in a batch run::
+
+        import warnings
+        from ergodic_insurance._warnings import ConfigurationWarning
+
+        warnings.filterwarnings("ignore", category=ConfigurationWarning)
+
+    Capture data-quality warnings during simulation::
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always", DataQualityWarning)
+            # ... run simulation ...
+            quality_issues = [x for x in w if issubclass(x.category, DataQualityWarning)]
+"""
+
+
+class ErgodicInsuranceWarning(UserWarning):
+    """Base class for all ergodic-insurance warnings."""
+
+
+class ConfigurationWarning(ErgodicInsuranceWarning):
+    """Unusual or potentially incorrect configuration parameters.
+
+    Raised during config validation when parameter values fall outside
+    typical ranges (e.g., unusually high operating margins, negative
+    cash-conversion cycles).
+    """
+
+
+class DataQualityWarning(ErgodicInsuranceWarning):
+    """Runtime data-quality observations.
+
+    Raised when simulation or analysis encounters data anomalies such as
+    non-finite values, unexpected distributions, or duration mismatches.
+    """
+
+
+class ExportWarning(ErgodicInsuranceWarning):
+    """Issues encountered while exporting visualizations.
+
+    Raised when a requested export format is unavailable (e.g., missing
+    *kaleido* for static Plotly images) and a fallback is used instead.
+    """

--- a/ergodic_insurance/ledger.py
+++ b/ergodic_insurance/ledger.py
@@ -920,7 +920,10 @@ class Ledger:
 
                 balanced, diff = ledger.verify_balance()
                 if not balanced:
-                    print(f"Warning: Ledger out of balance by ${diff:,.2f}")
+                    warnings.warn(
+                        f"Ledger out of balance by ${diff:,.2f}",
+                        stacklevel=2,
+                    )
         """
         total_debits = self._pruned_debits + sum(
             (e.amount for e in self.entries if e.entry_type == EntryType.DEBIT),

--- a/ergodic_insurance/sensitivity.py
+++ b/ergodic_insurance/sensitivity.py
@@ -29,12 +29,17 @@ Example:
             metric="optimal_roe"
         )
 
+.. versionchanged:: 0.7.0
+    Replaced bare ``print()`` warning calls with ``logging.warning()``.
+    See :issue:`382`.
+
 Author: Alex Filiakov
 Date: 2025-01-29
 """
 
 from dataclasses import dataclass
 import hashlib
+import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -42,6 +47,8 @@ import numpy as np
 import pandas as pd
 
 from .safe_pickle import safe_dump, safe_load
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -506,7 +513,7 @@ class SensitivityAnalyzer:
 
             except (KeyError, Exception) as e:  # pylint: disable=broad-exception-caught
                 # Skip parameters that cause errors
-                print(f"Warning: Could not analyze parameter '{param_name}': {e}")
+                logger.warning("Could not analyze parameter '%s': %s", param_name, e)
                 continue
 
         # Create DataFrame and sort by impact
@@ -708,6 +715,6 @@ class SensitivityAnalyzer:
                 )
                 results[param_name] = result
             except Exception as e:  # pylint: disable=broad-exception-caught
-                print(f"Warning: Could not analyze '{param_name}': {e}")
+                logger.warning("Could not analyze '%s': %s", param_name, e)
 
         return results

--- a/ergodic_insurance/tests/test_print_warnings_382.py
+++ b/ergodic_insurance/tests/test_print_warnings_382.py
@@ -1,0 +1,209 @@
+"""Tests for issue #382: replace print() warnings with logging/warnings module.
+
+Verifies that:
+- Custom warning classes exist and have the correct hierarchy.
+- Modules that previously used print() for warnings now use logging.warning().
+- No bare print("Warning: ...") calls remain in the package source.
+"""
+
+import logging
+from unittest.mock import MagicMock
+import warnings
+
+import pytest
+
+from ergodic_insurance._warnings import (
+    ConfigurationWarning,
+    DataQualityWarning,
+    ErgodicInsuranceWarning,
+    ExportWarning,
+)
+
+# ---------------------------------------------------------------------------
+# Warning class hierarchy
+# ---------------------------------------------------------------------------
+
+
+class TestWarningClassHierarchy:
+    """Custom warning classes have the expected inheritance chain."""
+
+    def test_base_is_user_warning(self):
+        assert issubclass(ErgodicInsuranceWarning, UserWarning)
+
+    def test_configuration_warning(self):
+        assert issubclass(ConfigurationWarning, ErgodicInsuranceWarning)
+        assert issubclass(ConfigurationWarning, UserWarning)
+
+    def test_data_quality_warning(self):
+        assert issubclass(DataQualityWarning, ErgodicInsuranceWarning)
+        assert issubclass(DataQualityWarning, UserWarning)
+
+    def test_export_warning(self):
+        assert issubclass(ExportWarning, ErgodicInsuranceWarning)
+        assert issubclass(ExportWarning, UserWarning)
+
+    def test_can_be_raised_and_caught(self):
+        with pytest.warns(ConfigurationWarning):
+            warnings.warn("test", ConfigurationWarning)
+
+    def test_filterable(self):
+        """Users can suppress warnings by category."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            warnings.filterwarnings("ignore", category=ConfigurationWarning)
+            warnings.warn("should be suppressed", ConfigurationWarning)
+            warnings.warn("should appear", DataQualityWarning)
+            assert len(w) == 1
+            assert issubclass(w[0].category, DataQualityWarning)
+
+
+# ---------------------------------------------------------------------------
+# Package-level lazy imports
+# ---------------------------------------------------------------------------
+
+
+class TestPackageLevelImports:
+    """Warning classes are accessible from the top-level package."""
+
+    def test_import_from_package(self):
+        import ergodic_insurance  # pylint: disable=reimported
+
+        for name in (
+            "ConfigurationWarning",
+            "DataQualityWarning",
+            "ErgodicInsuranceWarning",
+            "ExportWarning",
+        ):
+            cls = getattr(ergodic_insurance, name)
+            assert issubclass(cls, UserWarning)
+
+    def test_in_all(self):
+        import ergodic_insurance
+
+        for name in (
+            "ErgodicInsuranceWarning",
+            "ConfigurationWarning",
+            "DataQualityWarning",
+            "ExportWarning",
+        ):
+            assert name in ergodic_insurance.__all__
+
+
+# ---------------------------------------------------------------------------
+# sensitivity.py — logging instead of print
+# ---------------------------------------------------------------------------
+
+
+class TestSensitivityLogging:
+    """sensitivity.py uses logger.warning() instead of print()."""
+
+    def test_analyze_one_way_logs_on_error(self, caplog):
+        """create_tornado_diagram logs when a parameter fails analysis."""
+        from ergodic_insurance.sensitivity import SensitivityAnalyzer
+
+        # Build a minimal mock optimizer whose run always raises
+        mock_optimizer = MagicMock()
+        mock_optimizer.optimize.side_effect = RuntimeError("boom")
+
+        analyzer = SensitivityAnalyzer.__new__(SensitivityAnalyzer)
+        analyzer.base_config = MagicMock()
+        analyzer.optimizer = mock_optimizer
+        analyzer.results_cache = {}
+
+        with caplog.at_level(logging.WARNING, logger="ergodic_insurance.sensitivity"):
+            # analyze_parameter will raise; tornado diagram skips it
+            df = analyzer.create_tornado_diagram(
+                parameters=["bad_param"],
+                metric="optimal_roe",
+            )
+
+        assert any("bad_param" in r.message for r in caplog.records)
+        assert all(r.levelno == logging.WARNING for r in caplog.records if "bad_param" in r.message)
+
+    def test_analyze_parameter_group_logs_on_error(self, caplog):
+        """analyze_parameter_group logs when a parameter fails analysis."""
+        from ergodic_insurance.sensitivity import SensitivityAnalyzer
+
+        mock_optimizer = MagicMock()
+        mock_optimizer.optimize.side_effect = RuntimeError("boom")
+
+        analyzer = SensitivityAnalyzer.__new__(SensitivityAnalyzer)
+        analyzer.base_config = MagicMock()
+        analyzer.optimizer = mock_optimizer
+        analyzer.results_cache = {}
+
+        with caplog.at_level(logging.WARNING, logger="ergodic_insurance.sensitivity"):
+            results = analyzer.analyze_parameter_group({"bad_param": (0, 1)}, n_points=3)
+
+        assert any("bad_param" in r.message for r in caplog.records)
+        assert results == {}
+
+
+# ---------------------------------------------------------------------------
+# visualization/export.py — logging instead of print
+# ---------------------------------------------------------------------------
+
+
+class TestExportLogging:
+    """visualization/export.py uses logger.warning() instead of print()."""
+
+    def test_save_figure_logs_on_kaleido_missing(self, caplog, tmp_path):
+        """save_figure logs when plotly static export fails."""
+        import plotly.graph_objects as go
+
+        from ergodic_insurance.visualization.export import save_figure
+
+        fig = go.Figure()
+        fig.write_image = MagicMock(side_effect=ValueError("kaleido not installed"))
+
+        with caplog.at_level(logging.WARNING, logger="ergodic_insurance.visualization.export"):
+            result = save_figure(fig, str(tmp_path / "test"), formats=["png"])
+
+        assert any("kaleido" in r.message for r in caplog.records)
+        assert all(r.levelno == logging.WARNING for r in caplog.records if "kaleido" in r.message)
+
+    def test_save_for_presentation_logs_on_kaleido_missing(self, caplog, tmp_path):
+        """save_for_presentation logs when plotly static export fails."""
+        import plotly.graph_objects as go
+
+        from ergodic_insurance.visualization.export import save_for_presentation
+
+        fig = go.Figure()
+        fig.write_image = MagicMock(side_effect=ValueError("kaleido not installed"))
+
+        with caplog.at_level(logging.WARNING, logger="ergodic_insurance.visualization.export"):
+            save_for_presentation(fig, str(tmp_path / "pub"))
+
+        assert any("kaleido" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# No remaining print("Warning: …") in package source
+# ---------------------------------------------------------------------------
+
+
+class TestNoBareWarningPrints:
+    """Ensure no print('Warning: ...') calls remain in package source."""
+
+    def test_no_print_warnings_in_source(self):
+        """Scan all .py source files for print('Warning: ...')."""
+        from pathlib import Path
+        import re
+
+        pkg_root = Path(__file__).resolve().parent.parent
+        pattern = re.compile(r"""print\(f?['"]Warning:""")
+
+        violations = []
+        for py_file in pkg_root.rglob("*.py"):
+            # Skip tests and notebooks
+            rel = py_file.relative_to(pkg_root)
+            if "tests" in rel.parts or "notebooks" in rel.parts:
+                continue
+            text = py_file.read_text(encoding="utf-8", errors="replace")
+            for i, line in enumerate(text.splitlines(), 1):
+                if pattern.search(line):
+                    violations.append(f"{rel}:{i}: {line.strip()}")
+
+        assert violations == [], "Found bare print() warnings in package source:\n" + "\n".join(
+            violations
+        )

--- a/ergodic_insurance/visualization/export.py
+++ b/ergodic_insurance/visualization/export.py
@@ -2,13 +2,20 @@
 
 This module provides functions to export visualizations to different formats
 including high-resolution images, PDFs, and web-ready formats.
+
+.. versionchanged:: 0.7.0
+    Replaced bare ``print()`` warning calls with ``logging.warning()``.
+    See :issue:`382`.
 """
 
+import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 from matplotlib.figure import Figure
 import plotly.graph_objects as go
+
+logger = logging.getLogger(__name__)
 
 
 def save_figure(
@@ -93,8 +100,12 @@ def save_figure(
                     )
                     saved_files.append(str(output_path))
                 except Exception as e:
-                    print(f"Warning: Could not save plotly figure as {fmt}: {e}")
-                    print("Install kaleido for static image export: pip install kaleido")
+                    logger.warning(
+                        "Could not save plotly figure as %s: %s. "
+                        "Install kaleido for static image export: pip install kaleido",
+                        fmt,
+                        e,
+                    )
             else:
                 raise ValueError(f"Unsupported format for plotly: {fmt}")
     else:
@@ -211,8 +222,11 @@ def save_for_presentation(
                 scale=1,
             )
         except Exception as e:
-            print(f"Warning: Could not save plotly figure: {e}")
-            print("Install kaleido for static image export: pip install kaleido")
+            logger.warning(
+                "Could not save plotly figure: %s. "
+                "Install kaleido for static image export: pip install kaleido",
+                e,
+            )
             # Fallback to HTML
             output_path = f"{filename}.html"
             fig.write_html(output_path)


### PR DESCRIPTION
## Summary

- Defines custom warning classes (`ErgodicInsuranceWarning`, `ConfigurationWarning`, `DataQualityWarning`, `ExportWarning`) in `_warnings.py` and exports them from the package via lazy imports
- Converts `sensitivity.py` print-based warnings to `logger.warning()` (runtime observations)
- Converts `visualization/export.py` print-based warnings to `logger.warning()` (runtime observations)
- Updates `ledger.py` docstring example to use `warnings.warn()` instead of `print()`
- Adds 13 tests covering the warning class hierarchy, package-level imports, logging behavior, and a source scan ensuring no `print("Warning: ...")` calls remain

Closes #382

## Test plan
- [x] All 13 new tests in `test_print_warnings_382.py` pass
- [x] Existing `test_sensitivity.py` (26 tests) pass
- [x] Existing `test_ledger.py` (79 tests) pass
- [x] `TestNoBareWarningPrints` source scan confirms zero remaining print-based warnings
- [x] Pre-commit hooks (black, isort, mypy, pylint, mixed-line-ending) all pass