### PR TITLE
fix: pay tail factor once and use paid basis for BF ultimate (#810, #805)

### DIFF
--- a/ergodic_insurance/claim_development.py
+++ b/ergodic_insurance/claim_development.py
@@ -155,8 +155,7 @@ class ClaimDevelopment:
 
         if development_year < len(self.development_factors):
             return claim_amount * self.development_factors[development_year]
-        if self.tail_factor > 0:
-            # Apply tail factor for years beyond pattern
+        if self.tail_factor > 0 and development_year == len(self.development_factors):
             return claim_amount * self.tail_factor
         return 0.0
 
@@ -177,7 +176,7 @@ class ClaimDevelopment:
         )
 
         if years_since_accident > len(self.development_factors) and self.tail_factor > 0:
-            cumulative += self.tail_factor * (years_since_accident - len(self.development_factors))
+            cumulative += self.tail_factor
 
         return min(cumulative, 1.0)
 
@@ -761,7 +760,7 @@ class CashFlowProjector:
             cohort_premium = earned_premium.get(accident_year) if earned_premium else None
             if elr is not None and cohort_premium is not None:
                 bf_ibnr = elr * cohort_premium * (1 - pct_developed)
-                bf_ultimate = incurred + bf_ibnr
+                bf_ultimate = paid_to_date + bf_ibnr
 
             # Maturity-adaptive credibility blend (E2)
             if cl_ultimate is not None and bf_ultimate is not None:


### PR DESCRIPTION
## Summary
- **#810**: Fix `calculate_payments()` to pay tail factor only once at `development_year == len(factors)`, not every year beyond the pattern. Also fix `get_cumulative_paid()` to add tail factor once instead of multiplying by years elapsed. Prevents unbounded payments in long-horizon simulations.
- **#805**: Fix `estimate_ibnr()` BF formula from `incurred + bf_ibnr` to `paid_to_date + bf_ibnr` (standard Paid BF per Friedland Ch. 9, CAS Exam 5). Eliminates mixed-basis double-counting of case reserves.

Closes #810, closes #805.

## Changes
- `claim_development.py`: 3 one-line fixes (L157, L179, L763)
- `test_claim_development.py`: Updated 7 tests with corrected expected values, added 4 regression tests

## Test plan
- [x] All 62 `test_claim_development.py` tests pass
- [x] All 40 stochastic + integration claim development tests pass
- [x] All pre-commit hooks (black, isort, mypy, pylint) pass
- [x] Regression tests verify tail pays exactly once and total payments == claim_amount
- [x] Regression tests verify BF ultimate uses paid_to_date, not incurred