### PR TITLE
fix: add apply_tcja_limitation flag for pre/post-TCJA NOL modeling (#808)

### DIFF
--- a/ergodic_insurance/config/manufacturer.py
+++ b/ergodic_insurance/config/manufacturer.py
@@ -242,6 +242,13 @@ class ManufacturerConfig(BaseModel):
         "Set to 0.80 per IRC §172(a)(2) post-TCJA. "
         "Set to 1.0 for pre-2018 NOLs or non-US jurisdictions.",
     )
+    apply_tcja_limitation: bool = Field(
+        default=True,
+        description="Apply TCJA 80% NOL deduction limitation per IRC §172(a)(2). "
+        "When True (default), NOL deductions are limited to nol_limitation_pct of "
+        "taxable income (post-2017 rules). When False, NOLs can offset 100% of "
+        "taxable income (pre-2018 rules). See Issue #808.",
+    )
     retention_ratio: float = Field(
         default=0.7, ge=0, le=1, description="Portion of earnings retained"
     )

--- a/ergodic_insurance/manufacturer.py
+++ b/ergodic_insurance/manufacturer.py
@@ -178,7 +178,7 @@ class WidgetManufacturer(
         self.tax_rate = config.tax_rate
         self.retention_ratio = config.retention_ratio
 
-        # Tax handler with NOL carryforward tracking (Issue #365)
+        # Tax handler with NOL carryforward tracking (Issue #365, #808)
         self.tax_handler = TaxHandler(
             tax_rate=config.tax_rate,
             accrual_manager=self.accrual_manager,
@@ -186,6 +186,7 @@ class WidgetManufacturer(
             nol_limitation_pct=(
                 config.nol_limitation_pct if config.nol_carryforward_enabled else 0.0
             ),
+            apply_tcja_limitation=config.apply_tcja_limitation,
         )
         self._nol_carryforward_enabled = config.nol_carryforward_enabled
 


### PR DESCRIPTION
## Summary
- Adds `apply_tcja_limitation` boolean to `TaxHandler` and `ManufacturerConfig` to explicitly control whether the TCJA 80% NOL deduction limitation per IRC §172(a)(2) is applied
- When `True` (default): NOL deductions limited to `nol_limitation_pct` (80%) of taxable income, per post-2017 rules
- When `False`: NOLs can offset 100% of taxable income, for pre-2018 modeling scenarios

## Changes
| File | Change |
|---|---|
| `ergodic_insurance/tax_handler.py` | Added `apply_tcja_limitation: bool = True` field; branching logic in `calculate_tax_liability()` to bypass percentage limitation when False; TCJA docstring section |
| `ergodic_insurance/config/manufacturer.py` | Added `apply_tcja_limitation` Pydantic field with description |
| `ergodic_insurance/manufacturer.py` | Pass `apply_tcja_limitation` from config to TaxHandler |
| `ergodic_insurance/tests/test_nol_carryforward.py` | Added `TestTCJALimitation` class with 10 tests covering both modes, config propagation, multi-year scenarios, and TCJA vs pre-TCJA comparison |

## Test plan
- [x] All 22 NOL carryforward tests pass (10 existing + 12 new)
- [x] All 40 tax handling + DTA valuation allowance tests pass (no regressions)
- [x] `tax_handler.py` at 100% coverage (93 stmts, 28 branches, 0 misses)
- [x] All pre-commit hooks pass (black, isort, mypy, pylint, conventional commit)

Closes #808