### PR TITLE
fix: make AccrualManager tax payment scheduling fiscal-year-aware (#277)

### DIFF
--- a/ergodic_insurance/config/manufacturer.py
+++ b/ergodic_insurance/config/manufacturer.py
@@ -266,6 +266,15 @@ class ManufacturerConfig(BaseModel):
         "(Issue #255: Enables explicit COGS/SG&A calculation in Manufacturer)",
     )
 
+    # Fiscal year configuration (Issue #277)
+    fiscal_year_end: int = Field(
+        default=12,
+        ge=1,
+        le=12,
+        description="Month of fiscal year end (1-12). Default is 12 (December) for "
+        "calendar year alignment. Affects quarterly tax payment scheduling.",
+    )
+
     # Mid-year liquidity configuration (Issue #279)
     premium_payment_month: int = Field(
         default=0,

--- a/ergodic_insurance/manufacturer.py
+++ b/ergodic_insurance/manufacturer.py
@@ -169,8 +169,8 @@ class WidgetManufacturer(
         # Insurance accounting module
         self.insurance_accounting = InsuranceAccounting()
 
-        # Accrual management for timing differences
-        self.accrual_manager = AccrualManager()
+        # Accrual management for timing differences (Issue #277: fiscal-year-aware)
+        self.accrual_manager = AccrualManager(fiscal_year_end=config.fiscal_year_end)
 
         # Operating parameters
         self.asset_turnover_ratio = config.asset_turnover_ratio
@@ -851,8 +851,8 @@ class WidgetManufacturer(
         self._initial_assets = initial_assets
         self._initial_equity = initial_assets
 
-        # Reset accrual manager
-        self.accrual_manager = AccrualManager()
+        # Reset accrual manager (Issue #277: fiscal-year-aware)
+        self.accrual_manager = AccrualManager(fiscal_year_end=self.config.fiscal_year_end)
 
         # Reset tax handler with fresh NOL state (Issue #365)
         self.tax_handler = TaxHandler(


### PR DESCRIPTION
## Summary

- **AccrualManager** now accepts a `fiscal_year_end` parameter (default `12`) and computes quarterly tax payment dates relative to the fiscal year start per IRS rules (4th, 6th, 9th, 12th months of the corporation's tax year)
- Added `fiscal_year_end` field to **ManufacturerConfig** so it flows through to the accrual manager at init and reset
- Backward compatible: default `fiscal_year_end=12` produces identical behavior to the previous hardcoded calendar-year logic

## Files Changed

| File | Change |
|------|--------|
| `ergodic_insurance/accrual_manager.py` | Added `fiscal_year_end` param, `_get_fiscal_payment_periods()` helper, updated QUARTERLY and tax schedule logic |
| `ergodic_insurance/config/manufacturer.py` | Added `fiscal_year_end` field to `ManufacturerConfig` |
| `ergodic_insurance/manufacturer.py` | Pass `fiscal_year_end` from config to `AccrualManager` (init + reset) |
| `ergodic_insurance/tests/test_accrual_manager.py` | Added 10 new tests for fiscal year awareness |

## Test Plan

- [x] All 20 existing `TestAccrualManager` tests pass unchanged (backward compatibility)
- [x] 10 new `TestFiscalYearAwareScheduling` tests pass (June FYE, March FYE, year 2, deepcopy, payments due, explicit vs default)
- [x] 4 deep copy tests pass
- [x] 86 tax/NOL/DTA tests pass
- [x] 66 manufacturer tests pass
- [x] 216 config tests pass
- [x] All pre-commit hooks pass (black, isort, mypy, pylint)

Closes #277