### PR TITLE
perf: cache baseline results and use CRN in decision metrics (#1160)

### DIFF
--- a/ergodic_insurance/config/optimizer.py
+++ b/ergodic_insurance/config/optimizer.py
@@ -205,3 +205,22 @@ class DecisionEngineConfig(BaseModel):
         default=(5_000_000, 25_000_000),
         description="Attachment thresholds: (primary_ceiling, first_excess_ceiling).",
     )
+
+    # calculate_decision_metrics simulation parameters
+    metrics_n_simulations: int = Field(
+        default=1000,
+        ge=10,
+        description="Number of Monte Carlo simulations for decision metrics calculation.",
+    )
+    metrics_time_horizon: int = Field(
+        default=10,
+        ge=1,
+        description="Time horizon in years for decision metrics simulation.",
+    )
+    use_crn: bool = Field(
+        default=True,
+        description=(
+            "Use Common Random Numbers (CRN) for paired comparison between "
+            "with-insurance and without-insurance simulations."
+        ),
+    )

--- a/ergodic_insurance/tests/test_optimizer_config.py
+++ b/ergodic_insurance/tests/test_optimizer_config.py
@@ -211,7 +211,10 @@ class TestSerializationRoundTrip:
         assert "loss_cv" in dumped
         assert "default_optimization_weights" in dumped
         assert "layer_attachment_thresholds" in dumped
-        assert len(dumped) == 7  # All 7 fields present
+        assert "metrics_n_simulations" in dumped
+        assert "metrics_time_horizon" in dumped
+        assert "use_crn" in dumped
+        assert len(dumped) == 10  # All 10 fields present
 
     def test_model_json_schema_generation(self):
         """Verify JSON schema can be generated for API documentation."""


### PR DESCRIPTION
## Summary
- **Baseline cache**: Cache the "without insurance" simulation results keyed on manufacturer state + loss distribution, so the baseline is computed once and reused across multiple `calculate_decision_metrics()` calls (e.g., during sensitivity analysis which calls it 11+ times).
- **Common Random Numbers (CRN)**: Pre-generate a shared `(n_simulations, time_horizon)` loss array and pass it to both with/without insurance simulations. This pairs the comparison on identical loss draws, reducing variance in `roe_improvement` and `capital_efficiency` metrics.
- **Configurable simulation parameters**: Add `metrics_n_simulations`, `metrics_time_horizon`, and `use_crn` to `DecisionEngineConfig` so callers can tune speed vs. accuracy for metrics calculation independently of final evaluation.

## Changes
- `ergodic_insurance/config/optimizer.py` — 3 new fields on `DecisionEngineConfig`
- `ergodic_insurance/decision_engine.py` — `_baseline_cache`, `_baseline_cache_key()`, `_generate_loss_sequence()`, updated `calculate_decision_metrics()` and `_run_simulation()`, cache invalidation in `run_sensitivity_analysis()`
- `ergodic_insurance/tests/test_optimizer_config.py` — Updated serialization round-trip test for new field count

## Test plan
- [x] All 45 tests in `test_decision_engine.py` pass
- [x] All 34 tests in `test_decision_engine_edge_cases.py` pass
- [x] All 56 tests in `test_optimizer_config.py` pass (including updated serialization test)
- [x] All pre-commit hooks pass (black, isort, mypy, pylint, conventional commit)