### PR TITLE
feat!: replace dunder notation with dot-notation dict in Config.override()

### DIFF
--- a/ergodic_insurance/config_loader.py
+++ b/ergodic_insurance/config_loader.py
@@ -56,16 +56,16 @@ class ConfigLoader:
         self,
         config_name: str = "baseline",
         overrides: Optional[Dict[str, Any]] = None,
-        **kwargs: Any,
     ) -> Config:
         """Load configuration with optional overrides.
 
         Args:
             config_name: Name of config file (without .yaml extension)
                         or full path to config file.
-            overrides: Dictionary of overrides to apply.
-            **kwargs: Additional overrides in dot notation
-                     (e.g., manufacturer__operating_margin=0.1).
+            overrides: Dictionary of overrides to apply.  Supports
+                dot-notation keys (``{"manufacturer.tax_rate": 0.21}``)
+                and section-level dicts
+                (``{"manufacturer": {"tax_rate": 0.21}}``).
 
         Returns:
             Loaded and validated configuration.
@@ -94,7 +94,6 @@ class ConfigLoader:
         cache_key = (
             config_name,
             make_hashable(overrides) if overrides else None,
-            make_hashable(kwargs) if kwargs else None,
         )
 
         # Check cache
@@ -102,19 +101,16 @@ class ConfigLoader:
             return self._cache[cache_key]
 
         # Load using adapter and cache result
-        config: Config = self._adapter.load(config_name, overrides, **kwargs)
+        config: Config = self._adapter.load(config_name, overrides)
         self._cache[cache_key] = config
         return config
 
-    def load_scenario(
-        self, scenario: str, overrides: Optional[Dict[str, Any]] = None, **kwargs: Any
-    ) -> Config:
+    def load_scenario(self, scenario: str, overrides: Optional[Dict[str, Any]] = None) -> Config:
         """Load a predefined scenario configuration.
 
         Args:
             scenario: Scenario name ("baseline", "conservative", "optimistic").
             overrides: Dictionary of overrides to apply.
-            **kwargs: Additional overrides in dot notation.
 
         Returns:
             Loaded and validated configuration.
@@ -128,7 +124,7 @@ class ConfigLoader:
                 f"Unknown scenario '{scenario}'. Valid scenarios: {', '.join(valid_scenarios)}"
             )
 
-        return self.load(scenario, overrides, **kwargs)
+        return self.load(scenario, overrides)
 
     def compare_configs(
         self, config1: Union[str, Config], config2: Union[str, Config]
@@ -317,17 +313,17 @@ class ConfigLoader:
 def load_config(
     config_name: str = "baseline",
     overrides: Optional[Dict[str, Any]] = None,
-    **kwargs: Any,
 ) -> Config:
     """Quick helper to load a configuration.
 
     Args:
         config_name: Name of config file or full path.
-        overrides: Dictionary of overrides.
-        **kwargs: Keyword overrides in dot notation.
+        overrides: Dictionary of overrides.  Supports dot-notation keys
+            (``{"manufacturer.tax_rate": 0.21}``) and section-level dicts
+            (``{"manufacturer": {"tax_rate": 0.21}}``).
 
     Returns:
         Loaded configuration.
     """
     loader = ConfigLoader()
-    return loader.load(config_name, overrides, **kwargs)
+    return loader.load(config_name, overrides)

--- a/ergodic_insurance/config_manager.py
+++ b/ergodic_insurance/config_manager.py
@@ -237,7 +237,7 @@ class ConfigManager:
 
         # Apply runtime overrides
         if overrides:
-            config = config.with_overrides(**overrides)
+            config = config.with_overrides(overrides)
 
         # Validate completeness
         issues = config.validate_completeness()
@@ -401,17 +401,18 @@ class ConfigManager:
 
         return new_config
 
-    def with_overrides(self, config: ConfigV2, **overrides) -> ConfigV2:
+    def with_overrides(self, config: ConfigV2, overrides: Dict[str, Any]) -> ConfigV2:
         """Create a new configuration with runtime overrides.
 
         Args:
             config: Base configuration.
-            **overrides: Override parameters.
+            overrides: Override parameters as a dictionary with dot-notation
+                keys or section-level dictionaries.
 
         Returns:
             New ConfigV2 instance with overrides applied.
         """
-        return config.with_overrides(**overrides)
+        return config.with_overrides(overrides)
 
     def validate(self, config: ConfigV2) -> List[str]:
         """Validate a configuration for completeness and consistency.

--- a/ergodic_insurance/docs/architecture/configuration_v2.md
+++ b/ergodic_insurance/docs/architecture/configuration_v2.md
@@ -422,7 +422,7 @@ class ConfigV2(BaseModel):
 | `with_inheritance(profile_path, config_dir)` | Class method: load with recursive inheritance |
 | `apply_module(module_path)` | Apply a module YAML file to this config (in-place) |
 | `apply_preset(preset_name, preset_data)` | Apply preset parameters (in-place) |
-| `with_overrides(**kwargs)` | Return a new ConfigV2 with overrides (supports `section__field` notation) |
+| `with_overrides(overrides)` | Return a new ConfigV2 with overrides (supports `"section.field"` dot notation) |
 | `validate_completeness()` | Return list of missing or inconsistent items |
 | `_deep_merge(base, override)` | Static method: recursive dictionary merge |
 
@@ -1154,11 +1154,11 @@ config = manager.load_profile(
     simulation={"random_seed": 42}
 )
 
-# Double-underscore notation for nested overrides
-config = config.with_overrides(
-    manufacturer__initial_assets=20_000_000,
-    simulation__time_horizon_years=100
-)
+# Dot-notation for nested overrides
+config = config.with_overrides({
+    "manufacturer.initial_assets": 20_000_000,
+    "simulation.time_horizon_years": 100,
+})
 ```
 
 ### Testing Configurations

--- a/ergodic_insurance/docs/examples.rst
+++ b/ergodic_insurance/docs/examples.rst
@@ -83,7 +83,7 @@ Analyze sensitivity to operating margin:
     ruin_probs = []
 
     for margin in margins:
-        config = load_config("baseline", manufacturer__operating_margin=margin)
+        config = load_config("baseline", overrides={"manufacturer.operating_margin": margin})
 
         manufacturer = WidgetManufacturer(config.manufacturer)
         claim_generator = ClaimGenerator.from_config(config)
@@ -192,12 +192,12 @@ Advanced configuration management:
     base_config = loader.load("baseline")
 
     # Create a high-growth scenario
-    high_growth = base_config.override(
-        growth__annual_growth_rate=0.12,
-        growth__type="stochastic",
-        growth__volatility=0.15,
-        manufacturer__operating_margin=0.10
-    )
+    high_growth = base_config.override({
+        "growth.annual_growth_rate": 0.12,
+        "growth.type": "stochastic",
+        "growth.volatility": 0.15,
+        "manufacturer.operating_margin": 0.10,
+    })
 
     # Save custom configuration
     output_path = Path("outputs/high_growth_config.yaml")
@@ -220,9 +220,11 @@ For large-scale analysis, use these performance tips:
     # Configure for performance
     config = load_config(
         "baseline",
-        simulation__time_resolution="annual",  # Use annual steps
-        output__detailed_metrics=False,       # Reduce output detail
-        logging__enabled=False                 # Disable logging
+        overrides={
+            "simulation.time_resolution": "annual",  # Use annual steps
+            "output.detailed_metrics": False,         # Reduce output detail
+            "logging.enabled": False,                 # Disable logging
+        },
     )
 
     # Time a long simulation

--- a/ergodic_insurance/tests/test_config_loader.py
+++ b/ergodic_insurance/tests/test_config_loader.py
@@ -132,28 +132,24 @@ class TestConfigLoader:
 
             mock_load.assert_called_once_with("baseline", overrides)
 
-    def test_load_with_kwargs(self, temp_config_dir):
-        """Test loading configuration with keyword arguments."""
+    def test_load_with_dot_notation_overrides(self, temp_config_dir):
+        """Test loading configuration with dot-notation overrides."""
         loader = ConfigLoader(config_dir=temp_config_dir)
 
         with patch.object(loader._adapter, "load") as mock_load:
             mock_config = MagicMock(spec=Config)
             mock_load.return_value = mock_config
 
+            overrides = {
+                "manufacturer.base_operating_margin": 0.12,
+                "growth.annual_growth_rate": 0.08,
+            }
+
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", DeprecationWarning)
-                config = loader.load(
-                    "baseline",
-                    manufacturer__base_operating_margin=0.12,
-                    growth__annual_growth_rate=0.08,
-                )
+                config = loader.load("baseline", overrides=overrides)
 
-            mock_load.assert_called_once_with(
-                "baseline",
-                None,
-                manufacturer__base_operating_margin=0.12,
-                growth__annual_growth_rate=0.08,
-            )
+            mock_load.assert_called_once_with("baseline", overrides)
 
     def test_load_with_cache(self, temp_config_dir):
         """Test that configurations are cached."""

--- a/ergodic_insurance/tests/test_config_manager.py
+++ b/ergodic_insurance/tests/test_config_manager.py
@@ -110,7 +110,9 @@ class TestConfigManager:
         """Test profile loading with runtime overrides."""
         manager = ConfigManager(config_dir=temp_config_dir)
         config = manager.load_profile(
-            "test", manufacturer__initial_assets=20000000, simulation__time_horizon_years=200
+            "test",
+            manufacturer={"initial_assets": 20000000},
+            simulation={"time_horizon_years": 200},
         )
 
         assert config.manufacturer.initial_assets == 20000000
@@ -326,7 +328,9 @@ class TestConfigManager:
 
         # Test configuration merging through public API
         config = manager.load_profile(
-            "test", manufacturer__base_operating_margin=0.10, simulation__time_horizon_years=50
+            "test",
+            manufacturer={"base_operating_margin": 0.10},
+            simulation={"time_horizon_years": 50},
         )
         assert config.manufacturer.initial_assets == 10000000  # Preserved
         assert config.manufacturer.base_operating_margin == 0.10  # Overridden

--- a/ergodic_insurance/tests/test_config_manager_coverage.py
+++ b/ergodic_insurance/tests/test_config_manager_coverage.py
@@ -331,7 +331,9 @@ class TestWithPresetAndOverrides:
         manager = ConfigManager(config_dir=temp_config_dir)
         config = manager.load_profile("test", use_cache=False)
 
-        new_config = manager.with_overrides(config, manufacturer={"initial_assets": 99_999_999})
+        new_config = manager.with_overrides(
+            config, {"manufacturer": {"initial_assets": 99_999_999}}
+        )
         assert new_config.manufacturer.initial_assets == 99_999_999
 
 

--- a/ergodic_insurance/tests/test_config_v2.py
+++ b/ergodic_insurance/tests/test_config_v2.py
@@ -705,20 +705,22 @@ class TestConfigV2:
             logging=LoggingConfig(),
         )
 
-        # Test nested overrides
+        # Test nested overrides with dot notation
         new_config = config.with_overrides(
-            manufacturer__initial_assets=20000000,
-            manufacturer__base_operating_margin=0.10,
-            simulation__time_horizon_years=20,
+            {
+                "manufacturer.initial_assets": 20000000,
+                "manufacturer.base_operating_margin": 0.10,
+                "simulation.time_horizon_years": 20,
+            }
         )
 
         assert new_config.manufacturer.initial_assets == 20000000
         assert new_config.manufacturer.base_operating_margin == 0.10
         assert new_config.simulation.time_horizon_years == 20
         assert new_config.overrides == {
-            "manufacturer__initial_assets": 20000000,
-            "manufacturer__base_operating_margin": 0.10,
-            "simulation__time_horizon_years": 20,
+            "manufacturer.initial_assets": 20000000,
+            "manufacturer.base_operating_margin": 0.10,
+            "simulation.time_horizon_years": 20,
         }
 
         # Original config should be unchanged
@@ -747,10 +749,12 @@ class TestConfigV2:
             logging=LoggingConfig(),
         )
 
-        # Test simple key override
+        # Test simple key override (section-level dict)
         new_config = config.with_overrides(
-            custom_modules={"test": {"module_name": "test"}},
-            applied_presets=["preset1"],
+            {
+                "custom_modules": {"test": {"module_name": "test"}},
+                "applied_presets": ["preset1"],
+            }
         )
 
         assert "test" in new_config.custom_modules

--- a/ergodic_insurance/tests/test_config_v2_integration.py
+++ b/ergodic_insurance/tests/test_config_v2_integration.py
@@ -110,11 +110,13 @@ class TestIntegration:
         assert config.losses is not None and config.losses.tail_alpha == 3.0
         assert "high_volatility" in config.applied_presets
 
-        # Create override version
+        # Create override version using dot notation
         override_config = config.with_overrides(
-            manufacturer__initial_assets=20000000,
-            simulation__time_horizon_years=25,
-            insurance__deductible=150000,
+            {
+                "manufacturer.initial_assets": 20000000,
+                "simulation.time_horizon_years": 25,
+                "insurance.deductible": 150000,
+            }
         )
 
         assert override_config.manufacturer.initial_assets == 20000000

--- a/ergodic_insurance/tests/test_coverage_gaps_batch3.py
+++ b/ergodic_insurance/tests/test_coverage_gaps_batch3.py
@@ -473,7 +473,9 @@ class TestConfigV2WithOverridesNewSection:
         # Use a key path where intermediate keys do not exist in the data dict.
         # 'overrides' is already a dict; we use a deep path.
         new_config = base_config_v2.with_overrides(
-            manufacturer__initial_assets=20_000_000,
+            {
+                "manufacturer.initial_assets": 20_000_000,
+            }
         )
         assert new_config.manufacturer.initial_assets == 20_000_000
 

--- a/ergodic_insurance/tests/test_issue_357.py
+++ b/ergodic_insurance/tests/test_issue_357.py
@@ -244,7 +244,7 @@ class TestWithOverridesDeepMerge:
         original_retention = config.manufacturer.retention_ratio
 
         # Override only operating margin inside 'manufacturer'
-        result = config.with_overrides(manufacturer={"base_operating_margin": 0.15})
+        result = config.with_overrides({"manufacturer": {"base_operating_margin": 0.15}})
 
         # The overridden field is updated
         assert result.manufacturer.base_operating_margin == 0.15
@@ -257,7 +257,7 @@ class TestWithOverridesDeepMerge:
         config = _make_configv2()
         original_console = config.logging.console_output
 
-        result = config.with_overrides(logging={"level": "DEBUG"})
+        result = config.with_overrides({"logging": {"level": "DEBUG"}})
 
         assert result.logging.level == "DEBUG"
         assert result.logging.console_output == original_console
@@ -266,15 +266,15 @@ class TestWithOverridesDeepMerge:
         """Scalar overrides still replace the value entirely."""
         config = _make_configv2()
 
-        result = config.with_overrides(manufacturer={"initial_assets": 99_000_000})
+        result = config.with_overrides({"manufacturer": {"initial_assets": 99_000_000}})
 
         assert result.manufacturer.initial_assets == 99_000_000
 
-    def test_dunder_notation_still_works(self):
-        """Double-underscore notation for deep keys should still work."""
+    def test_dot_notation_works(self):
+        """Dot-notation for deep keys should work."""
         config = _make_configv2()
 
-        result = config.with_overrides(manufacturer__base_operating_margin=0.20)
+        result = config.with_overrides({"manufacturer.base_operating_margin": 0.20})
 
         assert result.manufacturer.base_operating_margin == 0.20
 


### PR DESCRIPTION
## Summary

Resolves #473 — replaces non-standard double-underscore (dunder) notation for nested config overrides with intuitive dot-notation dicts.

**Before:**
```python
config.override(manufacturer__tax_rate=0.21, simulation__time_horizon_years=100)
```

**After:**
```python
config.override({"manufacturer.tax_rate": 0.21, "simulation.time_horizon_years": 100})
```

### Changes

- **`Config.override()`** — accepts `Dict[str, Any]` with dot-notation keys; validates paths and raises clear `ValueError` for unknown sections/fields
- **`ConfigV2.with_overrides()`** — accepts dot-notation dict; also supports section-level dicts (`{"manufacturer": {"tax_rate": 0.21}}`) for backward compat with `ConfigManager`
- **`ConfigManager.with_overrides()`** — updated to pass dict directly
- **`ConfigLoader` / `config_compat`** — removed `**kwargs` dunder support; all override params now go through the `overrides` dict parameter
- **Validation** — invalid paths like `"nonexistent.field"` raise `ValueError` with a list of valid sections/fields
- **Tests** — 250 tests pass across 9 test files
- **Docs** — `examples.rst` and `configuration_v2.md` updated

## Test plan

- [x] `config.override({"manufacturer.tax_rate": 0.21})` works
- [x] Existing dunder syntax no longer works (removed from all APIs)
- [x] Docstrings show dot-notation as the preferred approach
- [x] All documentation updated to use new notation
- [x] All relevant tests updated (250 passing)
- [x] Invalid paths raise clear `ValueError` with valid options listed