### PR TITLE
fix: use time_horizon_years instead of non-existent 'years' attribute (#1080)

### DIFF
--- a/ergodic_insurance/simulation.py
+++ b/ergodic_insurance/simulation.py
@@ -1055,7 +1055,7 @@ class Simulation:
 
         sim_config = MonteCarloConfig(
             n_simulations=n_scenarios,
-            n_years=getattr(config.simulation, "years", 10),
+            n_years=config.simulation.time_horizon_years,
             parallel=n_jobs > 1 if n_jobs else True,
             n_workers=n_jobs,
             chunk_size=batch_size,
@@ -1193,7 +1193,7 @@ class Simulation:
         # Build shared simulation config with CRN enabled
         sim_config = MonteCarloConfig(
             n_simulations=n_scenarios,
-            n_years=getattr(config.simulation, "years", 10),
+            n_years=config.simulation.time_horizon_years,
             parallel=n_jobs > 1 if n_jobs else True,
             n_workers=n_jobs,
             checkpoint_interval=n_scenarios + 1,  # Don't checkpoint for comparisons


### PR DESCRIPTION
## Summary
- Fixed `run_monte_carlo()` and `compare_insurance_strategies()` using `getattr(config.simulation, "years", 10)` which always fell back to 10 because `SimulationConfig` has no `years` attribute — the correct field is `time_horizon_years`
- Added regression tests for both methods verifying the configured time horizon propagates correctly

## Test plan
- [x] `test_run_monte_carlo_respects_time_horizon_years` — sets `time_horizon_years=25` and asserts `n_years=25` reaches `MonteCarloConfig`
- [x] `test_compare_respects_time_horizon_years` — sets `time_horizon_years=30` and asserts `n_years=30` reaches all engine configs
- [x] All 32 tests in `test_simulation_coverage.py` pass
- [x] All pre-commit hooks pass (black, isort, mypy, pylint, conventional commit)

Closes #1080