### PR TITLE
fix: incorporate LAE loading into technical premium (#800)

### DIFF
--- a/ergodic_insurance/insurance_pricing.py
+++ b/ergodic_insurance/insurance_pricing.py
@@ -547,12 +547,17 @@ class InsurancePricer:
         pure_premium: float,
         limit: float,
     ) -> float:
-        """Convert pure premium to technical premium with risk loading.
+        """Convert pure premium to technical premium with risk and LAE loading.
 
         Technical premium adds a risk loading for parameter uncertainty
-        to the pure premium. Expense and profit margins are applied
+        to the pure premium, plus LAE (loss adjustment expense) as a known
+        cost component per ASOP 29.  Expense and profit margins are applied
         separately via the loss ratio in calculate_market_premium()
         to avoid double-counting.
+
+        Formula:
+            technical_premium = pure_premium * (1 + risk_loading)
+                              + pure_premium * lae_ratio
 
         Args:
             pure_premium: Expected loss cost
@@ -564,8 +569,11 @@ class InsurancePricer:
         # Add risk loading for uncertainty
         risk_loading = 1 + self.parameters.risk_loading
 
+        # LAE is a known cost component added on top of risk-loaded premium
+        lae_loading = pure_premium * self.parameters.lae_ratio
+
         # Calculate technical premium (expense/profit applied via loss ratio)
-        technical_premium = pure_premium * risk_loading
+        technical_premium = (pure_premium * risk_loading) + lae_loading
 
         # Apply minimum premium
         technical_premium = max(technical_premium, self.parameters.min_premium)


### PR DESCRIPTION
## Summary
- LAE (ALAE + ULAE) was calculated but never added to the technical premium, understating premiums by the full LAE ratio (default 15%)
- Updated `calculate_technical_premium()` formula to: `pure_premium * (1 + risk_loading) + pure_premium * lae_ratio`
- Added two new tests verifying LAE inclusion and flow-through to market premium

## Details
Per ASOP 29 and Werner & Modlin Ch. 7, LAE must be reflected in the premium charged. Risk loading applies to loss uncertainty; LAE is added as a known cost component. The fix propagates automatically to `calculate_market_premium()`, `price_layer()`, and `compare_market_cycles()` through the call chain.

Closes #800

## Test plan
- [x] `test_insurance_pricing.py` — 59 passed (updated existing test + 2 new)
- [x] `test_lae_tracking.py` — 31 passed (no regressions)
- [x] `test_insurance_pricing_coverage.py` — 15 passed (no regressions)
- [x] `test_layer_pricing.py` — 53 passed (no regressions)