### PR TITLE
feat: add copy parameter to Simulation.__init__ to protect caller's manufacturer (#802)

### DIFF
--- a/ergodic_insurance/integrated_analysis.py
+++ b/ergodic_insurance/integrated_analysis.py
@@ -88,7 +88,7 @@ def integrate_loss_ergodic_analysis(
     simulation_results = []
     for sim_idx in range(n_simulations):
         mfg_copy = copy.deepcopy(manufacturer)
-        sim = Simulation(manufacturer=mfg_copy, time_horizon=time_horizon, seed=sim_idx)
+        sim = Simulation(manufacturer=mfg_copy, time_horizon=time_horizon, seed=sim_idx, copy=False)
 
         # Initialize result storage
         sim.years = np.arange(time_horizon)

--- a/ergodic_insurance/tests/test_execution_semantics.py
+++ b/ergodic_insurance/tests/test_execution_semantics.py
@@ -128,6 +128,112 @@ class TestReEntrancy:
         assert results1.equity[0] == results2.equity[0]
 
 
+class TestCopyParameter:
+    """Test that Simulation.__init__ copy parameter protects caller's manufacturer (Issue #802)."""
+
+    def test_caller_manufacturer_not_mutated_by_default(self, manufacturer_config, loss_generator):
+        """Default copy=True protects the caller's manufacturer from mutation."""
+        manufacturer = WidgetManufacturer(manufacturer_config)
+        original_assets = manufacturer.current_assets
+        original_equity = manufacturer.current_equity
+
+        sim = Simulation(
+            manufacturer=manufacturer,
+            loss_generator=loss_generator,
+            time_horizon=10,
+            seed=42,
+        )
+        sim.run()
+
+        assert manufacturer.current_assets == original_assets
+        assert manufacturer.current_equity == original_equity
+
+    def test_copy_false_shares_reference(self, manufacturer_config, loss_generator):
+        """copy=False shares the caller's manufacturer reference with the simulation."""
+        manufacturer = WidgetManufacturer(manufacturer_config)
+
+        sim = Simulation(
+            manufacturer=manufacturer,
+            loss_generator=loss_generator,
+            time_horizon=10,
+            seed=42,
+            copy=False,
+        )
+
+        # With copy=False, sim.manufacturer IS the caller's object
+        assert sim.manufacturer is manufacturer
+
+    def test_copy_true_isolates_reference(self, manufacturer_config, loss_generator):
+        """copy=True (default) creates an independent copy of the manufacturer."""
+        manufacturer = WidgetManufacturer(manufacturer_config)
+
+        sim = Simulation(
+            manufacturer=manufacturer,
+            loss_generator=loss_generator,
+            time_horizon=10,
+            seed=42,
+        )
+
+        # With copy=True, sim.manufacturer is a different object
+        assert sim.manufacturer is not manufacturer
+
+    def test_copy_false_exposes_caller_to_step_annual_mutation(self, manufacturer_config):
+        """copy=False means step_annual() directly mutates the caller's manufacturer."""
+        manufacturer = WidgetManufacturer(manufacturer_config)
+        original_equity = manufacturer.current_equity
+
+        sim = Simulation(
+            manufacturer=manufacturer,
+            time_horizon=10,
+            seed=42,
+            copy=False,
+        )
+
+        # Directly call step_annual (bypasses run()'s reset)
+        large_loss = LossEvent(time=0, amount=1_000_000)
+        sim.step_annual(0, [large_loss])
+
+        # The caller's manufacturer was mutated
+        assert manufacturer.current_equity != original_equity
+
+    def test_reuse_manufacturer_across_simulations(self, manufacturer_config, loss_generator):
+        """Default copy=True allows safe reuse across multiple simulations."""
+        manufacturer = WidgetManufacturer(manufacturer_config)
+
+        sim_a = Simulation(
+            manufacturer=manufacturer,
+            loss_generator=loss_generator,
+            time_horizon=10,
+            seed=42,
+        )
+        results_a = sim_a.run()
+
+        sim_b = Simulation(
+            manufacturer=manufacturer,
+            loss_generator=loss_generator,
+            time_horizon=10,
+            seed=42,
+        )
+        results_b = sim_b.run()
+
+        # Both simulations start from identical initial state
+        np.testing.assert_array_equal(results_a.assets, results_b.assets)
+        np.testing.assert_array_equal(results_a.equity, results_b.equity)
+
+    def test_re_entrancy_preserved_with_copy(self, manufacturer, loss_generator):
+        """Re-entrancy still works with copy=True."""
+        sim = Simulation(
+            manufacturer=manufacturer,
+            loss_generator=loss_generator,
+            time_horizon=5,
+            seed=42,
+        )
+        results1 = sim.run()
+        results2 = sim.run()
+
+        np.testing.assert_array_equal(results1.assets, results2.assets)
+
+
 class TestInsolvencyDetection:
     """Test that insolvency is detected in the year it occurs."""
 

--- a/ergodic_insurance/tests/test_simulation.py
+++ b/ergodic_insurance/tests/test_simulation.py
@@ -283,7 +283,10 @@ class TestSimulation:
             manufacturer=manufacturer, loss_generator=loss_generator, time_horizon=100, seed=42
         )
 
-        assert sim.manufacturer == manufacturer
+        # copy=True (default) deep-copies the manufacturer (Issue #802)
+        assert sim.manufacturer is not manufacturer
+        assert sim.manufacturer.current_assets == manufacturer.current_assets
+        assert sim.manufacturer.current_equity == manufacturer.current_equity
         assert sim.loss_generator == [loss_generator]  # Simulation wraps single generator in list
         assert sim.time_horizon == 100
         assert sim.seed == 42


### PR DESCRIPTION
## Summary
- `Simulation.__init__` now deep-copies the manufacturer by default (`copy=True`), preventing silent mutation of the caller's reference during simulation
- `copy=False` escape hatch available for performance-critical paths (e.g., when the caller already deep-copied the manufacturer)
- Updated `integrated_analysis.py` to use `copy=False` in its Monte Carlo loop where it already performs its own deep-copy

Closes #802

## Test plan
- [x] New `TestCopyParameter` test class with 6 tests covering:
  - Default `copy=True` protects caller's manufacturer from mutation
  - `copy=False` shares the caller's reference
  - `copy=True` isolates the reference
  - `copy=False` exposes caller to `step_annual()` mutation
  - Safe reuse of manufacturer across multiple simulations
  - Re-entrancy preserved with `copy=True`
- [x] All 63 simulation-related tests pass (test_execution_semantics, test_simulation, test_simulation_coverage)
- [x] All 51 integration/deep-copy/ROE tests pass (only pre-existing performance benchmark flaky)
- [x] All pre-commit hooks pass (black, isort, mypy, pylint, conventional commit)