### PR TITLE
fix: clarify tail_index docstring — returns Pareto alpha, not Hill gamma (#507)

### DIFF
--- a/ergodic_insurance/notebooks/05_risk_metrics.ipynb
+++ b/ergodic_insurance/notebooks/05_risk_metrics.ipynb
@@ -171,28 +171,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Calculate additional metrics\n",
-    "print(\"\\nAdditional Risk Metrics\\n\" + \"=\"*40)\n",
-    "\n",
-    "# Expected Shortfall at VaR(99%) threshold\n",
-    "var_99 = var_results[0.99]\n",
-    "es_99 = metrics.expected_shortfall(var_99)\n",
-    "print(f\"Expected Shortfall (99% threshold): ${es_99:,.0f}\")\n",
-    "\n",
-    "# Economic Capital\n",
-    "ec_999 = metrics.economic_capital(0.999)\n",
-    "print(f\"Economic Capital (99.9%): ${ec_999:,.0f}\")\n",
-    "\n",
-    "# Maximum Drawdown\n",
-    "max_dd = metrics.maximum_drawdown()\n",
-    "print(f\"Maximum Drawdown: ${max_dd:,.0f}\")\n",
-    "\n",
-    "# Tail Index (heaviness of tail)\n",
-    "tail_idx = metrics.tail_index()\n",
-    "print(f\"Tail Index (Hill estimator): {tail_idx:.2f}\")\n",
-    "print(f\"  → {'Heavy' if tail_idx < 3 else 'Moderate'} tail\")"
-   ]
+   "source": "# Calculate additional metrics\nprint(\"\\nAdditional Risk Metrics\\n\" + \"=\"*40)\n\n# Expected Shortfall at VaR(99%) threshold\nvar_99 = var_results[0.99]\nes_99 = metrics.expected_shortfall(var_99)\nprint(f\"Expected Shortfall (99% threshold): ${es_99:,.0f}\")\n\n# Economic Capital\nec_999 = metrics.economic_capital(0.999)\nprint(f\"Economic Capital (99.9%): ${ec_999:,.0f}\")\n\n# Maximum Drawdown\nmax_dd = metrics.maximum_drawdown()\nprint(f\"Maximum Drawdown: ${max_dd:,.0f}\")\n\n# Tail Index (heaviness of tail)\ntail_idx = metrics.tail_index()\nprint(f\"Tail Index (Pareto alpha via Hill's method): {tail_idx:.2f}\")\nprint(f\"  → {'Heavy' if tail_idx < 3 else 'Moderate'} tail\")"
   },
   {
    "cell_type": "markdown",

--- a/ergodic_insurance/risk_metrics.py
+++ b/ergodic_insurance/risk_metrics.py
@@ -478,16 +478,23 @@ class RiskMetrics:
         return return_periods, np.array(loss_values)
 
     def tail_index(self, threshold: Optional[float] = None) -> float:
-        """Estimate tail index using Hill estimator.
+        """Estimate the Pareto tail index alpha via Hill's method.
 
-        The tail index characterizes the heaviness of the tail.
-        Lower values indicate heavier tails.
+        Computes the Pareto shape parameter alpha (= 1 / gamma), where
+        gamma is the extreme value index from Hill (1975).  Larger alpha
+        means thinner tails; smaller alpha means heavier tails.
+
+        Note:
+            The classical Hill estimator returns gamma = (1/k) * sum(ln(X_i/u)).
+            This method returns its reciprocal, alpha = k / sum(ln(X_i/u)),
+            which is the maximum-likelihood estimate of the Pareto shape
+            parameter.  To recover the Hill gamma, compute ``1 / tail_index()``.
 
         Args:
             threshold: Threshold for tail definition (if None, uses 90th percentile).
 
         Returns:
-            Estimated tail index.
+            Estimated Pareto shape parameter alpha (= 1 / Hill gamma).
         """
         if threshold is None:
             threshold = np.percentile(self.losses, 90)
@@ -496,7 +503,7 @@ class RiskMetrics:
         if len(tail_losses) < 2:
             return np.nan
 
-        # Hill estimator
+        # Pareto alpha MLE via Hill's method (reciprocal of Hill gamma)
         k = len(tail_losses)
         hill_estimate = k / np.sum(np.log(tail_losses / threshold))
 

--- a/ergodic_insurance/tests/test_risk_metrics.py
+++ b/ergodic_insurance/tests/test_risk_metrics.py
@@ -350,16 +350,34 @@ class TestAdditionalMetrics:
         assert abs(ec - expected_ec) < 1
 
     def test_tail_index(self):
-        """Test tail index estimation."""
+        """Test tail index returns Pareto alpha (= 1/Hill gamma)."""
         np.random.seed(42)
-        # Generate heavy-tailed distribution (Pareto)
-        losses = np.random.pareto(2, 1000) * 1000
+        # Generate heavy-tailed distribution (Pareto with alpha=2)
+        # np.random.pareto draws from P(X>x) = (1/x)^alpha for x>=1,
+        # so multiplying by xm shifts the minimum.
+        true_alpha = 2.0
+        losses = np.random.pareto(true_alpha, 5000) * 1000
         metrics = RiskMetrics(losses)
 
-        tail_idx = metrics.tail_index()
-        assert tail_idx > 0
-        # For Pareto(2), tail index should be around 2
-        assert 1 < tail_idx < 4
+        alpha_hat = metrics.tail_index()
+        assert alpha_hat > 0
+        # The MLE alpha should be close to the true value
+        assert 1.5 < alpha_hat < 3.0, f"Expected ~{true_alpha}, got {alpha_hat:.2f}"
+
+        # Verify the reciprocal relationship: 1/alpha ≈ Hill gamma
+        gamma_hat = 1.0 / alpha_hat
+        assert 0.3 < gamma_hat < 0.7, f"Hill gamma should be ~0.5, got {gamma_hat:.2f}"
+
+    def test_tail_index_known_pareto(self):
+        """Verify tail_index on a larger Pareto sample with alpha=3."""
+        np.random.seed(123)
+        true_alpha = 3.0
+        losses = (np.random.pareto(true_alpha, 10000) + 1) * 500
+        metrics = RiskMetrics(losses)
+
+        alpha_hat = metrics.tail_index()
+        # With 10k samples the estimate should be reasonably tight
+        assert 2.0 < alpha_hat < 5.0, f"Expected ~{true_alpha}, got {alpha_hat:.2f}"
 
     def test_conditional_tail_expectation(self):
         """Test CTE calculation."""


### PR DESCRIPTION
## Summary

- Clarified `tail_index()` docstring to state it returns the **Pareto shape parameter alpha** (= 1/gamma), not the classical Hill estimator gamma from Hill (1975)
- Added a `Note` section explaining the alpha/gamma reciprocal relationship and how to recover Hill gamma via `1 / tail_index()`
- Updated inline comment and notebook label to say "Pareto alpha via Hill's method" instead of "Hill estimator"
- Added `test_tail_index_known_pareto` test with Pareto(alpha=3) verification and strengthened the existing test with explicit alpha/gamma assertions

## Test plan

- [x] All 107 tests in `test_risk_metrics.py` and `test_risk_metrics_coverage.py` pass
- [x] New `test_tail_index_known_pareto` verifies alpha estimate against known Pareto(3) distribution
- [x] Existing `test_tail_index` now also checks the reciprocal relationship (1/alpha ≈ Hill gamma)
- [x] Pre-commit hooks (black, isort, mypy, pylint) all pass

Closes #507