### PR TITLE
refactor: deprecate InsurancePolicy in favor of InsuranceProgram (#388)

### DIFF
--- a/ergodic_insurance/__init__.py
+++ b/ergodic_insurance/__init__.py
@@ -69,10 +69,10 @@ __all__ = [
     "run_analysis",
     "AnalysisResults",
     # Insurance & Risk
-    "InsurancePolicy",
-    "InsuranceLayer",
     "InsuranceProgram",
     "EnhancedInsuranceLayer",
+    "InsurancePolicy",  # Deprecated — use InsuranceProgram
+    "InsuranceLayer",  # Deprecated — use EnhancedInsuranceLayer
     "InsurancePricer",
     "MarketCycle",
     "RiskMetrics",

--- a/ergodic_insurance/docs/architecture/class_diagrams/core_classes.md
+++ b/ergodic_insurance/docs/architecture/class_diagrams/core_classes.md
@@ -14,7 +14,7 @@ classDiagram
     class Simulation {
         +manufacturer: WidgetManufacturer
         +loss_generator: List~ManufacturingLossGenerator~
-        +insurance_policy: InsurancePolicy
+        +insurance_program: InsuranceProgram
         +time_horizon: int
         +run() SimulationResults
         +step_annual(year, losses) dict
@@ -61,6 +61,7 @@ classDiagram
     }
 
     class InsurancePolicy {
+        <<deprecated>>
         +layers: List~InsuranceLayer~
         +deductible: float
         +process_claim(amount) tuple
@@ -79,7 +80,7 @@ classDiagram
 
     Simulation --> WidgetManufacturer : simulates
     Simulation --> ManufacturingLossGenerator : uses
-    Simulation --> InsurancePolicy : uses
+    Simulation --> InsurancePolicy : uses (deprecated)
     Simulation --> SimulationResults : produces
 
     MonteCarloEngine --> WidgetManufacturer : copies per path
@@ -87,7 +88,7 @@ classDiagram
     MonteCarloEngine --> InsuranceProgram : uses
     MonteCarloEngine --> MCSimulationResults : produces
 
-    InsurancePolicy --> InsuranceProgram : converts to
+    InsurancePolicy --> InsuranceProgram : converts to (deprecated)
 
     WidgetManufacturer ..|> FinancialStateProvider : implements
 ```
@@ -200,12 +201,13 @@ classDiagram
 
 ## Insurance Subsystem Detail
 
-This diagram shows both the basic insurance path (`InsurancePolicy` / `InsuranceLayer`)
-and the enhanced insurance path (`InsuranceProgram` / `EnhancedInsuranceLayer` / `LayerState`).
+This diagram shows the primary insurance path (`InsuranceProgram` / `EnhancedInsuranceLayer` / `LayerState`)
+and the deprecated basic path (`InsurancePolicy` / `InsuranceLayer`).
 
 ```{mermaid}
 classDiagram
     class InsurancePolicy {
+        <<deprecated>>
         +layers: List~InsuranceLayer~
         +deductible: float
         +pricing_enabled: bool
@@ -221,7 +223,7 @@ classDiagram
     }
 
     class InsuranceLayer {
-        <<dataclass>>
+        <<deprecated, dataclass>>
         +attachment_point: float
         +limit: float
         +rate: float
@@ -282,8 +284,8 @@ classDiagram
         +get_utilization_rate() float
     }
 
-    InsurancePolicy --> InsuranceLayer : contains 1..*
-    InsurancePolicy ..> InsuranceProgram : converts to
+    InsurancePolicy --> InsuranceLayer : contains 1..* (deprecated)
+    InsurancePolicy ..> InsuranceProgram : converts to (deprecated)
 
     InsuranceProgram --> EnhancedInsuranceLayer : contains 1..*
     InsuranceProgram --> LayerState : tracks 1..*
@@ -390,7 +392,7 @@ classDiagram
     class Simulation {
         +manufacturer: WidgetManufacturer
         +loss_generator: List~ManufacturingLossGenerator~
-        +insurance_policy: InsurancePolicy
+        +insurance_program: InsuranceProgram
         +time_horizon: int
         +seed: int
         +run(progress_interval) SimulationResults

--- a/ergodic_insurance/docs/architecture/monte_carlo_architecture.md
+++ b/ergodic_insurance/docs/architecture/monte_carlo_architecture.md
@@ -275,7 +275,7 @@ classDiagram
     class Simulation {
         +WidgetManufacturer manufacturer
         +List loss_generator
-        +InsurancePolicy insurance_policy
+        +InsuranceProgram insurance_program
         +int time_horizon
         +run() SimulationResults
         +step_annual() Dict

--- a/ergodic_insurance/docs/quick_start.rst
+++ b/ergodic_insurance/docs/quick_start.rst
@@ -83,7 +83,7 @@ Here's a complete example that demonstrates the key features:
    from ergodic_insurance.config_manager import ConfigManager
    from ergodic_insurance.manufacturer import WidgetManufacturer
    from ergodic_insurance.loss_distributions import ManufacturingLossGenerator
-   from ergodic_insurance import InsurancePolicy, InsuranceLayer
+   from ergodic_insurance import InsuranceProgram, EnhancedInsuranceLayer
    from ergodic_insurance.simulation import Simulation
 
    # Configuration
@@ -103,15 +103,15 @@ Here's a complete example that demonstrates the key features:
        seed=42
    )
 
-   # Create insurance policy
-   layer = InsuranceLayer(attachment_point=100_000, limit=5_000_000, rate=0.02)
-   policy = InsurancePolicy(layers=[layer], deductible=100_000)
+   # Create insurance program
+   layer = EnhancedInsuranceLayer(attachment_point=100_000, limit=5_000_000, base_premium_rate=0.02)
+   program = InsuranceProgram(layers=[layer], deductible=100_000)
 
    # Run simulation with insurance
    sim = Simulation(
        manufacturer=manufacturer,
        loss_generator=generator,
-       insurance_policy=policy,
+       insurance_program=program,
        time_horizon=50
    )
    results = sim.run()

--- a/ergodic_insurance/docs/tutorials/05_analyzing_results.md
+++ b/ergodic_insurance/docs/tutorials/05_analyzing_results.md
@@ -48,7 +48,7 @@ We assume you have your manufacturer and loss generator configured (see Tutorial
 ```python
 from ergodic_insurance import (
     ManufacturerConfig, WidgetManufacturer, ManufacturingLossGenerator,
-    InsurancePolicy, Simulation,
+    InsuranceProgram, Simulation,
 )
 
 # NovaTech's financial profile
@@ -61,10 +61,10 @@ config = ManufacturerConfig(
 )
 
 # NovaTech's proposed insurance program
-policy = InsurancePolicy.from_simple(
+policy = InsuranceProgram.simple(
     deductible=100_000,
     limit=5_000_000,
-    premium_rate=0.02
+    rate=0.02
 )
 
 # Run paired simulations
@@ -83,7 +83,7 @@ for seed in range(n_sims):
     sim_insured = Simulation(
         manufacturer=mfg_insured,
         loss_generator=loss_gen_insured,
-        insurance_policy=policy,
+        insurance_program=policy,
         time_horizon=time_horizon,
         seed=seed
     )
@@ -97,7 +97,7 @@ for seed in range(n_sims):
     sim_uninsured = Simulation(
         manufacturer=mfg_uninsured,
         loss_generator=loss_gen_uninsured,
-        # No insurance_policy here
+        # No insurance_program here
         time_horizon=time_horizon,
         seed=seed
     )
@@ -525,7 +525,7 @@ Here is the complete end-to-end analysis pipeline that Dana would run before her
 import numpy as np
 from ergodic_insurance import (
     ManufacturerConfig, WidgetManufacturer, ManufacturingLossGenerator,
-    InsurancePolicy, InsuranceLayer, Simulation, ErgodicAnalyzer,
+    InsuranceProgram, EnhancedInsuranceLayer, Simulation, ErgodicAnalyzer,
 )
 
 # ============================================================
@@ -539,8 +539,8 @@ config = ManufacturerConfig(
     retention_ratio=1.0
 )
 
-policy = InsurancePolicy(
-    layers=[InsuranceLayer(attachment_point=100_000, limit=5_000_000, rate=0.02)],
+policy = InsuranceProgram(
+    layers=[EnhancedInsuranceLayer(attachment_point=100_000, limit=5_000_000, base_premium_rate=0.02)],
     deductible=100_000
 )
 
@@ -561,7 +561,7 @@ for seed in range(n_sims):
     )
     sim = Simulation(
         manufacturer=mfg, loss_generator=loss_gen,
-        insurance_policy=policy, time_horizon=time_horizon, seed=seed
+        insurance_program=policy, time_horizon=time_horizon, seed=seed
     )
     insured_results.append(sim.run())
 
@@ -594,7 +594,7 @@ unins = comparison['uninsured']
 adv = comparison['ergodic_advantage']
 
 # Calculate cost-benefit ratio
-annual_premium = policy.calculate_premium()
+annual_premium = policy.calculate_annual_premium()
 expected_annual_loss = 0.2 * 1_000_000  # frequency x severity mean
 premium_loading = (annual_premium / expected_annual_loss - 1) * 100
 
@@ -651,8 +651,8 @@ Use the following table as a reference when reading `compare_scenarios()` output
 
 Run 200 paired simulations comparing NovaTech's current insurance program (low limits, high retention) against a proposed enhanced program (higher limits, lower retention). Calculate the ergodic divergence for each. Specifically:
 
-- **Current program**: `InsurancePolicy(layers=[InsuranceLayer(500_000, 2_000_000, 0.015)], deductible=500_000)`
-- **Proposed program**: `InsurancePolicy(layers=[InsuranceLayer(100_000, 5_000_000, 0.02)], deductible=100_000)`
+- **Current program**: `InsuranceProgram(layers=[EnhancedInsuranceLayer(500_000, 2_000_000, base_premium_rate=0.015)], deductible=500_000)`
+- **Proposed program**: `InsuranceProgram(layers=[EnhancedInsuranceLayer(100_000, 5_000_000, base_premium_rate=0.02)], deductible=100_000)`
 
 Compare the `time_average_gain` and `survival_gain` from `compare_scenarios()` for each program against the uninsured baseline. Which program produces a larger ergodic advantage?
 

--- a/ergodic_insurance/docs/tutorials/06_advanced_scenarios.md
+++ b/ergodic_insurance/docs/tutorials/06_advanced_scenarios.md
@@ -83,7 +83,7 @@ engine = MonteCarloEngine(
 results = engine.run()
 ```
 
-> **Important:** `MonteCarloEngine` accepts an `InsuranceProgram` (with `EnhancedInsuranceLayer`), not an `InsurancePolicy`. The `InsurancePolicy`/`InsuranceLayer` classes from Tutorial 3 are designed for the single-path `Simulation` engine. When working with Monte Carlo, always use `InsuranceProgram`.
+> **Note:** Both the `Simulation` engine and `MonteCarloEngine` accept `InsuranceProgram` (with `EnhancedInsuranceLayer`). The legacy `InsurancePolicy`/`InsuranceLayer` classes are deprecated.
 
 ### Reading the Results
 
@@ -323,8 +323,8 @@ hard_pricer = InsurancePricer(
 
 # Price NovaTech's program under each condition
 for label, pricer in [("Soft", soft_pricer), ("Normal", normal_pricer), ("Hard", hard_pricer)]:
-    priced = pricer.price_insurance_program(program, expected_revenue=25_000_000)
-    total_premium = priced.calculate_annual_premium()
+    priced_program = pricer.price_insurance_program(program, expected_revenue=25_000_000)
+    total_premium = priced_program.calculate_annual_premium()
     print(f"{label:>6} market premium: ${total_premium:>12,.0f}")
 ```
 

--- a/ergodic_insurance/docs/user_guide/case_studies.rst
+++ b/ergodic_insurance/docs/user_guide/case_studies.rst
@@ -79,14 +79,14 @@ Analysis Process
 
 .. code-block:: python
 
-   from ergodic_insurance import InsurancePolicy, InsuranceLayer
+   from ergodic_insurance import InsuranceProgram, EnhancedInsuranceLayer
 
-   current_policy = InsurancePolicy(
+   current_program = InsuranceProgram(
        layers=[
-           InsuranceLayer(
+           EnhancedInsuranceLayer(
                attachment_point=500_000,
                limit=5_000_000,
-               rate=0.025,
+               base_premium_rate=0.025,
            ),
        ],
        deductible=500_000,
@@ -101,7 +101,7 @@ Analysis Process
    sim = Simulation(
        manufacturer=manufacturer,
        loss_generator=loss_gen,
-       insurance_policy=current_policy,
+       insurance_program=current_program,
        time_horizon=10,
        seed=42,
    )
@@ -111,17 +111,17 @@ Analysis Process
 
 .. code-block:: python
 
-   optimized_policy = InsurancePolicy(
+   optimized_program = InsuranceProgram(
        layers=[
-           InsuranceLayer(
+           EnhancedInsuranceLayer(
                attachment_point=100_000,
                limit=5_000_000,
-               rate=0.025,
+               base_premium_rate=0.025,
            ),
-           InsuranceLayer(
+           EnhancedInsuranceLayer(
                attachment_point=5_100_000,
                limit=20_000_000,
-               rate=0.012,
+               base_premium_rate=0.012,
            ),
        ],
        deductible=100_000,
@@ -130,7 +130,7 @@ Analysis Process
    sim_opt = Simulation(
        manufacturer=WidgetManufacturer(config),
        loss_generator=loss_gen,
-       insurance_policy=optimized_policy,
+       insurance_program=optimized_program,
        time_horizon=10,
        seed=42,
    )
@@ -255,21 +255,21 @@ parameters to reflect a capital-light, high-growth profile:
 
 .. code-block:: python
 
-   from ergodic_insurance import InsurancePolicy, InsuranceLayer, Simulation
+   from ergodic_insurance import InsuranceProgram, EnhancedInsuranceLayer, Simulation
 
    # Minimal coverage option
-   minimal_policy = InsurancePolicy(
+   minimal_program = InsuranceProgram(
        layers=[
-           InsuranceLayer(attachment_point=50_000, limit=5_000_000, rate=0.036),
+           EnhancedInsuranceLayer(attachment_point=50_000, limit=5_000_000, base_premium_rate=0.036),
        ],
        deductible=50_000,
    )
 
    # Recommended comprehensive coverage
-   full_policy = InsurancePolicy(
+   full_program = InsuranceProgram(
        layers=[
-           InsuranceLayer(attachment_point=25_000, limit=5_000_000, rate=0.04),
-           InsuranceLayer(attachment_point=5_025_000, limit=45_000_000, rate=0.008),
+           EnhancedInsuranceLayer(attachment_point=25_000, limit=5_000_000, base_premium_rate=0.04),
+           EnhancedInsuranceLayer(attachment_point=5_025_000, limit=45_000_000, base_premium_rate=0.008),
        ],
        deductible=25_000,
    )
@@ -398,22 +398,22 @@ constructor captures this well:
 
 .. code-block:: python
 
-   from ergodic_insurance import InsurancePolicy, InsuranceLayer, Simulation
+   from ergodic_insurance import InsuranceProgram, EnhancedInsuranceLayer, Simulation
 
    # Current structure
-   current = InsurancePolicy(
+   current = InsuranceProgram(
        layers=[
-           InsuranceLayer(attachment_point=250_000, limit=10_000_000, rate=0.015),
-           InsuranceLayer(attachment_point=10_250_000, limit=100_000_000, rate=0.005),
+           EnhancedInsuranceLayer(attachment_point=250_000, limit=10_000_000, base_premium_rate=0.015),
+           EnhancedInsuranceLayer(attachment_point=10_250_000, limit=100_000_000, base_premium_rate=0.005),
        ],
        deductible=250_000,
    )
 
    # Optimized: raise retention, keep catastrophe protection
-   optimized = InsurancePolicy(
+   optimized = InsuranceProgram(
        layers=[
-           InsuranceLayer(attachment_point=2_000_000, limit=8_000_000, rate=0.012),
-           InsuranceLayer(attachment_point=10_000_000, limit=100_000_000, rate=0.005),
+           EnhancedInsuranceLayer(attachment_point=2_000_000, limit=8_000_000, base_premium_rate=0.012),
+           EnhancedInsuranceLayer(attachment_point=10_000_000, limit=100_000_000, base_premium_rate=0.005),
        ],
        deductible=2_000_000,
    )
@@ -490,7 +490,7 @@ Lesson 3: Market Capacity
 
 **Solution:** Structure the program with multiple carriers.
 
-This layered approach also naturally aligns with the framework's ``InsuranceLayer`` API, making it straightforward to model each carrier's contribution independently.
+This layered approach also naturally aligns with the framework's ``EnhancedInsuranceLayer`` API, making it straightforward to model each carrier's contribution independently.
 
 
 Further Analysis
@@ -530,6 +530,6 @@ Your Next Steps
 3. **Run your specific scenario** through the ``Simulation`` engine.
 4. **Compare results** with the relevant model case.
 5. **Iterate on the insurance structure** using different
-   ``InsurancePolicy`` configurations until you find the optimum.
+   ``InsuranceProgram`` configurations until you find the optimum.
 
 These cases are starting points. Your specific situation will require customized analysis, and the framework is designed to make that analysis straightforward and repeatable.

--- a/ergodic_insurance/docs/user_guide/faq.rst
+++ b/ergodic_insurance/docs/user_guide/faq.rst
@@ -46,16 +46,18 @@ At minimum:
 
 If you lack historical loss data, use industry benchmarks from your broker and run a sensitivity analysis to see how results change with different assumptions (see :doc:`../tutorials/04_optimization_workflow`).
 
-What is the difference between InsurancePolicy and InsuranceProgram?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+What happened to InsurancePolicy?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-They serve different simulation engines:
+``InsurancePolicy`` and ``InsuranceLayer`` are **deprecated**. Use ``InsuranceProgram`` and ``EnhancedInsuranceLayer`` instead. ``InsuranceProgram`` works with both the single-path ``Simulation`` engine and the ``MonteCarloEngine``, and supports advanced features like reinstatements, aggregate limits, and participation rates.
 
-- **``InsurancePolicy``** with **``InsuranceLayer``** -- used by the single-path ``Simulation`` engine. Each layer has an ``attachment_point``, ``limit``, and ``rate``.
+Migration is straightforward:
 
-- **``InsuranceProgram``** with **``EnhancedInsuranceLayer``** -- used by ``MonteCarloEngine``. Supports reinstatements, aggregate limits, participation rates, and per-occurrence vs. aggregate limit types.
+- ``InsurancePolicy.from_simple(deductible, limit, premium_rate)`` becomes ``InsuranceProgram.simple(deductible, limit, rate)``
+- ``InsuranceLayer(attachment_point, limit, rate)`` becomes ``EnhancedInsuranceLayer(attachment_point, limit, base_premium_rate=rate)``
+- ``InsurancePolicy(layers=[...], deductible=...)`` becomes ``InsuranceProgram(layers=[...], deductible=...)``
 
-Start with ``InsurancePolicy`` for exploration. Move to ``InsuranceProgram`` when you need Monte Carlo analysis or advanced layer features. See :doc:`../tutorials/03_configuring_insurance` for a walkthrough.
+See :doc:`../tutorials/03_configuring_insurance` for a walkthrough.
 
 How many simulations should I run?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -135,7 +137,7 @@ Common calibration mistakes:
 - **Loss frequency**: specifying per-simulation frequency instead of per-year
 - **Premium rate**: applying the rate to assets instead of to the layer limit
 
-Double-check ``ManufacturerConfig`` fields against your source data and verify ``InsuranceLayer`` parameters match your broker's terms.
+Double-check ``ManufacturerConfig`` fields against your source data and verify ``EnhancedInsuranceLayer`` parameters match your broker's terms.
 
 The simulation is slow.
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/ergodic_insurance/docs/user_guide/quick_start.rst
+++ b/ergodic_insurance/docs/user_guide/quick_start.rst
@@ -133,17 +133,17 @@ A real insurance program is a tower of layers, each covering a slice of loss:
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
                               Total Premium: $335K/year
 
-For quick single-layer policies, ``run_analysis()`` handles everything
-internally. You can also build a policy object directly:
+For quick single-layer programs, ``run_analysis()`` handles everything
+internally. You can also build a program object directly:
 
 .. code-block:: python
 
-   from ergodic_insurance import InsurancePolicy
+   from ergodic_insurance import InsuranceProgram
 
-   policy = InsurancePolicy.from_simple(
+   program = InsuranceProgram.simple(
        deductible=100_000,
        limit=5_000_000,
-       premium_rate=0.015,
+       rate=0.015,
    )
 
 For multi-layer towers and advanced structures, see

--- a/ergodic_insurance/examples/demo_excel_reports.py
+++ b/ergodic_insurance/examples/demo_excel_reports.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import numpy as np
 
 from ergodic_insurance import (
-    InsurancePolicy,
+    InsuranceProgram,
     ManufacturerConfig,
     ManufacturingLossGenerator,
     WidgetManufacturer,
@@ -64,8 +64,10 @@ def run_simulation_with_claims(years: int = 10, seed: int = 42) -> WidgetManufac
     )
 
     # Configure insurance
-    insurance = InsurancePolicy(
-        deductible=100_000, limit=5_000_000, base_premium_rate=0.02, coinsurance=0.1
+    insurance = InsuranceProgram.simple(
+        deductible=100_000,
+        limit=5_000_000,
+        rate=0.02,
     )
 
     # Run simulation
@@ -81,13 +83,12 @@ def run_simulation_with_claims(years: int = 10, seed: int = 42) -> WidgetManufac
         total_claims = sum(claims)
         company_payment, insurance_payment = manufacturer.process_insurance_claim(
             claim_amount=total_claims,
-            deductible=insurance.deductible,
-            insurance_limit=insurance.limit,
+            deductible_amount=insurance.deductible,
+            insurance_limit=insurance.get_total_coverage(),
         )
 
         # Calculate insurance premium
-        revenue_estimate = manufacturer.assets * manufacturer.asset_turnover_ratio
-        insurance_premium = revenue_estimate * insurance.base_premium_rate
+        insurance_premium = insurance.calculate_premium()
 
         # Run annual step
         metrics = manufacturer.step(letter_of_credit_rate=0.015, growth_rate=0.03)

--- a/ergodic_insurance/examples/test_notebook_comprehensive.py
+++ b/ergodic_insurance/examples/test_notebook_comprehensive.py
@@ -6,7 +6,6 @@ import numpy as np
 
 from ergodic_insurance import (
     EnhancedInsuranceLayer,
-    InsurancePolicy,
     InsurancePricer,
     InsuranceProgram,
     ManufacturingLossGenerator,

--- a/ergodic_insurance/insurance.py
+++ b/ergodic_insurance/insurance.py
@@ -1,51 +1,20 @@
 """Insurance policy structure and claim processing.
 
-This module provides classes for modeling multi-layer insurance policies
-with configurable attachment points, limits, and premium rates. It supports
-complex insurance structures commonly used in commercial insurance including
-excess layers, umbrella coverage, and multi-layer towers.
+.. deprecated::
+    The classes in this module (``InsurancePolicy`` and ``InsuranceLayer``)
+    are deprecated.  Use :class:`~ergodic_insurance.insurance_program.InsuranceProgram`
+    and :class:`~ergodic_insurance.insurance_program.EnhancedInsuranceLayer`
+    instead.
 
-The module integrates with pricing engines for dynamic premium calculation
-and supports both static and market-driven pricing models.
+Migration examples::
 
-Key Features:
-    - Multi-layer insurance towers with attachment points and limits
-    - Deductible and self-insured retention handling
-    - Dynamic pricing integration with market cycles
-    - Claim allocation across multiple layers
-    - Premium calculation with various rating methods
+    # Before (deprecated):
+    from ergodic_insurance.insurance import InsurancePolicy
+    policy = InsurancePolicy.from_simple(deductible=1_000_000, limit=5_000_000, premium_rate=0.03)
 
-Examples:
-    Simple single-layer policy (recommended)::
-
-        from ergodic_insurance.insurance import InsurancePolicy
-
-        # $5M excess $1M with 3% rate
-        policy = InsurancePolicy.from_simple(
-            deductible=1_000_000,
-            limit=5_000_000,
-            premium_rate=0.03,
-        )
-
-        # Process a $3M claim
-        company_payment, insurance_recovery = policy.process_claim(3_000_000)
-
-    Multi-layer tower::
-
-        # Build a insurance tower
-        layers = [
-            InsuranceLayer(1_000_000, 4_000_000, 0.025),  # Primary
-            InsuranceLayer(5_000_000, 5_000_000, 0.015),  # First excess
-            InsuranceLayer(10_000_000, 10_000_000, 0.01), # Second excess
-        ]
-
-        tower = InsurancePolicy(layers, deductible=1_000_000)
-        annual_premium = tower.calculate_premium()
-
-Note:
-    For advanced features like reinstatements and complex multi-layer programs,
-    see the insurance_program module which provides EnhancedInsuranceLayer and
-    InsuranceProgram classes.
+    # After (recommended):
+    from ergodic_insurance.insurance_program import InsuranceProgram
+    program = InsuranceProgram.simple(deductible=1_000_000, limit=5_000_000, rate=0.03)
 
 Since:
     Version 0.1.0
@@ -228,6 +197,12 @@ class InsurancePolicy:
     ):
         """Initialize insurance policy.
 
+        .. deprecated::
+            InsurancePolicy is deprecated. Use
+            :class:`~ergodic_insurance.insurance_program.InsuranceProgram`
+            instead.  For simple single-layer policies, use
+            ``InsuranceProgram.simple(deductible, limit, rate)``.
+
         Args:
             layers: List of InsuranceLayer objects defining the coverage tower.
                 Layers will be automatically sorted by attachment point.
@@ -253,6 +228,12 @@ class InsurancePolicy:
                     pricer=pricer
                 )
         """
+        warnings.warn(
+            "InsurancePolicy is deprecated. Use InsuranceProgram instead. "
+            "For simple policies, use InsuranceProgram.simple(deductible, limit, rate).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.layers = sorted(layers, key=lambda x: x.attachment_point)
         self.deductible = deductible
         self.pricing_enabled = pricing_enabled

--- a/ergodic_insurance/insurance_pricing.py
+++ b/ergodic_insurance/insurance_pricing.py
@@ -467,6 +467,9 @@ class InsurancePricer:
     ) -> "InsurancePolicy":
         """Price a basic insurance policy.
 
+        .. deprecated::
+            Use :meth:`price_insurance_program` instead.
+
         Prices all layers in the policy and optionally updates their rates.
 
         Args:
@@ -478,6 +481,14 @@ class InsurancePricer:
         Returns:
             Policy with updated pricing (original or copy based on update_policy)
         """
+        import warnings
+
+        warnings.warn(
+            "price_insurance_policy() is deprecated. "
+            "Use price_insurance_program() with an InsuranceProgram instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         from .insurance import InsurancePolicy
 
         # Create a copy if not updating in place

--- a/ergodic_insurance/insurance_program.py
+++ b/ergodic_insurance/insurance_program.py
@@ -527,6 +527,57 @@ class InsuranceProgram:
         self.pricer = pricer
         self.pricing_results: List[Any] = []
 
+    @classmethod
+    def simple(
+        cls,
+        deductible: float,
+        limit: float,
+        rate: float,
+        name: str = "Simple Insurance Program",
+        **kwargs,
+    ) -> "InsuranceProgram":
+        """Create a single-layer insurance program from basic parameters.
+
+        Convenience factory for the most common use case: a single primary
+        layer where the attachment point equals the deductible.
+
+        Args:
+            deductible: Self-insured retention in dollars.
+            limit: Maximum coverage amount in dollars above the deductible.
+            rate: Annual premium as a fraction of the limit (e.g. 0.025 for 2.5%).
+            name: Program identifier.
+            **kwargs: Additional keyword arguments (e.g. pricing_enabled, pricer).
+
+        Returns:
+            InsuranceProgram with a single layer.
+
+        Examples:
+            Quick single-layer program::
+
+                program = InsuranceProgram.simple(
+                    deductible=500_000,
+                    limit=10_000_000,
+                    rate=0.025,
+                )
+        """
+        layer = EnhancedInsuranceLayer(
+            attachment_point=deductible,
+            limit=limit,
+            base_premium_rate=rate,
+            reinstatements=0,
+        )
+        return cls(layers=[layer], deductible=deductible, name=name, **kwargs)
+
+    def calculate_premium(self) -> float:
+        """Calculate total annual premium across all layers.
+
+        Convenience alias for ``calculate_annual_premium(0.0)``.
+
+        Returns:
+            Total annual premium in dollars.
+        """
+        return self.calculate_annual_premium(0.0)
+
     def calculate_annual_premium(self, time: float = 0.0) -> float:
         """Calculate total annual premium for the program.
 

--- a/ergodic_insurance/notebooks/run_basic_simulation.py
+++ b/ergodic_insurance/notebooks/run_basic_simulation.py
@@ -13,7 +13,6 @@ import seaborn as sns
 from ergodic_insurance.config import ManufacturerConfig
 from ergodic_insurance.ergodic_analyzer import ErgodicAnalyzer
 from ergodic_insurance.exposure_base import RevenueExposure
-from ergodic_insurance.insurance import InsuranceLayer, InsurancePolicy
 from ergodic_insurance.insurance_program import EnhancedInsuranceLayer, InsuranceProgram
 from ergodic_insurance.loss_distributions import ManufacturingLossGenerator
 from ergodic_insurance.manufacturer import WidgetManufacturer

--- a/ergodic_insurance/notebooks/run_basic_simulation_colab.py
+++ b/ergodic_insurance/notebooks/run_basic_simulation_colab.py
@@ -13,7 +13,6 @@ import seaborn as sns
 from ergodic_insurance.config import ManufacturerConfig
 from ergodic_insurance.ergodic_analyzer import ErgodicAnalyzer
 from ergodic_insurance.exposure_base import RevenueExposure
-from ergodic_insurance.insurance import InsuranceLayer, InsurancePolicy
 from ergodic_insurance.insurance_program import EnhancedInsuranceLayer, InsuranceProgram
 from ergodic_insurance.loss_distributions import ManufacturingLossGenerator
 from ergodic_insurance.manufacturer import WidgetManufacturer

--- a/ergodic_insurance/simulation.py
+++ b/ergodic_insurance/simulation.py
@@ -50,7 +50,7 @@ from dataclasses import dataclass
 import logging
 from pathlib import Path
 import time
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Mapping, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -58,7 +58,7 @@ import pandas as pd
 from .config import DEFAULT_RISK_FREE_RATE, Config
 from .decimal_utils import ZERO, to_decimal
 from .insurance import InsurancePolicy
-from .insurance_program import InsuranceProgram
+from .insurance_program import EnhancedInsuranceLayer, InsuranceProgram
 from .loss_distributions import LossData, LossEvent, ManufacturingLossGenerator
 from .manufacturer import WidgetManufacturer
 from .monte_carlo import MonteCarloEngine
@@ -422,25 +422,25 @@ class Simulation:
             from ergodic_insurance.config import ManufacturerConfig
             from ergodic_insurance.manufacturer import WidgetManufacturer
             from ergodic_insurance.loss_distributions import ManufacturingLossGenerator
-            from ergodic_insurance.insurance import InsurancePolicy
+            from ergodic_insurance.insurance_program import InsuranceProgram
             from ergodic_insurance.simulation import Simulation
 
             # Create manufacturer
             config = ManufacturerConfig(initial_assets=10_000_000)
             manufacturer = WidgetManufacturer(config)
 
-            # Create insurance policy
-            policy = InsurancePolicy.from_simple(
+            # Create insurance program
+            program = InsuranceProgram.simple(
                 deductible=500_000,
                 limit=5_000_000,
-                premium_rate=0.02
+                rate=0.02,
             )
 
             # Run simulation
             sim = Simulation(
                 manufacturer=manufacturer,
                 loss_generator=ManufacturingLossGenerator.create_simple(seed=42),
-                insurance_policy=policy,
+                insurance_policy=program,
                 time_horizon=10
             )
             results = sim.run()
@@ -482,7 +482,7 @@ class Simulation:
         loss_generator: Optional[
             Union[ManufacturingLossGenerator, List[ManufacturingLossGenerator]]
         ] = None,
-        insurance_policy: Optional[InsurancePolicy] = None,
+        insurance_policy: Optional[Union[InsuranceProgram, InsurancePolicy]] = None,
         time_horizon: int = 100,
         seed: Optional[int] = None,
         growth_rate: float = 0.0,
@@ -497,8 +497,10 @@ class Simulation:
                 creating loss events. If a list is provided, losses from all
                 generators are combined. If None, a default generator with
                 standard parameters is created.
-            insurance_policy: Insurance policy for claim processing. If None,
-                legacy claim processing is used with fixed parameters.
+            insurance_policy: Insurance program (or deprecated InsurancePolicy)
+                for claim processing. Accepts :class:`InsuranceProgram`
+                (preferred) or :class:`InsurancePolicy` (deprecated, auto-
+                converted). If None, no insurance coverage is applied.
             time_horizon: Number of years to simulate. Must be positive.
             seed: Random seed for reproducibility. Passed to loss generator(s).
             growth_rate: Revenue growth rate per period (default 0.0).
@@ -511,17 +513,17 @@ class Simulation:
         Examples:
             Setup with custom insurance::
 
-                from ergodic_insurance.insurance import InsurancePolicy
+                from ergodic_insurance.insurance_program import InsuranceProgram
 
-                policy = InsurancePolicy(
+                program = InsuranceProgram.simple(
                     deductible=1_000_000,
                     limit=10_000_000,
-                    premium_rate=0.03
+                    rate=0.03,
                 )
 
                 sim = Simulation(
                     manufacturer=manufacturer,
-                    insurance_policy=policy,
+                    insurance_policy=program,
                     time_horizon=50
                 )
 
@@ -556,6 +558,18 @@ class Simulation:
             self.loss_generator = loss_generator
         else:
             self.loss_generator = [loss_generator]
+
+        # Normalize insurance input to InsuranceProgram
+        if insurance_policy is not None and isinstance(insurance_policy, InsurancePolicy):
+            import warnings
+
+            warnings.warn(
+                "Passing InsurancePolicy to Simulation is deprecated. "
+                "Use InsuranceProgram instead (e.g., InsuranceProgram.simple(...)).",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            insurance_policy = insurance_policy.to_enhanced_program()
 
         self.insurance_policy = insurance_policy
         self.time_horizon = time_horizon
@@ -915,7 +929,7 @@ class Simulation:
     def run_monte_carlo(  # pylint: disable=too-many-locals
         cls,
         config: Config,
-        insurance_policy: InsurancePolicy,
+        insurance_policy: Optional[Union[InsuranceProgram, InsurancePolicy]] = None,
         n_scenarios: int = 10000,
         batch_size: int = 1000,
         n_jobs: int = 7,
@@ -931,7 +945,9 @@ class Simulation:
 
         Args:
             config: Configuration object.
-            insurance_policy: Insurance policy to simulate.
+            insurance_policy: Insurance program (or deprecated InsurancePolicy)
+                to simulate. Accepts :class:`InsuranceProgram` (preferred) or
+                :class:`InsurancePolicy` (deprecated, auto-converted).
             n_scenarios: Number of scenarios to run.
             batch_size: Scenarios per batch.
             n_jobs: Number of parallel jobs.
@@ -948,19 +964,21 @@ class Simulation:
 
         loss_generator = ManufacturingLossGenerator(seed=seed)
 
-        # Create insurance program with layers passed to constructor so that
-        # layer_states are properly initialized (Issue #348)
-        if insurance_policy:
-            from .insurance_program import EnhancedInsuranceLayer
+        # Normalize to InsuranceProgram
+        if insurance_policy is not None and isinstance(insurance_policy, InsurancePolicy):
+            import warnings as _warnings
 
-            layer = EnhancedInsuranceLayer(
-                attachment_point=0,
-                limit=(
-                    insurance_policy.limit if hasattr(insurance_policy, "limit") else float("inf")
-                ),
-                base_premium_rate=0.01,
+            _warnings.warn(
+                "Passing InsurancePolicy to run_monte_carlo is deprecated. "
+                "Use InsuranceProgram instead.",
+                DeprecationWarning,
+                stacklevel=2,
             )
-            insurance_program = InsuranceProgram(layers=[layer])
+            insurance_policy = insurance_policy.to_enhanced_program()
+
+        # Create insurance program (Issue #348)
+        if insurance_policy is not None:
+            insurance_program = insurance_policy
         else:
             insurance_program = InsuranceProgram(layers=[])
 
@@ -1026,7 +1044,9 @@ class Simulation:
                 geo_with = stats_with["geometric_return"]
                 geo_without = stats_without["geometric_return"]
 
-                premium_cost = insurance_policy.calculate_premium()
+                premium_cost = (
+                    insurance_policy.calculate_premium() if insurance_policy is not None else 0.0
+                )
                 initial_assets = config.manufacturer.initial_assets
                 premium_rate = premium_cost / initial_assets
 
@@ -1073,7 +1093,7 @@ class Simulation:
     def compare_insurance_strategies(
         cls,
         config: Config,
-        insurance_policies: Dict[str, InsurancePolicy],
+        insurance_policies: Mapping[str, Union[InsuranceProgram, InsurancePolicy]],
         n_scenarios: int = 1000,
         n_jobs: int = 7,
         seed: Optional[int] = None,
@@ -1082,7 +1102,8 @@ class Simulation:
 
         Args:
             config: Configuration object.
-            insurance_policies: Dictionary of policy name to InsurancePolicy.
+            insurance_policies: Dictionary of strategy name to
+                :class:`InsuranceProgram` (or deprecated :class:`InsurancePolicy`).
             n_scenarios: Scenarios per policy.
             n_jobs: Number of parallel jobs.
             seed: Random seed.

--- a/ergodic_insurance/strategy_backtester.py
+++ b/ergodic_insurance/strategy_backtester.py
@@ -32,7 +32,6 @@ from typing import Any, Dict, List, Optional, Union
 import numpy as np
 import pandas as pd
 
-from .insurance import InsuranceLayer, InsurancePolicy
 from .insurance_program import EnhancedInsuranceLayer, InsuranceProgram
 from .loss_distributions import ManufacturingLossGenerator
 from .manufacturer import WidgetManufacturer
@@ -267,14 +266,13 @@ class OptimizedStaticStrategy(InsuranceStrategy):
             # x = [deductible, primary_limit, excess_limit]
             deductible, primary, excess = x
 
-            # Create trial insurance program
+            # Create trial insurance program directly
             layers = [
-                InsuranceLayer(deductible, primary - deductible, 0.015),
-                InsuranceLayer(primary, excess, 0.008),
+                EnhancedInsuranceLayer(deductible, primary - deductible, base_premium_rate=0.015),
+                EnhancedInsuranceLayer(primary, excess, base_premium_rate=0.008),
             ]
-            policy = InsurancePolicy(layers, deductible)
+            program = InsuranceProgram(layers=layers, deductible=deductible)
 
-            # Run short simulation to evaluate
             # Run short simulation using MonteCarloEngine
             from .monte_carlo import MonteCarloEngine
             from .monte_carlo import SimulationConfig as MCConfig
@@ -283,19 +281,6 @@ class OptimizedStaticStrategy(InsuranceStrategy):
 
             # Create loss generator
             loss_generator = ManufacturingLossGenerator(seed=42)
-
-            # Create insurance program from policy
-            from .insurance_program import EnhancedInsuranceLayer, InsuranceProgram
-
-            program_layers = [
-                EnhancedInsuranceLayer(
-                    attachment_point=layer.attachment_point,
-                    limit=layer.limit,
-                    base_premium_rate=layer.rate,
-                )
-                for layer in policy.layers
-            ]
-            program = InsuranceProgram(layers=program_layers)
 
             # Initialize Monte Carlo engine with required parameters
             mc_engine = MonteCarloEngine(
@@ -315,10 +300,10 @@ class OptimizedStaticStrategy(InsuranceStrategy):
             deductible, primary, excess = x
 
             layers = [
-                InsuranceLayer(deductible, primary - deductible, 0.015),
-                InsuranceLayer(primary, excess, 0.008),
+                EnhancedInsuranceLayer(deductible, primary - deductible, base_premium_rate=0.015),
+                EnhancedInsuranceLayer(primary, excess, base_premium_rate=0.008),
             ]
-            policy = InsurancePolicy(layers, deductible)
+            program = InsuranceProgram(layers=layers, deductible=deductible)
 
             # Run short simulation using MonteCarloEngine
             from .monte_carlo import MonteCarloEngine
@@ -328,19 +313,6 @@ class OptimizedStaticStrategy(InsuranceStrategy):
 
             # Create loss generator
             loss_generator = ManufacturingLossGenerator(seed=42)
-
-            # Create insurance program from policy
-            from .insurance_program import EnhancedInsuranceLayer, InsuranceProgram
-
-            program_layers = [
-                EnhancedInsuranceLayer(
-                    attachment_point=layer.attachment_point,
-                    limit=layer.limit,
-                    base_premium_rate=layer.rate,
-                )
-                for layer in policy.layers
-            ]
-            program = InsuranceProgram(layers=program_layers)
 
             # Initialize Monte Carlo engine with required parameters
             mc_engine = MonteCarloEngine(

--- a/ergodic_insurance/tests/integration/test_critical_integrations.py
+++ b/ergodic_insurance/tests/integration/test_critical_integrations.py
@@ -11,6 +11,8 @@ This module covers:
 
 # mypy: ignore-errors
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -85,17 +87,21 @@ class TestErgodicIntegration:
         for i in range(10):
             # Insured simulation
             manufacturer = WidgetManufacturer(config.manufacturer)
-            policy = InsurancePolicy(
-                layers=[InsuranceLayer(100_000, 5_000_000, 0.02)],
-                deductible=100_000,
-            )
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                policy = InsurancePolicy(
+                    layers=[InsuranceLayer(100_000, 5_000_000, 0.02)],
+                    deductible=100_000,
+                )
 
-            sim = Simulation(
-                manufacturer=manufacturer,
-                time_horizon=config.simulation.time_horizon_years,
-                insurance_policy=policy,
-                seed=42 + i,
-            )
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                sim = Simulation(
+                    manufacturer=manufacturer,
+                    time_horizon=config.simulation.time_horizon_years,
+                    insurance_policy=policy,
+                    seed=42 + i,
+                )
             insured_results.append(sim.run())
 
             # Uninsured simulation

--- a/ergodic_insurance/tests/integration/test_fixtures.py
+++ b/ergodic_insurance/tests/integration/test_fixtures.py
@@ -202,12 +202,16 @@ def basic_insurance_policy() -> InsurancePolicy:
     Returns:
         InsurancePolicy: Basic insurance for testing.
     """
+    import warnings
+
     layer = InsuranceLayer(
         attachment_point=100_000,
         limit=5_000_000,
         rate=0.02,
     )
-    return InsurancePolicy(layers=[layer], deductible=100_000)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        return InsurancePolicy(layers=[layer], deductible=100_000)
 
 
 @pytest.fixture
@@ -217,6 +221,8 @@ def multi_layer_insurance() -> InsurancePolicy:
     Returns:
         InsurancePolicy: Multi-layer insurance for testing.
     """
+    import warnings
+
     primary = InsuranceLayer(
         attachment_point=50_000,
         limit=2_000_000,
@@ -232,10 +238,12 @@ def multi_layer_insurance() -> InsurancePolicy:
         limit=10_000_000,
         rate=0.008,
     )
-    return InsurancePolicy(
-        layers=[primary, excess1, excess2],
-        deductible=50_000,
-    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        return InsurancePolicy(
+            layers=[primary, excess1, excess2],
+            deductible=50_000,
+        )
 
 
 @pytest.fixture

--- a/ergodic_insurance/tests/integration/test_insurance_stack.py
+++ b/ergodic_insurance/tests/integration/test_insurance_stack.py
@@ -6,6 +6,8 @@ insurance programs, and manufacturer components.
 
 # mypy: ignore-errors
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -502,10 +504,12 @@ class TestInsuranceStack:
         # Simulate each structure
         results = []
         for i, structure in enumerate(structures):
-            policy = InsurancePolicy(
-                layers=structure["layers"],
-                deductible=structure["layers"][0].attachment_point,
-            )
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                policy = InsurancePolicy(
+                    layers=structure["layers"],
+                    deductible=structure["layers"][0].attachment_point,
+                )
 
             # Run simulation
             sim_mfg = manufacturer.copy()
@@ -645,29 +649,31 @@ class TestInsuranceStack:
         manufacturer = base_manufacturer.copy()
 
         # Year 1-3: Startup phase with basic coverage
-        startup_policy = InsurancePolicy(
-            layers=[InsuranceLayer(100_000, 2_000_000, 0.03)],
-            deductible=100_000,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            startup_policy = InsurancePolicy(
+                layers=[InsuranceLayer(100_000, 2_000_000, 0.03)],
+                deductible=100_000,
+            )
 
-        # Year 4-6: Growth phase with expanded coverage
-        growth_policy = InsurancePolicy(
-            layers=[
-                InsuranceLayer(75_000, 3_000_000, 0.025),
-                InsuranceLayer(3_075_000, 5_000_000, 0.015),
-            ],
-            deductible=75_000,
-        )
+            # Year 4-6: Growth phase with expanded coverage
+            growth_policy = InsurancePolicy(
+                layers=[
+                    InsuranceLayer(75_000, 3_000_000, 0.025),
+                    InsuranceLayer(3_075_000, 5_000_000, 0.015),
+                ],
+                deductible=75_000,
+            )
 
-        # Year 7-10: Mature phase with optimized coverage
-        mature_policy = InsurancePolicy(
-            layers=[
-                InsuranceLayer(150_000, 2_000_000, 0.02),
-                InsuranceLayer(2_150_000, 4_000_000, 0.012),
-                InsuranceLayer(6_150_000, 10_000_000, 0.008),
-            ],
-            deductible=150_000,
-        )
+            # Year 7-10: Mature phase with optimized coverage
+            mature_policy = InsurancePolicy(
+                layers=[
+                    InsuranceLayer(150_000, 2_000_000, 0.02),
+                    InsuranceLayer(2_150_000, 4_000_000, 0.012),
+                    InsuranceLayer(6_150_000, 10_000_000, 0.008),
+                ],
+                deductible=150_000,
+            )
 
         # Run multi-year simulation
         phases = [

--- a/ergodic_insurance/tests/test_execution_semantics.py
+++ b/ergodic_insurance/tests/test_execution_semantics.py
@@ -8,6 +8,8 @@ Validates that:
 5. Execution ordering is consistent: losses → claims → premium → step
 """
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -48,15 +50,17 @@ def loss_generator():
 @pytest.fixture
 def insurance_policy():
     """Create a test insurance policy."""
-    layer = InsuranceLayer(
-        attachment_point=100_000,
-        limit=5_000_000,
-        rate=0.02,
-    )
-    return InsurancePolicy(
-        layers=[layer],
-        deductible=100_000,
-    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        layer = InsuranceLayer(
+            attachment_point=100_000,
+            limit=5_000_000,
+            rate=0.02,
+        )
+        return InsurancePolicy(
+            layers=[layer],
+            deductible=100_000,
+        )
 
 
 class TestReEntrancy:
@@ -87,13 +91,15 @@ class TestReEntrancy:
         self, manufacturer, loss_generator, insurance_policy
     ):
         """Run simulation with insurance twice and verify results are identical."""
-        sim = Simulation(
-            manufacturer=manufacturer,
-            loss_generator=loss_generator,
-            insurance_policy=insurance_policy,
-            time_horizon=10,
-            seed=42,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            sim = Simulation(
+                manufacturer=manufacturer,
+                loss_generator=loss_generator,
+                insurance_policy=insurance_policy,
+                time_horizon=10,
+                seed=42,
+            )
 
         results1 = sim.run()
         results2 = sim.run()
@@ -307,12 +313,14 @@ class TestExecutionOrdering:
         """Verify that premium is recorded before manufacturer.step()."""
         manufacturer = WidgetManufacturer(manufacturer_config)
 
-        sim = Simulation(
-            manufacturer=manufacturer,
-            insurance_policy=insurance_policy,
-            time_horizon=5,
-            seed=42,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            sim = Simulation(
+                manufacturer=manufacturer,
+                insurance_policy=insurance_policy,
+                time_horizon=5,
+                seed=42,
+            )
 
         call_order = []
         original_step = manufacturer.step

--- a/ergodic_insurance/tests/test_insurance.py
+++ b/ergodic_insurance/tests/test_insurance.py
@@ -65,7 +65,8 @@ class TestInsurancePolicy:
             InsuranceLayer(attachment_point=0, limit=5_000_000, rate=0.02),
             InsuranceLayer(attachment_point=5_000_000, limit=10_000_000, rate=0.01),
         ]
-        return InsurancePolicy(layers=layers, deductible=0)
+        with pytest.warns(DeprecationWarning, match="InsurancePolicy is deprecated"):
+            return InsurancePolicy(layers=layers, deductible=0)
 
     @pytest.fixture
     def policy_with_deductible(self):
@@ -75,7 +76,8 @@ class TestInsurancePolicy:
             InsuranceLayer(attachment_point=5_000_000, limit=20_000_000, rate=0.008),
             InsuranceLayer(attachment_point=25_000_000, limit=25_000_000, rate=0.004),
         ]
-        return InsurancePolicy(layers=layers, deductible=500_000)
+        with pytest.warns(DeprecationWarning, match="InsurancePolicy is deprecated"):
+            return InsurancePolicy(layers=layers, deductible=500_000)
 
     def test_policy_initialization(self, simple_policy):
         """Test policy initialization and layer sorting."""
@@ -169,7 +171,8 @@ class TestInsurancePolicy:
         layers = [
             InsuranceLayer(attachment_point=100_000, limit=200_000, rate=0.01),
         ]
-        policy = InsurancePolicy(layers=layers, deductible=500_000)
+        with pytest.warns(DeprecationWarning, match="InsurancePolicy is deprecated"):
+            policy = InsurancePolicy(layers=layers, deductible=500_000)
         assert policy.get_total_coverage() == 0.0
 
     def test_layer_recovery_capped_per_layer(self):
@@ -180,7 +183,8 @@ class TestInsurancePolicy:
             InsuranceLayer(attachment_point=0, limit=5_000_000, rate=0.02),
             InsuranceLayer(attachment_point=5_000_000, limit=5_000_000, rate=0.01),
         ]
-        policy = InsurancePolicy(layers=layers, deductible=1_000_000)
+        with pytest.warns(DeprecationWarning, match="InsurancePolicy is deprecated"):
+            policy = InsurancePolicy(layers=layers, deductible=1_000_000)
 
         # 3M claim: deductible=1M, max_recoverable=2M
         # Layer 0 would pay min(3M, 5M)=3M but capped at remaining 2M
@@ -194,7 +198,8 @@ class TestInsurancePolicy:
 
     def test_empty_policy(self):
         """Test policy with no layers."""
-        policy = InsurancePolicy(layers=[], deductible=100_000)
+        with pytest.warns(DeprecationWarning, match="InsurancePolicy is deprecated"):
+            policy = InsurancePolicy(layers=[], deductible=100_000)
 
         company_payment, insurance_recovery = policy.process_claim(500_000)
         assert company_payment == 500_000  # Company pays everything
@@ -226,7 +231,8 @@ class TestInsurancePolicyYAML:
 
     def test_load_from_yaml(self, yaml_config_path):
         """Test loading policy from YAML file."""
-        policy = InsurancePolicy.from_yaml(yaml_config_path)
+        with pytest.warns(DeprecationWarning, match="InsurancePolicy is deprecated"):
+            policy = InsurancePolicy.from_yaml(yaml_config_path)
 
         assert policy.deductible == 250_000
         assert len(policy.layers) == 2
@@ -247,7 +253,8 @@ class TestInsurancePolicyYAML:
         config_path = Path(__file__).parent.parent / "data" / "parameters" / "insurance.yaml"
 
         if config_path.exists():
-            policy = InsurancePolicy.from_yaml(str(config_path))
+            with pytest.warns(DeprecationWarning, match="InsurancePolicy is deprecated"):
+                policy = InsurancePolicy.from_yaml(str(config_path))
 
             assert policy.deductible == 500_000
             assert len(policy.layers) == 3
@@ -273,7 +280,8 @@ class TestIntegrationScenarios:
             InsuranceLayer(attachment_point=5_000_000, limit=20_000_000, rate=0.008),
             InsuranceLayer(attachment_point=25_000_000, limit=25_000_000, rate=0.004),
         ]
-        return InsurancePolicy(layers=layers, deductible=500_000)
+        with pytest.warns(DeprecationWarning, match="InsurancePolicy is deprecated"):
+            return InsurancePolicy(layers=layers, deductible=500_000)
 
     def test_small_attritional_losses(self, realistic_policy):
         """Test handling of small frequent losses."""
@@ -344,7 +352,8 @@ class TestOverRecoveryGuard:
         layers = [
             InsuranceLayer(attachment_point=500_000, limit=4_500_000, rate=0.015),
         ]
-        policy = InsurancePolicy(layers=layers, deductible=200_000)
+        with pytest.warns(DeprecationWarning, match="InsurancePolicy is deprecated"):
+            policy = InsurancePolicy(layers=layers, deductible=200_000)
 
         # 3M claim: deductible=200K, layer recovery=min(3M-500K, 4.5M)=2.5M
         # Without guard: total = 200K + 2.5M = 2.7M (< 3M, no over-recovery here)
@@ -364,7 +373,8 @@ class TestOverRecoveryGuard:
         layers = [
             InsuranceLayer(attachment_point=500_000, limit=5_000_000, rate=0.015),
         ]
-        policy = InsurancePolicy(layers=layers, deductible=1_000_000)
+        with pytest.warns(DeprecationWarning, match="InsurancePolicy is deprecated"):
+            policy = InsurancePolicy(layers=layers, deductible=1_000_000)
 
         # 3M claim: deductible=1M, max_recoverable=2M
         # Layer: min(3M-500K, 5M) = 2.5M, but cap at 2M
@@ -379,7 +389,8 @@ class TestOverRecoveryGuard:
             InsuranceLayer(attachment_point=0, limit=5_000_000, rate=0.02),
             InsuranceLayer(attachment_point=0, limit=5_000_000, rate=0.02),
         ]
-        policy = InsurancePolicy(layers=layers, deductible=0)
+        with pytest.warns(DeprecationWarning, match="InsurancePolicy is deprecated"):
+            policy = InsurancePolicy(layers=layers, deductible=0)
 
         # 3M claim: each layer would pay 3M, total 6M > 3M claim
         company, insurance = policy.process_claim(3_000_000)
@@ -392,7 +403,8 @@ class TestOverRecoveryGuard:
             InsuranceLayer(attachment_point=100_000, limit=10_000_000, rate=0.01),
             InsuranceLayer(attachment_point=200_000, limit=10_000_000, rate=0.01),
         ]
-        policy = InsurancePolicy(layers=layers, deductible=500_000)
+        with pytest.warns(DeprecationWarning, match="InsurancePolicy is deprecated"):
+            policy = InsurancePolicy(layers=layers, deductible=500_000)
 
         for claim in [100_000, 500_000, 1_000_000, 5_000_000, 15_000_000]:
             company, insurance = policy.process_claim(claim)
@@ -407,7 +419,8 @@ class TestOverRecoveryGuard:
         layers = [
             InsuranceLayer(attachment_point=500_000, limit=5_000_000, rate=0.015),
         ]
-        policy = InsurancePolicy(layers=layers, deductible=1_000_000)
+        with pytest.warns(DeprecationWarning, match="InsurancePolicy is deprecated"):
+            policy = InsurancePolicy(layers=layers, deductible=1_000_000)
 
         # 3M claim: max_recoverable = 3M - 1M = 2M
         # Layer: min(3M - 500K, 5M) = 2.5M → capped to 2M
@@ -417,7 +430,8 @@ class TestOverRecoveryGuard:
     def test_zero_claim_returns_zero(self):
         """Test zero and negative claims produce zero recovery."""
         layers = [InsuranceLayer(attachment_point=0, limit=5_000_000, rate=0.01)]
-        policy = InsurancePolicy(layers=layers, deductible=0)
+        with pytest.warns(DeprecationWarning, match="InsurancePolicy is deprecated"):
+            policy = InsurancePolicy(layers=layers, deductible=0)
 
         company, insurance = policy.process_claim(0)
         assert company == 0 and insurance == 0
@@ -428,7 +442,8 @@ class TestOverRecoveryGuard:
     def test_claim_exactly_at_deductible(self):
         """Test claim exactly equal to deductible."""
         layers = [InsuranceLayer(attachment_point=500_000, limit=5_000_000, rate=0.01)]
-        policy = InsurancePolicy(layers=layers, deductible=500_000)
+        with pytest.warns(DeprecationWarning, match="InsurancePolicy is deprecated"):
+            policy = InsurancePolicy(layers=layers, deductible=500_000)
 
         company, insurance = policy.process_claim(500_000)
         assert company == 500_000
@@ -440,7 +455,8 @@ class TestOverRecoveryGuard:
             InsuranceLayer(attachment_point=1_000_000, limit=4_000_000, rate=0.015),
             InsuranceLayer(attachment_point=5_000_000, limit=10_000_000, rate=0.008),
         ]
-        policy = InsurancePolicy(layers=layers, deductible=1_000_000)
+        with pytest.warns(DeprecationWarning, match="InsurancePolicy is deprecated"):
+            policy = InsurancePolicy(layers=layers, deductible=1_000_000)
 
         # Claim exactly at first layer exhaust point (5M)
         company, insurance = policy.process_claim(5_000_000)
@@ -458,38 +474,42 @@ class TestFromSimple:
 
     def test_creates_single_layer_policy(self):
         """from_simple() should create a policy with exactly one layer."""
-        policy = InsurancePolicy.from_simple(
-            deductible=500_000,
-            limit=10_000_000,
-            premium_rate=0.025,
-        )
+        with pytest.warns(DeprecationWarning, match="InsurancePolicy is deprecated"):
+            policy = InsurancePolicy.from_simple(
+                deductible=500_000,
+                limit=10_000_000,
+                premium_rate=0.025,
+            )
         assert len(policy.layers) == 1
 
     def test_deductible_set_correctly(self):
         """Deductible on the policy matches the argument."""
-        policy = InsurancePolicy.from_simple(
-            deductible=500_000,
-            limit=10_000_000,
-            premium_rate=0.025,
-        )
+        with pytest.warns(DeprecationWarning, match="InsurancePolicy is deprecated"):
+            policy = InsurancePolicy.from_simple(
+                deductible=500_000,
+                limit=10_000_000,
+                premium_rate=0.025,
+            )
         assert policy.deductible == 500_000
 
     def test_layer_attachment_equals_deductible(self):
         """The single layer's attachment point equals the deductible."""
-        policy = InsurancePolicy.from_simple(
-            deductible=500_000,
-            limit=10_000_000,
-            premium_rate=0.025,
-        )
+        with pytest.warns(DeprecationWarning, match="InsurancePolicy is deprecated"):
+            policy = InsurancePolicy.from_simple(
+                deductible=500_000,
+                limit=10_000_000,
+                premium_rate=0.025,
+            )
         assert policy.layers[0].attachment_point == 500_000
 
     def test_layer_limit_and_rate(self):
         """Layer limit and rate match the arguments."""
-        policy = InsurancePolicy.from_simple(
-            deductible=500_000,
-            limit=10_000_000,
-            premium_rate=0.025,
-        )
+        with pytest.warns(DeprecationWarning, match="InsurancePolicy is deprecated"):
+            policy = InsurancePolicy.from_simple(
+                deductible=500_000,
+                limit=10_000_000,
+                premium_rate=0.025,
+            )
         assert policy.layers[0].limit == 10_000_000
         assert policy.layers[0].rate == 0.025
 
@@ -500,13 +520,15 @@ class TestFromSimple:
             limit=10_000_000,
             rate=0.025,
         )
-        manual_policy = InsurancePolicy(layers=[manual_layer], deductible=500_000)
+        with pytest.warns(DeprecationWarning, match="InsurancePolicy is deprecated"):
+            manual_policy = InsurancePolicy(layers=[manual_layer], deductible=500_000)
 
-        simple_policy = InsurancePolicy.from_simple(
-            deductible=500_000,
-            limit=10_000_000,
-            premium_rate=0.025,
-        )
+        with pytest.warns(DeprecationWarning, match="InsurancePolicy is deprecated"):
+            simple_policy = InsurancePolicy.from_simple(
+                deductible=500_000,
+                limit=10_000_000,
+                premium_rate=0.025,
+            )
 
         # Same structure
         assert simple_policy.deductible == manual_policy.deductible
@@ -524,20 +546,22 @@ class TestFromSimple:
 
     def test_premium_calculation(self):
         """Premium is limit * premium_rate."""
-        policy = InsurancePolicy.from_simple(
-            deductible=500_000,
-            limit=10_000_000,
-            premium_rate=0.025,
-        )
+        with pytest.warns(DeprecationWarning, match="InsurancePolicy is deprecated"):
+            policy = InsurancePolicy.from_simple(
+                deductible=500_000,
+                limit=10_000_000,
+                premium_rate=0.025,
+            )
         assert policy.calculate_premium() == 250_000  # 10M * 0.025
 
     def test_claim_processing(self):
         """Claims flow correctly through a from_simple() policy."""
-        policy = InsurancePolicy.from_simple(
-            deductible=500_000,
-            limit=10_000_000,
-            premium_rate=0.025,
-        )
+        with pytest.warns(DeprecationWarning, match="InsurancePolicy is deprecated"):
+            policy = InsurancePolicy.from_simple(
+                deductible=500_000,
+                limit=10_000_000,
+                premium_rate=0.025,
+            )
 
         # Below deductible
         company, insurance = policy.process_claim(300_000)
@@ -556,11 +580,12 @@ class TestFromSimple:
 
     def test_zero_deductible(self):
         """from_simple() works with zero deductible."""
-        policy = InsurancePolicy.from_simple(
-            deductible=0,
-            limit=5_000_000,
-            premium_rate=0.03,
-        )
+        with pytest.warns(DeprecationWarning, match="InsurancePolicy is deprecated"):
+            policy = InsurancePolicy.from_simple(
+                deductible=0,
+                limit=5_000_000,
+                premium_rate=0.03,
+            )
         assert policy.deductible == 0
         assert policy.layers[0].attachment_point == 0
 
@@ -570,12 +595,13 @@ class TestFromSimple:
 
     def test_kwargs_forwarded(self):
         """Extra kwargs are forwarded to InsurancePolicy.__init__."""
-        policy = InsurancePolicy.from_simple(
-            deductible=500_000,
-            limit=10_000_000,
-            premium_rate=0.025,
-            pricing_enabled=True,
-        )
+        with pytest.warns(DeprecationWarning, match="InsurancePolicy is deprecated"):
+            policy = InsurancePolicy.from_simple(
+                deductible=500_000,
+                limit=10_000_000,
+                premium_rate=0.025,
+                pricing_enabled=True,
+            )
         assert policy.pricing_enabled is True
 
     def test_validation_propagates(self):

--- a/ergodic_insurance/tests/test_insurance_pricing.py
+++ b/ergodic_insurance/tests/test_insurance_pricing.py
@@ -567,18 +567,20 @@ class TestInsurancePolicyIntegration:
                 rate=0.008,
             ),
         ]
-        return InsurancePolicy(layers=layers, deductible=250_000)
+        with pytest.warns(DeprecationWarning, match="InsurancePolicy is deprecated"):
+            return InsurancePolicy(layers=layers, deductible=250_000)
 
     def test_price_insurance_policy(self, pricer, policy):
         """Test pricing an insurance policy."""
         original_rates = [layer.rate for layer in policy.layers]
 
-        priced_policy = pricer.price_insurance_policy(
-            policy=policy,
-            expected_revenue=15_000_000,
-            market_cycle=MarketCycle.NORMAL,
-            update_policy=True,
-        )
+        with pytest.warns(DeprecationWarning, match="price_insurance_policy.*deprecated"):
+            priced_policy = pricer.price_insurance_policy(
+                policy=policy,
+                expected_revenue=15_000_000,
+                market_cycle=MarketCycle.NORMAL,
+                update_policy=True,
+            )
 
         # Should be the same object if update_policy=True
         assert priced_policy is policy
@@ -601,19 +603,22 @@ class TestInsurancePolicyIntegration:
             ),
         ]
 
-        policy = InsurancePolicy(
-            layers=layers,
-            deductible=250_000,
-            pricing_enabled=True,
-        )
+        with pytest.warns(DeprecationWarning, match="InsurancePolicy is deprecated"):
+            policy = InsurancePolicy(
+                layers=layers,
+                deductible=250_000,
+                pricing_enabled=True,
+            )
 
         original_rate = policy.layers[0].rate
 
-        policy.apply_pricing(
-            expected_revenue=15_000_000,
-            market_cycle=MarketCycle.HARD,
-            loss_generator=loss_generator,
-        )
+        # apply_pricing internally calls price_insurance_policy which emits DeprecationWarning
+        with pytest.warns(DeprecationWarning, match="price_insurance_policy.*deprecated"):
+            policy.apply_pricing(
+                expected_revenue=15_000_000,
+                market_cycle=MarketCycle.HARD,
+                loss_generator=loss_generator,
+            )
 
         # Rate should be updated
         assert policy.layers[0].rate != original_rate
@@ -631,13 +636,14 @@ class TestInsurancePolicyIntegration:
             ),
         ]
 
-        policy = InsurancePolicy.create_with_pricing(
-            layers=layers,
-            loss_generator=loss_generator,
-            expected_revenue=15_000_000,
-            market_cycle=MarketCycle.SOFT,
-            deductible=250_000,
-        )
+        with pytest.warns(DeprecationWarning):
+            policy = InsurancePolicy.create_with_pricing(
+                layers=layers,
+                loss_generator=loss_generator,
+                expected_revenue=15_000_000,
+                market_cycle=MarketCycle.SOFT,
+                deductible=250_000,
+            )
 
         assert policy.pricing_enabled
         assert policy.pricer is not None
@@ -670,7 +676,8 @@ class TestBackwardCompatibility:
                 rate=0.015,
             ),
         ]
-        policy = InsurancePolicy(layers=layers, deductible=250_000)
+        with pytest.warns(DeprecationWarning, match="InsurancePolicy is deprecated"):
+            policy = InsurancePolicy(layers=layers, deductible=250_000)
 
         # Should work normally
         assert policy.calculate_premium() > 0

--- a/ergodic_insurance/tests/test_insurance_pricing_coverage.py
+++ b/ergodic_insurance/tests/test_insurance_pricing_coverage.py
@@ -41,14 +41,18 @@ def _make_insurance_program():
 
 def _make_insurance_policy():
     """Create a minimal InsurancePolicy for pricing tests."""
+    import warnings
+
     from ergodic_insurance.insurance import InsuranceLayer, InsurancePolicy
 
-    return InsurancePolicy(
-        layers=[
-            InsuranceLayer(attachment_point=100_000, limit=5_000_000, rate=0.03),
-        ],
-        deductible=100_000,
-    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        return InsurancePolicy(
+            layers=[
+                InsuranceLayer(attachment_point=100_000, limit=5_000_000, rate=0.03),
+            ],
+            deductible=100_000,
+        )
 
 
 class TestPriceInsuranceProgramNoRevenue:
@@ -108,11 +112,12 @@ class TestPriceInsurancePolicyCopy:
         policy = _make_insurance_policy()
         original_rate = policy.layers[0].rate
 
-        priced_copy = pricer.price_insurance_policy(
-            policy=policy,
-            expected_revenue=10_000_000,
-            update_policy=False,
-        )
+        with pytest.warns(DeprecationWarning, match="price_insurance_policy.*deprecated"):
+            priced_copy = pricer.price_insurance_policy(
+                policy=policy,
+                expected_revenue=10_000_000,
+                update_policy=False,
+            )
 
         # Original should be unchanged
         assert policy.layers[0].rate == original_rate
@@ -130,11 +135,12 @@ class TestPriceInsurancePolicyCopy:
         )
         policy = _make_insurance_policy()
 
-        priced = pricer.price_insurance_policy(
-            policy=policy,
-            expected_revenue=10_000_000,
-            update_policy=True,
-        )
+        with pytest.warns(DeprecationWarning, match="price_insurance_policy.*deprecated"):
+            priced = pricer.price_insurance_policy(
+                policy=policy,
+                expected_revenue=10_000_000,
+                update_policy=True,
+            )
         # Should be the same object
         assert priced is policy
 
@@ -152,10 +158,11 @@ class TestPriceInsurancePolicyStoreResults:
         )
         policy = _make_insurance_policy()
 
-        pricer.price_insurance_policy(
-            policy=policy,
-            expected_revenue=10_000_000,
-        )
+        with pytest.warns(DeprecationWarning, match="price_insurance_policy.*deprecated"):
+            pricer.price_insurance_policy(
+                policy=policy,
+                expected_revenue=10_000_000,
+            )
         assert hasattr(policy, "pricing_results")
         assert len(policy.pricing_results) == 1
         assert isinstance(policy.pricing_results[0], LayerPricing)

--- a/ergodic_insurance/tests/test_integration.py
+++ b/ergodic_insurance/tests/test_integration.py
@@ -6,6 +6,7 @@ pipeline works correctly and demonstrates the ergodic advantage of insurance.
 
 import time
 from typing import Any, Dict
+import warnings
 
 import numpy as np
 import psutil
@@ -52,13 +53,15 @@ class TestIntegration:
     @pytest.fixture
     def insurance_policy(self) -> InsurancePolicy:
         """Create insurance policy for tests."""
-        # Create a single layer insurance structure
-        layer = InsuranceLayer(
-            attachment_point=50_000,  # Acts like deductible
-            limit=5_000_000,
-            rate=0.02,
-        )
-        return InsurancePolicy(layers=[layer], deductible=50_000)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            # Create a single layer insurance structure
+            layer = InsuranceLayer(
+                attachment_point=50_000,  # Acts like deductible
+                limit=5_000_000,
+                rate=0.02,
+            )
+            return InsurancePolicy(layers=[layer], deductible=50_000)
 
     def test_full_pipeline_execution(self, base_config: dict, insurance_policy: InsurancePolicy):
         """Test that the full simulation pipeline executes without errors."""
@@ -79,12 +82,14 @@ class TestIntegration:
         )
 
         # Run single simulation
-        simulation = Simulation(
-            manufacturer=manufacturer,
-            loss_generator=loss_gen,
-            time_horizon=base_config["time_horizon"],
-            insurance_policy=insurance_policy,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            simulation = Simulation(
+                manufacturer=manufacturer,
+                loss_generator=loss_gen,
+                time_horizon=base_config["time_horizon"],
+                insurance_policy=insurance_policy,
+            )
         result = simulation.run()
 
         # Verify results
@@ -150,13 +155,15 @@ class TestIntegration:
         insured_results = []
         for i in range(10):  # Small sample for speed
             mfg = self.create_manufacturer(initial_assets=base_config["initial_assets"])
-            simulation = Simulation(
-                manufacturer=mfg,
-                loss_generator=loss_gen,
-                time_horizon=base_config["time_horizon"],
-                insurance_policy=insurance_policy,
-                seed=base_config["random_seed"] + i,
-            )
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                simulation = Simulation(
+                    manufacturer=mfg,
+                    loss_generator=loss_gen,
+                    time_horizon=base_config["time_horizon"],
+                    insurance_policy=insurance_policy,
+                    seed=base_config["random_seed"] + i,
+                )
             result = simulation.run()
             insured_results.append(result)
 
@@ -209,12 +216,14 @@ class TestIntegration:
         )
 
         # Better calibrated insurance for testing
-        layer = InsuranceLayer(
-            attachment_point=50_000,  # Lower attachment for better coverage
-            limit=5_000_000,  # Reasonable limit
-            rate=0.02,  # 2% rate = $100k premium
-        )
-        insurance = InsurancePolicy(layers=[layer], deductible=50_000)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            layer = InsuranceLayer(
+                attachment_point=50_000,  # Lower attachment for better coverage
+                limit=5_000_000,  # Reasonable limit
+                rate=0.02,  # 2% rate = $100k premium
+            )
+            insurance = InsurancePolicy(layers=[layer], deductible=50_000)
 
         # Run comparison
         analyzer = ErgodicAnalyzer()
@@ -230,13 +239,15 @@ class TestIntegration:
                 asset_turnover=1.2,
                 base_operating_margin=0.1,
             )
-            insured_simulation = Simulation(
-                manufacturer=insured_mfg,
-                loss_generator=loss_gen,
-                time_horizon=50,  # Shorter for testing
-                insurance_policy=insurance,
-                seed=base_config["random_seed"] + i,
-            )
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                insured_simulation = Simulation(
+                    manufacturer=insured_mfg,
+                    loss_generator=loss_gen,
+                    time_horizon=50,  # Shorter for testing
+                    insurance_policy=insurance,
+                    seed=base_config["random_seed"] + i,
+                )
             insured_result = insured_simulation.run()
             insured_batch.append(insured_result)
 
@@ -523,8 +534,10 @@ class TestIntegration:
         )
 
         # Create insurance
-        layer = InsuranceLayer(attachment_point=100_000, limit=5_000_000, rate=0.02)
-        insurance = InsurancePolicy(layers=[layer], deductible=100_000)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            layer = InsuranceLayer(attachment_point=100_000, limit=5_000_000, rate=0.02)
+            insurance = InsurancePolicy(layers=[layer], deductible=100_000)
 
         # Run base scenario (no insurance)
         sim_base = Simulation(
@@ -537,13 +550,15 @@ class TestIntegration:
         result_base = sim_base.run()
 
         # Run insured scenario
-        sim_insured = Simulation(
-            manufacturer=manufacturer_insured,
-            loss_generator=loss_gen,
-            time_horizon=20,
-            insurance_policy=insurance,
-            seed=42,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            sim_insured = Simulation(
+                manufacturer=manufacturer_insured,
+                loss_generator=loss_gen,
+                time_horizon=20,
+                insurance_policy=insurance,
+                seed=42,
+            )
         result_insured = sim_insured.run()
 
         # Create analyzer and validate

--- a/ergodic_insurance/tests/test_roe_insurance.py
+++ b/ergodic_insurance/tests/test_roe_insurance.py
@@ -4,6 +4,8 @@ This module ensures that ROE calculations correctly include all insurance
 expenses (premiums and claim deductibles) and that the fix doesn't regress.
 """
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -167,21 +169,23 @@ class TestROEWithInsurance:
         )
 
         # Create insurance policy
-        insurance = InsurancePolicy(
-            layers=[
-                InsuranceLayer(attachment_point=100_000, limit=10_000_000, rate=0.02)  # 2% rate
-            ],
-            deductible=100_000,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            insurance = InsurancePolicy(
+                layers=[
+                    InsuranceLayer(attachment_point=100_000, limit=10_000_000, rate=0.02)  # 2% rate
+                ],
+                deductible=100_000,
+            )
 
-        # Run short simulation
-        sim = Simulation(
-            manufacturer=manufacturer,
-            loss_generator=loss_gen,
-            insurance_policy=insurance,
-            time_horizon=3,
-            seed=42,
-        )
+            # Run short simulation
+            sim = Simulation(
+                manufacturer=manufacturer,
+                loss_generator=loss_gen,
+                insurance_policy=insurance,
+                time_horizon=3,
+                seed=42,
+            )
 
         results = sim.run()
         stats = results.summary_stats()
@@ -249,19 +253,21 @@ class TestROEWithInsurance:
         )
 
         # Create insurance
-        insurance = InsurancePolicy(
-            layers=[InsuranceLayer(attachment_point=100_000, limit=10_000_000, rate=0.015)],
-            deductible=100_000,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            insurance = InsurancePolicy(
+                layers=[InsuranceLayer(attachment_point=100_000, limit=10_000_000, rate=0.015)],
+                deductible=100_000,
+            )
 
-        # Run simulation with multiple generators
-        sim = Simulation(
-            manufacturer=manufacturer,
-            loss_generator=[standard, catastrophic],
-            insurance_policy=insurance,
-            time_horizon=5,
-            seed=42,
-        )
+            # Run simulation with multiple generators
+            sim = Simulation(
+                manufacturer=manufacturer,
+                loss_generator=[standard, catastrophic],
+                insurance_policy=insurance,
+                time_horizon=5,
+                seed=42,
+            )
 
         results = sim.run()
         stats = results.summary_stats()

--- a/ergodic_insurance/tests/test_run_analysis.py
+++ b/ergodic_insurance/tests/test_run_analysis.py
@@ -173,9 +173,9 @@ class TestRunAnalysis:
             seed=0,
             compare_uninsured=False,
         )
-        assert results.insurance_policy.deductible == 250_000
-        assert len(results.insurance_policy.layers) == 1
-        assert results.insurance_policy.layers[0].limit == 8_000_000
+        assert results.insurance_program.deductible == 250_000
+        assert len(results.insurance_program.layers) == 1
+        assert results.insurance_program.layers[0].limit == 8_000_000
 
 
 # ---------------------------------------------------------------------------
@@ -325,7 +325,7 @@ class TestEdgeCases:
             seed=0,
             compare_uninsured=False,
         )
-        assert results.insurance_policy.deductible == 0
+        assert results.insurance_program.deductible == 0
 
     def test_under_ten_lines(self):
         """Acceptance criterion: complete comparison in <10 lines."""

--- a/ergodic_insurance/tests/test_simulation_coverage.py
+++ b/ergodic_insurance/tests/test_simulation_coverage.py
@@ -9,6 +9,7 @@ Coverage targets:
 """
 
 from unittest.mock import MagicMock, Mock, patch
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -74,23 +75,27 @@ def manufacturer(manufacturer_config):
 @pytest.fixture
 def simple_insurance_policy():
     """Create a basic insurance policy for testing."""
-    layer = InsuranceLayer(
-        attachment_point=500_000,
-        limit=5_000_000,
-        rate=0.02,
-    )
-    return InsurancePolicy(layers=[layer], deductible=500_000)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        layer = InsuranceLayer(
+            attachment_point=500_000,
+            limit=5_000_000,
+            rate=0.02,
+        )
+        return InsurancePolicy(layers=[layer], deductible=500_000)
 
 
 @pytest.fixture
 def simulation_with_policy(manufacturer, simple_insurance_policy):
     """Create a simulation instance with insurance policy attached."""
-    return Simulation(
-        manufacturer=manufacturer,
-        insurance_policy=simple_insurance_policy,
-        time_horizon=10,
-        seed=42,
-    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        return Simulation(
+            manufacturer=manufacturer,
+            insurance_policy=simple_insurance_policy,
+            time_horizon=10,
+            seed=42,
+        )
 
 
 @pytest.fixture
@@ -364,12 +369,14 @@ class TestRunMonteCarlo:
     @pytest.fixture
     def test_policy(self):
         """Create a test insurance policy with known premium and coverage."""
-        layer = InsuranceLayer(
-            attachment_point=500_000,
-            limit=5_000_000,
-            rate=0.02,
-        )
-        return InsurancePolicy(layers=[layer], deductible=500_000)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            layer = InsuranceLayer(
+                attachment_point=500_000,
+                limit=5_000_000,
+                rate=0.02,
+            )
+            return InsurancePolicy(layers=[layer], deductible=500_000)
 
     @staticmethod
     def _make_mock_mc_results(has_statistics=True, has_geo_return=True):
@@ -418,13 +425,15 @@ class TestRunMonteCarlo:
 
         MockMCEngine.side_effect = [mock_engine_insured, mock_engine_uninsured]
 
-        output = Simulation.run_monte_carlo(
-            config=full_config,
-            insurance_policy=test_policy,
-            n_scenarios=100,
-            n_jobs=1,
-            seed=42,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            output = Simulation.run_monte_carlo(
+                config=full_config,
+                insurance_policy=test_policy,
+                n_scenarios=100,
+                n_jobs=1,
+                seed=42,
+            )
 
         # Verify both engines were created and run
         assert MockMCEngine.call_count == 2
@@ -470,13 +479,15 @@ class TestRunMonteCarlo:
 
         MockMCEngine.side_effect = [mock_engine_insured, mock_engine_uninsured]
 
-        output = Simulation.run_monte_carlo(
-            config=full_config,
-            insurance_policy=test_policy,
-            n_scenarios=50,
-            n_jobs=1,
-            seed=42,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            output = Simulation.run_monte_carlo(
+                config=full_config,
+                insurance_policy=test_policy,
+                n_scenarios=50,
+                n_jobs=1,
+                seed=42,
+            )
 
         assert "results_with_insurance" in output
         assert "results_without_insurance" in output
@@ -503,13 +514,15 @@ class TestRunMonteCarlo:
 
         MockMCEngine.side_effect = [mock_engine_insured, mock_engine_uninsured]
 
-        output = Simulation.run_monte_carlo(
-            config=full_config,
-            insurance_policy=test_policy,
-            n_scenarios=50,
-            n_jobs=1,
-            seed=42,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            output = Simulation.run_monte_carlo(
+                config=full_config,
+                insurance_policy=test_policy,
+                n_scenarios=50,
+                n_jobs=1,
+                seed=42,
+            )
 
         assert "results_with_insurance" in output
         assert "results_without_insurance" in output
@@ -524,13 +537,15 @@ class TestRunMonteCarlo:
         mock_engine.run.return_value = mock_results
         MockMCEngine.return_value = mock_engine
 
-        Simulation.run_monte_carlo(
-            config=full_config,
-            insurance_policy=test_policy,
-            n_scenarios=50,
-            n_jobs=4,
-            seed=99,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            Simulation.run_monte_carlo(
+                config=full_config,
+                insurance_policy=test_policy,
+                n_scenarios=50,
+                n_jobs=4,
+                seed=99,
+            )
 
         # Check that MonteCarloEngine was called with proper config
         assert MockMCEngine.call_count == 2
@@ -549,13 +564,15 @@ class TestRunMonteCarlo:
         mock_engine.run.return_value = mock_results
         MockMCEngine.return_value = mock_engine
 
-        Simulation.run_monte_carlo(
-            config=full_config,
-            insurance_policy=test_policy,
-            n_scenarios=10,
-            n_jobs=1,
-            seed=42,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            Simulation.run_monte_carlo(
+                config=full_config,
+                insurance_policy=test_policy,
+                n_scenarios=10,
+                n_jobs=1,
+                seed=42,
+            )
 
         call_kwargs = MockMCEngine.call_args_list[0][1]
         sim_config = call_kwargs["config"]
@@ -577,13 +594,15 @@ class TestRunMonteCarlo:
 
         MockMCEngine.side_effect = [mock_engine_insured, mock_engine_uninsured]
 
-        output = Simulation.run_monte_carlo(
-            config=full_config,
-            insurance_policy=test_policy,
-            n_scenarios=100,
-            n_jobs=1,
-            seed=42,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            output = Simulation.run_monte_carlo(
+                config=full_config,
+                insurance_policy=test_policy,
+                n_scenarios=100,
+                n_jobs=1,
+                seed=42,
+            )
 
         expected_premium = test_policy.calculate_premium()
         expected_initial_assets = full_config.manufacturer.initial_assets
@@ -611,26 +630,28 @@ class TestCompareInsuranceStrategies:
     @pytest.fixture
     def policy_dict(self):
         """Create a dictionary of insurance policies for comparison."""
-        low_coverage = InsurancePolicy(
-            layers=[InsuranceLayer(500_000, 2_000_000, 0.015)],
-            deductible=500_000,
-        )
-        medium_coverage = InsurancePolicy(
-            layers=[InsuranceLayer(500_000, 5_000_000, 0.02)],
-            deductible=500_000,
-        )
-        high_coverage = InsurancePolicy(
-            layers=[
-                InsuranceLayer(500_000, 5_000_000, 0.025),
-                InsuranceLayer(5_500_000, 10_000_000, 0.015),
-            ],
-            deductible=500_000,
-        )
-        return {
-            "Low": low_coverage,
-            "Medium": medium_coverage,
-            "High": high_coverage,
-        }
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            low_coverage = InsurancePolicy(
+                layers=[InsuranceLayer(500_000, 2_000_000, 0.015)],
+                deductible=500_000,
+            )
+            medium_coverage = InsurancePolicy(
+                layers=[InsuranceLayer(500_000, 5_000_000, 0.02)],
+                deductible=500_000,
+            )
+            high_coverage = InsurancePolicy(
+                layers=[
+                    InsuranceLayer(500_000, 5_000_000, 0.025),
+                    InsuranceLayer(5_500_000, 10_000_000, 0.015),
+                ],
+                deductible=500_000,
+            )
+            return {
+                "Low": low_coverage,
+                "Medium": medium_coverage,
+                "High": high_coverage,
+            }
 
     @staticmethod
     def _make_mc_output(n_scenarios=100):
@@ -736,12 +757,14 @@ class TestCompareInsuranceStrategies:
     @patch.object(Simulation, "run_monte_carlo")
     def test_compare_single_policy(self, mock_run_mc, full_config):
         """Works correctly with a single policy."""
-        single_policy = {
-            "OnlyPolicy": InsurancePolicy(
-                layers=[InsuranceLayer(0, 1_000_000, 0.03)],
-                deductible=0,
-            )
-        }
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            single_policy = {
+                "OnlyPolicy": InsurancePolicy(
+                    layers=[InsuranceLayer(0, 1_000_000, 0.03)],
+                    deductible=0,
+                )
+            }
         mock_run_mc.return_value = self._make_mc_output()
 
         df = Simulation.compare_insurance_strategies(
@@ -796,12 +819,14 @@ class TestCompareInsuranceStrategies:
             "results_without_insurance": MagicMock(),
         }
 
-        single_policy = {
-            "TestPolicy": InsurancePolicy(
-                layers=[InsuranceLayer(0, 1_000_000, 0.02)],
-                deductible=0,
-            )
-        }
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            single_policy = {
+                "TestPolicy": InsurancePolicy(
+                    layers=[InsuranceLayer(0, 1_000_000, 0.02)],
+                    deductible=0,
+                )
+            }
 
         df = Simulation.compare_insurance_strategies(
             config=full_config,
@@ -828,12 +853,14 @@ class TestCompareInsuranceStrategies:
             "results_without_insurance": MagicMock(),
         }
 
-        single_policy = {
-            "Test": InsurancePolicy(
-                layers=[InsuranceLayer(0, 1_000_000, 0.02)],
-                deductible=0,
-            )
-        }
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            single_policy = {
+                "Test": InsurancePolicy(
+                    layers=[InsuranceLayer(0, 1_000_000, 0.02)],
+                    deductible=0,
+                )
+            }
 
         df = Simulation.compare_insurance_strategies(
             config=full_config,
@@ -862,12 +889,14 @@ class TestCompareInsuranceStrategies:
             "results_without_insurance": MagicMock(),
         }
 
-        single_policy = {
-            "Test": InsurancePolicy(
-                layers=[InsuranceLayer(0, 1_000_000, 0.02)],
-                deductible=0,
-            )
-        }
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            single_policy = {
+                "Test": InsurancePolicy(
+                    layers=[InsuranceLayer(0, 1_000_000, 0.02)],
+                    deductible=0,
+                )
+            }
 
         df = Simulation.compare_insurance_strategies(
             config=full_config,


### PR DESCRIPTION
## Summary

- **Deprecates** `InsurancePolicy` and `InsuranceLayer` in favor of `InsuranceProgram` and `EnhancedInsuranceLayer` as the sole public API for insurance modeling (resolves #388)
- **Adds** `InsuranceProgram.simple(deductible, limit, rate)` factory and `calculate_premium()` convenience alias
- **Migrates** all internal code (`Simulation`, `run_analysis()`, `strategy_backtester`, `InsurancePricer`) to use `InsuranceProgram` directly
- **Preserves** full backward compatibility — deprecated classes still work with `DeprecationWarning`
- **Updates** all 12 documentation files, 6 example/notebook files, and 15 test files (34 new tests added)

## Acceptance Criteria (from issue)

- [x] `InsuranceProgram.simple(deductible, limit, rate)` factory for basic use cases
- [x] `InsuranceProgram.calculate_premium()` alias exists
- [x] `Simulation` and `MonteCarloEngine` both accept `InsuranceProgram`
- [x] `run_analysis()` uses `InsuranceProgram` internally
- [x] `AnalysisResults` exposes `insurance_program` (with backward-compat `insurance_policy` property)
- [x] `strategy_backtester.py` uses `InsuranceProgram` directly (no more convert-on-the-fly)
- [x] `InsurancePricer.price_insurance_policy()` emits deprecation warning
- [x] `InsurancePolicy` has deprecation warning directing to `InsuranceProgram`
- [x] Docs updated with no primary mention of `InsurancePolicy`
- [x] All existing tests pass (with deprecation warning assertions where needed)
- [x] New tests for `InsuranceProgram.simple()`, `calculate_premium()`, and Simulation integration

## Test plan

- [x] 4479 tests pass, 33 skipped, 0 failures (full suite with `-W error::DeprecationWarning`)
- [x] All pre-commit hooks pass (black, isort, mypy, pylint, conventional commit)
- [ ] Verify CI pipeline passes
- [ ] Smoke-test `run_analysis()` produces correct results
- [ ] Verify existing InsurancePolicy-based user code still works (with warnings)