### PR TITLE
fix: reject unsupported industries and verify IndustryConfig validation (#460, #462)

### DIFF
--- a/ergodic_insurance/config/core.py
+++ b/ergodic_insurance/config/core.py
@@ -131,7 +131,14 @@ class Config(BaseModel):
             },
         }
 
-        defaults = industry_defaults.get(industry, industry_defaults["manufacturing"])
+        if industry not in industry_defaults:
+            supported = ", ".join(sorted(industry_defaults.keys()))
+            raise ValueError(
+                f"Unsupported industry '{industry}'. "
+                f"Supported values: {supported}. "
+                f"Use Config() with explicit sub-configs for other industries."
+            )
+        defaults = industry_defaults[industry]
 
         return cls(
             manufacturer=ManufacturerConfig(


### PR DESCRIPTION
## Summary
- **#460**: `Config.from_company()` now raises `ValueError` for unsupported industry values instead of silently falling back to manufacturing defaults. The error message lists all supported values and suggests using `Config()` with explicit sub-configs as an alternative.
- **#462**: `IndustryConfig` and its subclasses (`ManufacturingConfig`, `ServiceConfig`, `RetailConfig`) are already Pydantic `BaseModel` instances with `Field` validators and `@model_validator`. Added a comprehensive test suite (`TestIndustryConfigValidationRobustness`) that verifies no `assert`-based validation exists in the source and that all constraints are enforced via Pydantic.

## Test plan
- [x] `Config.from_company(industry="technology")` raises `ValueError`
- [x] Error message lists all supported industry values (manufacturing, retail, service)
- [x] Error message suggests alternative approach for unsupported industries
- [x] Docstring for `industry` parameter lists valid values
- [x] `IndustryConfig` validation cannot be bypassed with `python -O` (Pydantic-based)
- [x] All subclasses validated (ManufacturingConfig, ServiceConfig, RetailConfig)
- [x] 130 config-related tests pass, 30 industry config tests pass

Closes #460, closes #462