### PR TITLE
ci: exclude performance benchmarks from CI with @pytest.mark.benchmark

### DIFF
--- a/ergodic_insurance/pytest.ini
+++ b/ergodic_insurance/pytest.ini
@@ -23,6 +23,7 @@ markers =
     integration: marks tests as integration tests
     unit: marks tests as unit tests
     requires_multiprocessing: marks tests that spawn child processes or use shared memory (skip in CI with xdist)
+    benchmark: performance benchmark test (skipped in CI)
 filterwarnings =
     # Ignore expected numerical warnings from test data with zero variance
     ignore:invalid value encountered in divide:RuntimeWarning:numpy.lib._function_base_impl

--- a/ergodic_insurance/tests/conftest.py
+++ b/ergodic_insurance/tests/conftest.py
@@ -39,14 +39,19 @@ from ergodic_insurance.tests.integration.test_fixtures import (
 
 
 def pytest_collection_modifyitems(config, items):
-    """Auto-skip requires_multiprocessing tests in CI (they crash xdist workers)."""
+    """Auto-skip requires_multiprocessing and benchmark tests in CI."""
     if os.environ.get("CI"):
-        skip_marker = pytest.mark.skip(
+        skip_mp = pytest.mark.skip(
             reason="Multiprocessing/shared memory tests crash xdist workers in CI"
+        )
+        skip_bench = pytest.mark.skip(
+            reason="Benchmark tests skipped in CI (variable performance on shared runners)"
         )
         for item in items:
             if "requires_multiprocessing" in item.keywords:
-                item.add_marker(skip_marker)
+                item.add_marker(skip_mp)
+            if "benchmark" in item.keywords:
+                item.add_marker(skip_bench)
 
 
 @pytest.fixture

--- a/ergodic_insurance/tests/integration/test_critical_integrations.py
+++ b/ergodic_insurance/tests/integration/test_critical_integrations.py
@@ -665,6 +665,7 @@ class TestValidationFramework:
 class TestEndToEndScenarios:
     """Test complete end-to-end scenarios."""
 
+    @pytest.mark.benchmark
     def test_startup_company_scenario(self, default_config_v2: ConfigV2):
         """Test startup company scenario (low assets, high risk).
 
@@ -760,9 +761,7 @@ class TestEndToEndScenarios:
         # Verify timing
         assert t["elapsed"] < 60, f"Startup scenario took {t['elapsed']:.2f}s, should be < 60s"
 
-    @pytest.mark.skip(
-        reason="Mature company scenario test is time-consuming and may require tuning."
-    )
+    @pytest.mark.benchmark
     def test_mature_company_scenario(self, default_config_v2: ConfigV2):
         """Test mature company scenario (stable, optimized).
 
@@ -1030,9 +1029,7 @@ class TestEndToEndScenarios:
             volatility > 0.16
         ), f"Growth scenario should have some volatility, got {volatility:.4f}"
 
-    @pytest.mark.skip(
-        reason="Performance benchmarks are environment-dependent and may not be stable in CI"
-    )
+    @pytest.mark.benchmark
     def test_performance_benchmarks(self, default_config_v2: ConfigV2):
         """Test that performance benchmarks are met.
 

--- a/ergodic_insurance/tests/integration/test_simulation_pipeline.py
+++ b/ergodic_insurance/tests/integration/test_simulation_pipeline.py
@@ -63,6 +63,7 @@ def worker_task_for_shared_memory_test(args: Tuple[int, int, int, Any]) -> None:
 class TestSimulationPipeline:
     """Test simulation pipeline integration."""
 
+    @pytest.mark.benchmark
     def test_monte_carlo_basic_execution(
         self,
         monte_carlo_engine: MonteCarloEngine,
@@ -640,7 +641,7 @@ class TestSimulationPipeline:
         assert full_results is not None, "Should have results"
         assert len(full_results.final_assets) == original_n_sims, "Should have complete results"
 
-    @pytest.mark.skip(reason="Performance test - enable manually")
+    @pytest.mark.benchmark
     def test_performance_scaling(
         self,
         default_config_v2: ConfigV2,

--- a/ergodic_insurance/tests/test_autocorrelation_fft_380.py
+++ b/ergodic_insurance/tests/test_autocorrelation_fft_380.py
@@ -5,7 +5,6 @@ matching the original O(N*L) loop implementation within 1e-10, and that
 the performance improvement is at least 1.5x for chains of length 25K+.
 """
 
-import os
 import time
 
 import numpy as np
@@ -111,10 +110,7 @@ class TestFFTAutocorrelationAccuracy:
         np.testing.assert_allclose(fft_result, loop_result[: len(fft_result)], atol=1e-10)
 
 
-@pytest.mark.skipif(
-    os.environ.get("CI") == "true",
-    reason="Speedup benchmarks are flaky on shared CI runners due to variable CPU performance",
-)
+@pytest.mark.benchmark
 class TestFFTAutocorrelationPerformance:
     """Verify >= 1.5x speedup for chains of length 25K+."""
 

--- a/ergodic_insurance/tests/test_benchmarking.py
+++ b/ergodic_insurance/tests/test_benchmarking.py
@@ -25,6 +25,8 @@ from ergodic_insurance.benchmarking import (
     run_quick_benchmark,
 )
 
+pytestmark = pytest.mark.benchmark
+
 
 class TestBenchmarkMetrics:
     """Test BenchmarkMetrics dataclass."""

--- a/ergodic_insurance/tests/test_cache_manager.py
+++ b/ergodic_insurance/tests/test_cache_manager.py
@@ -488,6 +488,7 @@ class TestCachePerformance:
         # Cleanup
         shutil.rmtree(temp_dir, ignore_errors=True)
 
+    @pytest.mark.benchmark
     def test_large_array_performance(self, perf_cache_manager):
         """Test performance with 10,000 × 1,000 array."""
         params = {"perf": "test"}
@@ -521,6 +522,7 @@ class TestCachePerformance:
         assert speedup > 5, f"Cache speedup only {speedup:.1f}x, expected >5x"
         print(f"Speedup: {speedup:.1f}x faster than computation")
 
+    @pytest.mark.benchmark
     @pytest.mark.parametrize(
         "compression,expected_ratio",
         [

--- a/ergodic_insurance/tests/test_claim_development.py
+++ b/ergodic_insurance/tests/test_claim_development.py
@@ -478,6 +478,7 @@ class TestLoadDevelopmentPatterns:
 class TestPerformance:
     """Performance tests for claim development."""
 
+    @pytest.mark.benchmark
     def test_large_cohort_performance(self):
         """Test performance with large number of claims."""
         import time
@@ -505,6 +506,7 @@ class TestPerformance:
         assert elapsed < 0.20, f"Processing took {elapsed:.3f}s, expected < 200ms"
         assert payment > 0  # Should have calculated payments
 
+    @pytest.mark.benchmark
     def test_multi_year_projection_performance(self):
         """Test performance of multi-year projections."""
         import time

--- a/ergodic_insurance/tests/test_end_to_end.py
+++ b/ergodic_insurance/tests/test_end_to_end.py
@@ -471,6 +471,7 @@ class TestDecisionFramework:
 class TestPerformanceWithRealData:
     """Test performance characteristics with real computations."""
 
+    @pytest.mark.benchmark
     def test_simulation_performance_scaling(self):
         """Test that simulation performance scales appropriately.
 
@@ -518,6 +519,7 @@ class TestPerformanceWithRealData:
         max_time = max(time_per_sim)
         assert max_time < min_time * 10.0
 
+    @pytest.mark.benchmark
     def test_cache_effectiveness_real_data(self):
         """Test cache effectiveness with real simulations.
 

--- a/ergodic_insurance/tests/test_insurance_program.py
+++ b/ergodic_insurance/tests/test_insurance_program.py
@@ -1045,6 +1045,7 @@ class TestCatastrophicScenarios:
         assert result["uncovered_loss"] == 5_000_000
         assert result["deductible_paid"] == 5_000_000  # Company pays uncovered
 
+    @pytest.mark.benchmark
     def test_performance_batch_processing(self):
         """Test performance requirement: process 10K claims in < 100ms."""
         import time

--- a/ergodic_insurance/tests/test_integration.py
+++ b/ergodic_insurance/tests/test_integration.py
@@ -63,6 +63,7 @@ class TestIntegration:
             )
             return InsurancePolicy(layers=[layer], deductible=50_000)
 
+    @pytest.mark.benchmark
     def test_full_pipeline_execution(self, base_config: dict, insurance_policy: InsurancePolicy):
         """Test that the full simulation pipeline executes without errors."""
         start_time = time.time()
@@ -287,7 +288,7 @@ class TestIntegration:
             comparison["insured"]["time_average_mean"]
         ), "Insured time average should be finite"
 
-    @pytest.mark.skip(reason="Performance benchmark, not regular test")
+    @pytest.mark.benchmark
     def test_performance_benchmarks(self, base_config: dict):
         """Test performance benchmarks for different scenario counts."""
         benchmarks = [
@@ -615,6 +616,7 @@ class TestIntegration:
         # Insured amount should be less due to recoveries
         assert total_insured <= total_original
 
+    @pytest.mark.benchmark
     def test_performance_with_loss_data(self, base_config: dict):
         """Test performance when using LossData structures."""
         # Generate large loss dataset

--- a/ergodic_insurance/tests/test_loss_distributions.py
+++ b/ergodic_insurance/tests/test_loss_distributions.py
@@ -787,6 +787,7 @@ class TestStatisticalTests:
 class TestPerformance:
     """Test performance requirements."""
 
+    @pytest.mark.benchmark
     def test_generate_million_samples(self):
         """Test that we can generate 1M samples in < 1 second."""
         dist = LognormalLoss(mean=50_000, cv=1.5)
@@ -798,6 +799,7 @@ class TestPerformance:
         assert len(samples) == 1_000_000
         assert elapsed_time < 1.0  # Should complete in less than 1 second
 
+    @pytest.mark.benchmark
     def test_large_simulation_performance(self):
         """Test performance of comprehensive simulation."""
         gen = ManufacturingLossGenerator()

--- a/ergodic_insurance/tests/test_monte_carlo_extended.py
+++ b/ergodic_insurance/tests/test_monte_carlo_extended.py
@@ -138,6 +138,7 @@ class TestMonteCarloExtended:
         assert results.execution_time > 0, "Execution time should be tracked"
         assert len(results.metrics) > 0, "Results should include computed metrics"
 
+    @pytest.mark.benchmark
     def test_cache_operations(self, setup_simple_engine):
         """Test cache save and load operations."""
         engine = setup_simple_engine

--- a/ergodic_insurance/tests/test_parallel_executor.py
+++ b/ergodic_insurance/tests/test_parallel_executor.py
@@ -617,6 +617,7 @@ class TestIntegration:
         assert "mean_final" in results
         assert "std_final" in results
 
+    @pytest.mark.benchmark
     @pytest.mark.skipif(
         platform.system() == "Windows", reason="Shared memory has issues on Windows in tests"
     )

--- a/ergodic_insurance/tests/test_performance.py
+++ b/ergodic_insurance/tests/test_performance.py
@@ -52,7 +52,7 @@ from ergodic_insurance.tests.test_fixtures import (
     TestDataGenerator,
 )
 
-pytest.skip(allow_module_level=True)
+pytestmark = pytest.mark.benchmark
 
 
 class TestPerformanceBenchmarks:

--- a/ergodic_insurance/tests/test_report_generation.py
+++ b/ergodic_insurance/tests/test_report_generation.py
@@ -705,6 +705,7 @@ class TestIntegration:
             for path in generated_reports:
                 assert path.exists()
 
+    @pytest.mark.benchmark
     def test_performance_requirements(self):
         """Test that report generation meets performance requirements."""
         import time

--- a/ergodic_insurance/tests/test_risk_metrics.py
+++ b/ergodic_insurance/tests/test_risk_metrics.py
@@ -542,6 +542,7 @@ class TestCompareRiskMetrics:
 class TestPerformance:
     """Test performance requirements."""
 
+    @pytest.mark.benchmark
     def test_large_dataset_performance(self):
         """Test that metrics calculate quickly for large datasets."""
         np.random.seed(42)

--- a/ergodic_insurance/tests/test_scenario_batch.py
+++ b/ergodic_insurance/tests/test_scenario_batch.py
@@ -761,6 +761,7 @@ class TestPerformance:
         assert len(scenarios) == 100
         assert len(manager.scenarios) == 100
 
+    @pytest.mark.benchmark
     def test_checkpoint_performance(self, mock_components):
         """Test checkpoint save/load performance."""
         loss_gen, insurance, manufacturer = mock_components

--- a/ergodic_insurance/tests/test_simulation.py
+++ b/ergodic_insurance/tests/test_simulation.py
@@ -326,7 +326,7 @@ class TestSimulation:
         # Check that some losses were generated
         assert np.sum(results.claim_counts) >= 0
 
-    @pytest.mark.skip(reason="Performance benchmark, not regular test")
+    @pytest.mark.benchmark
     def test_run_performance(self, manufacturer, loss_generator):
         """Test that 1000-year simulation completes in reasonable time."""
         sim = Simulation(

--- a/ergodic_insurance/tests/test_skipped_slow_tests.py
+++ b/ergodic_insurance/tests/test_skipped_slow_tests.py
@@ -33,10 +33,10 @@ else:
         StorageConfig = None  # type: ignore
         TrajectoryStorage = None  # type: ignore
 
-pytest.skip(allow_module_level=True)
+pytestmark = pytest.mark.benchmark
 
 
-def _test_cpu_bound_work(item):  # type: ignore[unreachable]
+def _test_cpu_bound_work(item):
     """Helper function for testing CPU-bound work."""
     result = 0
     for i in range(1000000):

--- a/ergodic_insurance/tests/test_trajectory_storage.py
+++ b/ergodic_insurance/tests/test_trajectory_storage.py
@@ -510,6 +510,7 @@ class TestMemoryEfficiency:
     """Test memory efficiency requirements."""
 
     @pytest.mark.slow
+    @pytest.mark.benchmark
     def test_lazy_loading_efficiency(self, tmp_path):
         """Test that lazy loading doesn't load unnecessary data."""
         import gc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,14 @@ known_first_party = ["ergodic_insurance"]
 sections = ["FUTURE", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]
 force_sort_within_sections = true
 
+[tool.pytest.ini_options]
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "integration: marks tests as integration tests",
+    "requires_multiprocessing: marks tests that require multiprocessing",
+    "benchmark: performance benchmark test (skipped in CI)",
+]
+
 [tool.coverage.run]
 source = ["ergodic_insurance"]
 omit = [


### PR DESCRIPTION
## Summary

- Register a `benchmark` pytest marker and auto-skip marked tests when the `CI` environment variable is set, preventing flaky failures from variable wall-clock timing on shared CI runners
- Mark 93 performance/benchmark tests across 19 files with `@pytest.mark.benchmark`
- Replace module-level `pytest.skip()`, ad-hoc `@pytest.mark.skip`, and `@pytest.mark.skipif(CI)` patterns with the centralized marker so benchmark tests are runnable locally via `pytest -m benchmark`

## Test plan

- [x] `pytest -m benchmark --collect-only` collects 93 benchmark tests
- [x] `CI=true pytest -m benchmark` skips all 93 tests
- [x] `pytest -m "not benchmark"` runs 4662 non-benchmark tests — all pass
- [x] All pre-commit hooks pass (black, isort, mypy, pylint, conventional-commit)

Closes #593