### PR TITLE
fix: process each loss event individually through InsuranceProgram (#1136)

### DIFF
--- a/ergodic_insurance/tests/test_ruin_probability.py
+++ b/ergodic_insurance/tests/test_ruin_probability.py
@@ -403,6 +403,92 @@ class TestRuinProbabilityAnalyzer:
         mock_manufacturer.calculate_revenue.assert_called_once()
         mock_manufacturer.step.assert_called_once()
 
+    def test_process_simulation_year_per_occurrence(self, mock_manufacturer, mock_config):
+        """Test that each loss event is processed individually through process_claim.
+
+        Regression test for issue #1136: previously all annual losses were summed
+        into a single claim, breaking per-occurrence deductible and layer semantics.
+        """
+        # Create 3 separate loss events
+        event1 = MagicMock()
+        event1.amount = 200_000
+        event2 = MagicMock()
+        event2.amount = 300_000
+        event3 = MagicMock()
+        event3.amount = 500_000
+
+        loss_generator = MagicMock()
+        loss_generator.generate_losses.return_value = (
+            [event1, event2, event3],
+            {"total_loss": 1_000_000},
+        )
+
+        # Insurance program with per-occurrence deductible of 100K
+        # Each event should be processed separately:
+        #   event1: 200K claim -> 100K deductible, 100K recovery
+        #   event2: 300K claim -> 100K deductible, 200K recovery
+        #   event3: 500K claim -> 100K deductible, 400K recovery
+        # Total recovery = 700K, retained = 300K
+        insurance_program = MagicMock()
+        insurance_program.process_claim.side_effect = [
+            ClaimResult(
+                total_claim=200_000,
+                deductible_paid=100_000,
+                insurance_recovery=100_000,
+                uncovered_loss=0.0,
+                reinstatement_premiums=0.0,
+            ),
+            ClaimResult(
+                total_claim=300_000,
+                deductible_paid=100_000,
+                insurance_recovery=200_000,
+                uncovered_loss=0.0,
+                reinstatement_premiums=0.0,
+            ),
+            ClaimResult(
+                total_claim=500_000,
+                deductible_paid=100_000,
+                insurance_recovery=400_000,
+                uncovered_loss=0.0,
+                reinstatement_premiums=0.0,
+            ),
+        ]
+
+        analyzer = RuinProbabilityAnalyzer(
+            mock_manufacturer, loss_generator, insurance_program, mock_config
+        )
+
+        analyzer._process_simulation_year(mock_manufacturer, 0)
+
+        # Verify process_claim was called 3 times (once per event), NOT once with the sum
+        assert insurance_program.process_claim.call_count == 3
+        insurance_program.process_claim.assert_any_call(200_000)
+        insurance_program.process_claim.assert_any_call(300_000)
+        insurance_program.process_claim.assert_any_call(500_000)
+
+        # Retained = 1_000_000 total - 700_000 recovery = 300_000
+        mock_manufacturer.process_uninsured_claim.assert_called_once_with(
+            claim_amount=300_000,
+            immediate_payment=False,
+        )
+
+    def test_process_simulation_year_no_events(self, mock_config, mock_manufacturer):
+        """Test that no claims are processed when there are no loss events."""
+        loss_generator = MagicMock()
+        loss_generator.generate_losses.return_value = ([], {"total_loss": 0})
+
+        insurance_program = MagicMock()
+
+        analyzer = RuinProbabilityAnalyzer(
+            mock_manufacturer, loss_generator, insurance_program, mock_config
+        )
+
+        analyzer._process_simulation_year(mock_manufacturer, 0)
+
+        # No events means no claims processed and no uninsured loss
+        insurance_program.process_claim.assert_not_called()
+        mock_manufacturer.process_uninsured_claim.assert_not_called()
+
     def test_pad_survival_curves(self, analyzer):
         """Test padding survival curves to uniform length."""
         curves = [


### PR DESCRIPTION
## Summary
- Fixed `RuinProbabilityAnalyzer._process_simulation_year()` to process each `LossEvent` through `InsuranceProgram.process_claim()` individually, instead of aggregating all annual losses into a single claim
- This corrects per-occurrence deductible and layer attachment semantics — previously a $100K deductible was applied once to the annual total instead of once per event
- Added regression tests verifying per-occurrence processing and the zero-events edge case

Closes #1136

## Test plan
- [x] `test_process_simulation_year` — existing test still passes (single event)
- [x] `test_process_simulation_year_per_occurrence` — new test verifies `process_claim` is called once per event with individual amounts, and retained loss is correct
- [x] `test_process_simulation_year_no_events` — new test verifies no claims processed when no events occur
- [x] All 47 tests in `test_ruin_probability.py` and `test_limit_types.py` pass
- [x] All pre-commit hooks pass (black, isort, mypy, pylint)