### PR TITLE
fix: log and track worker item failures in parallel executor (#1005)

### DIFF
--- a/ergodic_insurance/parallel_executor.py
+++ b/ergodic_insurance/parallel_executor.py
@@ -30,12 +30,14 @@ Date:
 
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass
+import logging
 import multiprocessing as mp
 from multiprocessing import shared_memory
 import os
 import platform
 import threading
 import time
+import traceback
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import uuid
 import warnings
@@ -45,6 +47,8 @@ import psutil
 from tqdm import tqdm
 
 from ergodic_insurance.safe_pickle import safe_dumps, safe_loads
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -339,6 +343,8 @@ class PerformanceMetrics:
     cpu_utilization: float = 0.0
     items_per_second: float = 0.0
     speedup: float = 1.0
+    total_items: int = 0
+    failed_items: int = 0
 
     def summary(self) -> str:
         """Generate performance summary.
@@ -348,19 +354,27 @@ class PerformanceMetrics:
         """
         overhead = self.serialization_time / self.total_time * 100 if self.total_time > 0 else 0
 
-        return (
-            f"Performance Summary\n"
-            f"{'='*50}\n"
-            f"Total Time: {self.total_time:.2f}s\n"
-            f"Setup: {self.setup_time:.2f}s\n"
-            f"Computation: {self.computation_time:.2f}s\n"
-            f"Serialization: {self.serialization_time:.2f}s ({overhead:.1f}% overhead)\n"
-            f"Reduction: {self.reduction_time:.2f}s\n"
-            f"Peak Memory: {self.memory_peak / 1024**2:.1f} MB\n"
-            f"CPU Utilization: {self.cpu_utilization:.1f}%\n"
-            f"Throughput: {self.items_per_second:.0f} items/s\n"
-            f"Speedup: {self.speedup:.2f}x\n"
-        )
+        lines = [
+            f"Performance Summary\n",
+            f"{'='*50}\n",
+            f"Total Time: {self.total_time:.2f}s\n",
+            f"Setup: {self.setup_time:.2f}s\n",
+            f"Computation: {self.computation_time:.2f}s\n",
+            f"Serialization: {self.serialization_time:.2f}s ({overhead:.1f}% overhead)\n",
+            f"Reduction: {self.reduction_time:.2f}s\n",
+            f"Peak Memory: {self.memory_peak / 1024**2:.1f} MB\n",
+            f"CPU Utilization: {self.cpu_utilization:.1f}%\n",
+            f"Throughput: {self.items_per_second:.0f} items/s\n",
+            f"Speedup: {self.speedup:.2f}x\n",
+        ]
+
+        if self.failed_items > 0:
+            failure_rate = self.failed_items / self.total_items * 100 if self.total_items > 0 else 0
+            lines.append(
+                f"Failed Items: {self.failed_items}/{self.total_items}" f" ({failure_rate:.1f}%)\n"
+            )
+
+        return "".join(lines)
 
 
 class ParallelExecutor:
@@ -377,6 +391,7 @@ class ParallelExecutor:
         chunking_strategy: Optional[ChunkingStrategy] = None,
         shared_memory_config: Optional[SharedMemoryConfig] = None,
         monitor_performance: bool = True,
+        max_failure_rate: Optional[float] = None,
     ):
         """Initialize parallel executor.
 
@@ -385,6 +400,10 @@ class ParallelExecutor:
             chunking_strategy: Strategy for work distribution
             shared_memory_config: Configuration for shared memory
             monitor_performance: Enable performance monitoring
+            max_failure_rate: Maximum fraction of items that may fail before
+                raising a ``RuntimeError``.  For example, ``0.1`` means raise
+                if more than 10 % of items fail.  ``None`` (default) disables
+                the threshold check.
         """
         # Detect CPU profile
         self.cpu_profile = CPUProfile.detect()
@@ -404,6 +423,9 @@ class ParallelExecutor:
 
         # Initialize shared memory manager
         self.shared_memory_manager = SharedMemoryManager(self.shared_memory_config)
+
+        # Failure threshold
+        self.max_failure_rate = max_failure_rate
 
         # Performance monitoring
         self.monitor_performance = monitor_performance
@@ -614,6 +636,7 @@ class ParallelExecutor:
             List[Any]: Results from all chunks
         """
         results = []
+        total_failed = 0
 
         # Create process pool with optimized settings
         # Set CPU affinity if on Linux
@@ -648,9 +671,10 @@ class ParallelExecutor:
                     break
 
                 try:
-                    result = future.result()
+                    chunk_results, chunk_failed = future.result()
                     chunk_info = futures[future]
-                    results.append((chunk_info[0], result))
+                    results.append((chunk_info[0], chunk_results))
+                    total_failed += chunk_failed
 
                     # Update completed count
                     completed_items += chunk_info[1] - chunk_info[0]
@@ -665,9 +689,35 @@ class ParallelExecutor:
                     # Return empty list for failed chunks instead of None
                     chunk_info = futures[future]
                     results.append((chunk_info[0], []))
+                    # Count all items in the failed chunk as failures
+                    total_failed += chunk_info[1] - chunk_info[0]
 
             if progress_bar:
                 pbar.close()
+
+        # Update failure metrics
+        self.performance_metrics.total_items = total_items
+        self.performance_metrics.failed_items = total_failed
+
+        if total_failed > 0:
+            logger.warning(
+                "%d of %d work items failed (%.1f%%)",
+                total_failed,
+                total_items,
+                total_failed / total_items * 100 if total_items > 0 else 0,
+            )
+
+        # Check failure rate threshold
+        if (
+            self.max_failure_rate is not None
+            and total_items > 0
+            and total_failed / total_items > self.max_failure_rate
+        ):
+            raise RuntimeError(
+                f"Failure rate {total_failed}/{total_items} "
+                f"({total_failed / total_items:.1%}) exceeds maximum "
+                f"allowed rate of {self.max_failure_rate:.1%}"
+            )
 
         # Sort results by original order
         results.sort(key=lambda x: x[0])
@@ -724,9 +774,10 @@ def _execute_chunk(
         shared_memory_config: Shared memory configuration
 
     Returns:
-        Any: Results from the chunk
+        Tuple[List[Any], int]: A tuple of (results, failed_count) where
+            failed items are represented as ``None`` in the results list.
     """
-    _start_idx, _end_idx, items = chunk
+    start_idx, _end_idx, items = chunk
 
     # Reconstruct shared data
     shared_data = {}
@@ -745,7 +796,8 @@ def _execute_chunk(
     # Process items - return partial results on individual failures
     try:
         results = []
-        for item in items:
+        failed_count = 0
+        for idx, item in enumerate(items):
             try:
                 if shared_data:
                     result = work_function(item, **shared_data)
@@ -753,9 +805,16 @@ def _execute_chunk(
                     result = work_function(item)
                 results.append(result)
             except Exception:
+                failed_count += 1
+                item_idx = start_idx + idx
+                logger.warning(
+                    "Work item %d failed: %s",
+                    item_idx,
+                    traceback.format_exc().strip(),
+                )
                 results.append(None)
 
-        return results
+        return results, failed_count
     finally:
         if sm_manager is not None:
             sm_manager.cleanup()

--- a/ergodic_insurance/tests/test_coverage_gaps_parallel_executor.py
+++ b/ergodic_insurance/tests/test_coverage_gaps_parallel_executor.py
@@ -446,10 +446,11 @@ class TestExecuteChunkArrayPathMocked:
             return float(item * w.sum())
 
         chunk = (0, 3, [1, 2, 3])
-        results = _execute_chunk(work, chunk, shared_refs, config)
+        results, failed_count = _execute_chunk(work, chunk, shared_refs, config)
 
         total = 10.0 + 20.0 + 30.0  # 60.0
         assert results == [1 * total, 2 * total, 3 * total]
+        assert failed_count == 0
 
         manager.cleanup()
 
@@ -471,8 +472,9 @@ class TestExecuteChunkArrayPathMocked:
             return item * kwargs["cfg"]["factor"]
 
         chunk = (0, 2, [3, 7])
-        results = _execute_chunk(work, chunk, shared_refs, config)
+        results, failed_count = _execute_chunk(work, chunk, shared_refs, config)
         assert results == [15, 35]
+        assert failed_count == 0
 
         manager.cleanup()
 
@@ -495,8 +497,9 @@ class TestExecuteChunkArrayPathMocked:
             return item * kwargs["comp_cfg"]["multiplier"]
 
         chunk = (0, 2, [4, 8])
-        results = _execute_chunk(work, chunk, shared_refs, config)
+        results, failed_count = _execute_chunk(work, chunk, shared_refs, config)
         assert results == [12, 24]
+        assert failed_count == 0
 
         manager.cleanup()
 
@@ -528,10 +531,11 @@ class TestExecuteChunkArrayPathMocked:
             return float(item * v.sum() + c["offset"])
 
         chunk = (0, 2, [1, 2])
-        results = _execute_chunk(work, chunk, shared_refs, config)
+        results, failed_count = _execute_chunk(work, chunk, shared_refs, config)
 
         vec_sum = 1.0 + 2.0 + 3.0  # 6.0
         assert results == [1 * vec_sum + 100, 2 * vec_sum + 100]
+        assert failed_count == 0
 
         manager.cleanup()
 
@@ -553,9 +557,10 @@ class TestExecuteChunkArrayPathMocked:
             return int(row[0] + row[1])
 
         chunk = (0, 3, [0, 1, 2])
-        results = _execute_chunk(work, chunk, shared_refs, config)
+        results, failed_count = _execute_chunk(work, chunk, shared_refs, config)
 
         assert results == [3, 7, 11]  # 1+2, 3+4, 5+6
+        assert failed_count == 0
 
         manager.cleanup()
 
@@ -568,8 +573,9 @@ class TestExecuteChunkArrayPathMocked:
             return x**2
 
         chunk = (0, 4, [2, 3, 5, 7])
-        results = _execute_chunk(square, chunk, {}, config)
+        results, failed_count = _execute_chunk(square, chunk, {}, config)
         assert results == [4, 9, 25, 49]
+        assert failed_count == 0
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary
- **Log exceptions** in `_execute_chunk` with `logger.warning()` including item index and full traceback, replacing the silent bare `except Exception` catch
- **Track failure counts** in new `PerformanceMetrics.failed_items` / `total_items` fields, exposed in the performance summary
- **Add configurable `max_failure_rate`** to `ParallelExecutor` that raises `RuntimeError` when too many items fail (e.g. `max_failure_rate=0.1` for 10% threshold)

## Motivation
Closes #1005 — `_execute_chunk` silently swallowed all worker item exceptions, replacing them with `None` in the results. This masked data corruption in Monte Carlo simulations, hid attack signals, and left no audit trail.

## Changes
| File | Change |
|------|--------|
| `parallel_executor.py` | Add `logging`/`traceback` imports; add `logger`; add `total_items`/`failed_items` to `PerformanceMetrics` with summary output; add `max_failure_rate` param to `ParallelExecutor`; update `_execute_chunk` to log + count failures and return `(results, failed_count)` tuple; update `_execute_parallel` to aggregate failures, populate metrics, and enforce threshold |
| `test_parallel_executor.py` | Add `total_items`/`failed_items` default assertions; add `test_metrics_summary_with_failures`; add `test_error_handling_tracks_failures_in_metrics`, `test_max_failure_rate_raises_on_threshold`, `test_max_failure_rate_allows_below_threshold` |
| `test_parallel_executor_coverage.py` | Update all `_execute_chunk` calls to unpack `(results, failed_count)` tuples; add `test_execute_chunk_logs_exception` and `test_execute_chunk_multiple_failures` |
| `test_coverage_gaps_parallel_executor.py` | Update all `_execute_chunk` calls to unpack tuples |

## Test plan
- [x] `test_parallel_executor.py` — 23 passed, 6 skipped
- [x] `test_parallel_executor_coverage.py` — 30 passed, 6 skipped
- [x] `test_coverage_gaps_parallel_executor.py` — 24 passed
- [x] `test_monte_carlo_parallel.py` — 14 passed
- [x] All pre-commit hooks pass (black, isort, mypy, pylint, conventional-commit)