### PR TITLE
perf: reuse BusinessOptimizer in ParameterSweeper._run_single (#497)

### DIFF
--- a/ergodic_insurance/business_optimizer.py
+++ b/ergodic_insurance/business_optimizer.py
@@ -199,6 +199,31 @@ class BusinessOptimizer:
         self.ergodic_analyzer = ergodic_analyzer
         self.logger = logging.getLogger(self.__class__.__name__)
 
+    def with_manufacturer(self, manufacturer: WidgetManufacturer) -> "BusinessOptimizer":
+        """Create a lightweight optimizer for a different manufacturer.
+
+        Reuses the optimizer config, loss distribution, decision engine, and
+        ergodic analyzer from this instance, avoiding the overhead of
+        reconstructing shared components (YAML I/O, engine initialization).
+
+        The decision engine retains a reference to the original manufacturer,
+        which is correct because methods like maximize_roe_with_insurance read
+        directly from self.manufacturer rather than through the decision engine.
+
+        Args:
+            manufacturer: New manufacturer to optimize for.
+
+        Returns:
+            A new BusinessOptimizer sharing this instance's internal components.
+        """
+        return BusinessOptimizer(
+            manufacturer=manufacturer,
+            decision_engine=self.decision_engine,
+            ergodic_analyzer=self.ergodic_analyzer,
+            loss_distribution=self.loss_distribution,
+            optimizer_config=self.optimizer_config,
+        )
+
     def maximize_roe_with_insurance(
         self, constraints: BusinessConstraints, time_horizon: int = 10, n_simulations: int = 1000
     ) -> OptimalStrategy:


### PR DESCRIPTION
## Summary
- **Fix**: `_run_single()` always reconstructed a new `BusinessOptimizer` on every sweep point — both the `if` and `else` branches created `BusinessOptimizer(manufacturer)`, making the passed-in `self.optimizer` completely ignored.
- **Add** `BusinessOptimizer.with_manufacturer()` that creates a lightweight copy sharing the decision engine, loss distribution, optimizer config, and ergodic analyzer — only swapping the manufacturer.
- **Optimize** `_run_single()` to reuse optimizer components via `with_manufacturer()`, and cache a template optimizer for the no-optimizer case.

## Details
Each `BusinessOptimizer` construction triggers `InsuranceDecisionEngine.__init__` which performs YAML file I/O (`_load_pricing_scenarios`), creates `ConfigManager`, `ErgodicAnalyzer`, and sets up caches. For a 100-point sweep, this added ~100 redundant disk reads and engine constructions.

The `maximize_roe_with_insurance` path (used by sweeps) reads directly from `self.manufacturer` and `self.optimizer_config` — it never touches `self.decision_engine`. This makes it safe to share the decision engine across manufacturer swaps.

Closes #497

## Test plan
- [x] `test_with_manufacturer_shares_components` — verifies shared object identity for config, loss dist, decision engine, ergodic analyzer
- [x] `test_with_manufacturer_produces_working_optimizer` — verifies cloned optimizer can run full optimization
- [x] `test_run_single_reuses_optimizer_via_with_manufacturer` — verifies `with_manufacturer` is called instead of constructor
- [x] `test_run_single_caches_template_when_no_optimizer` — verifies template caching on first call, reuse on second
- [x] All 69 existing tests in `test_parameter_sweep.py` and `test_business_optimizer.py` pass
- [x] All pre-commit hooks pass (black, isort, mypy, pylint)