### PR TITLE
fix: consolidate duplicate ExcelReportConfig into single Pydantic definition (#465)

### DIFF
--- a/ergodic_insurance/config/reporting.py
+++ b/ergodic_insurance/config/reporting.py
@@ -8,7 +8,7 @@ Since:
 """
 
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Any, Dict, Literal, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -61,16 +61,39 @@ class LoggingConfig(BaseModel):
 
 
 class ExcelReportConfig(BaseModel):
-    """Configuration for Excel report generation."""
+    """Configuration for Excel report generation.
+
+    This is the canonical definition used throughout the codebase.
+    Both ``ExcelReporter`` and the unified config hierarchy (``ConfigV2``)
+    use this class.
+
+    Attributes:
+        enabled: Whether Excel reporting is enabled.
+        output_path: Directory for output files.
+        include_balance_sheet: Whether to include balance sheet.
+        include_income_statement: Whether to include income statement.
+        include_cash_flow: Whether to include cash flow statement.
+        include_reconciliation: Whether to include reconciliation sheet.
+        include_metrics_dashboard: Whether to include metrics dashboard.
+        include_pivot_data: Whether to include pivot-ready data sheet.
+        formatting: Custom formatting options.
+        engine: Excel engine to use ('xlsxwriter', 'openpyxl', 'auto', 'pandas').
+        currency_format: Currency format string.
+        decimal_places: Number of decimal places for numbers.
+        date_format: Date format string.
+    """
 
     enabled: bool = Field(default=True, description="Whether Excel reporting is enabled")
-    output_path: str = Field(default="./reports", description="Directory for Excel reports")
+    output_path: Path = Field(default=Path("./reports"), description="Directory for Excel reports")
     include_balance_sheet: bool = Field(default=True, description="Include balance sheet")
     include_income_statement: bool = Field(default=True, description="Include income statement")
     include_cash_flow: bool = Field(default=True, description="Include cash flow statement")
     include_reconciliation: bool = Field(default=True, description="Include reconciliation report")
     include_metrics_dashboard: bool = Field(default=True, description="Include metrics dashboard")
     include_pivot_data: bool = Field(default=True, description="Include pivot-ready data")
+    formatting: Optional[Dict[str, Any]] = Field(
+        default=None, description="Custom formatting options"
+    )
     engine: str = Field(default="auto", description="Excel engine: xlsxwriter, openpyxl, or auto")
     currency_format: str = Field(default="$#,##0", description="Currency format string")
     decimal_places: int = Field(default=0, ge=0, le=10, description="Number of decimal places")

--- a/ergodic_insurance/excel_reporter.py
+++ b/ergodic_insurance/excel_reporter.py
@@ -7,7 +7,8 @@ Monte Carlo aggregations with advanced formatting and validation.
 Example:
     Generate Excel report from simulation::
 
-        from ergodic_insurance.excel_reporter import ExcelReporter, ExcelReportConfig
+        from ergodic_insurance.config import ExcelReportConfig
+        from ergodic_insurance.excel_reporter import ExcelReporter
         from ergodic_insurance.manufacturer import WidgetManufacturer
 
         # Configure report
@@ -26,7 +27,6 @@ Example:
         )
 """
 
-from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Literal, Optional
@@ -52,43 +52,11 @@ except ImportError:
     OPENPYXL_AVAILABLE = False
     warnings.warn("openpyxl not available. Using pandas default Excel writer.")
 
+from .config import ExcelReportConfig
 from .financial_statements import FinancialStatementConfig, FinancialStatementGenerator
 
 if TYPE_CHECKING:
     from .manufacturer import WidgetManufacturer
-
-
-@dataclass
-class ExcelReportConfig:
-    """Configuration for Excel report generation.
-
-    Attributes:
-        output_path: Directory for output files
-        include_balance_sheet: Whether to include balance sheet
-        include_income_statement: Whether to include income statement
-        include_cash_flow: Whether to include cash flow statement
-        include_reconciliation: Whether to include reconciliation sheet
-        include_metrics_dashboard: Whether to include metrics dashboard
-        include_pivot_data: Whether to include pivot-ready data sheet
-        formatting: Custom formatting options
-        engine: Excel engine to use ('xlsxwriter', 'openpyxl', 'auto')
-        currency_format: Currency format string
-        decimal_places: Number of decimal places for numbers
-        date_format: Date format string
-    """
-
-    output_path: Path = field(default_factory=lambda: Path("./reports"))
-    include_balance_sheet: bool = True
-    include_income_statement: bool = True
-    include_cash_flow: bool = True
-    include_reconciliation: bool = True
-    include_metrics_dashboard: bool = True
-    include_pivot_data: bool = True
-    formatting: Optional[Dict[str, Any]] = None
-    engine: str = "auto"
-    currency_format: str = "$#,##0"
-    decimal_places: int = 0
-    date_format: str = "yyyy-mm-dd"
 
 
 class ExcelReporter:


### PR DESCRIPTION
## Summary
- Removes the duplicate `@dataclass ExcelReportConfig` from `excel_reporter.py` and consolidates into the canonical Pydantic `BaseModel` definition in `config/reporting.py`
- Fixes `output_path` type from `str` to `Path` (required by `ExcelReporter` which calls `.mkdir()`)
- Adds the `formatting` field (previously only in the dataclass) to the Pydantic version
- Re-exports `ExcelReportConfig` from `excel_reporter` for backward compatibility — existing imports like `from ergodic_insurance.excel_reporter import ExcelReportConfig` continue to work

Closes #465

## Test plan
- [x] All 21 tests in `test_excel_reporter.py` pass (including new `test_invalid_engine_rejected`)
- [x] All 2 tests in `test_coverage_gaps_batch3.py::TestExcelReportConfigEngine` pass
- [x] All 5 ExcelReport tests in `test_coverage_gaps_batch4.py` pass
- [x] Integration test confirms both import paths (`config` and `excel_reporter`) resolve to the same class
- [x] All pre-commit hooks pass (black, isort, mypy, pylint)