### PR TITLE
perf: fix unbounded Ledger.entries growth during MC simulation (#1146)

### DIFF
--- a/ergodic_insurance/monte_carlo.py
+++ b/ergodic_insurance/monte_carlo.py
@@ -341,7 +341,7 @@ class MonteCarloConfig:
     growth_rate: float = 0.0  # Revenue growth rate per period
     time_resolution: str = "annual"  # "annual" or "monthly"
     apply_stochastic: bool = False  # Whether to apply stochastic shocks
-    enable_ledger_pruning: bool = False  # Prune old ledger entries to bound memory (Issue #315)
+    enable_ledger_pruning: bool = True  # Prune old ledger entries to bound memory (Issue #315)
     crn_base_seed: Optional[int] = None  # Common Random Numbers seed for cross-scenario comparison
     use_gpu: bool = False  # Use GPU-accelerated vectorized simulation (Issue #961)
 

--- a/ergodic_insurance/monte_carlo_worker.py
+++ b/ergodic_insurance/monte_carlo_worker.py
@@ -91,6 +91,7 @@ def _run_chunk_impl(
                 copy.deepcopy(manufacturer.stochastic_process) if _has_stochastic else None
             ),
             use_float=True,
+            simulation_mode=True,
         )
 
         # Create a fresh insurance program from config instead of deep-copying

--- a/ergodic_insurance/tests/test_monte_carlo_coverage.py
+++ b/ergodic_insurance/tests/test_monte_carlo_coverage.py
@@ -1395,12 +1395,12 @@ class TestMonteCarloConfigExtended:
         assert config2.crn_base_seed == 12345
 
     def test_enable_ledger_pruning_config(self):
-        """enable_ledger_pruning defaults to False."""
+        """enable_ledger_pruning defaults to True (Issue #1146)."""
         config = MonteCarloConfig()
-        assert config.enable_ledger_pruning is False
+        assert config.enable_ledger_pruning is True
 
-        config2 = MonteCarloConfig(enable_ledger_pruning=True)
-        assert config2.enable_ledger_pruning is True
+        config2 = MonteCarloConfig(enable_ledger_pruning=False)
+        assert config2.enable_ledger_pruning is False
 
     def test_bootstrap_config_defaults(self):
         """Bootstrap-related config fields should have sensible defaults."""


### PR DESCRIPTION
## Summary
- **Default ledger pruning on**: Changed `enable_ledger_pruning` default from `False` to `True` in `MonteCarloConfig`, so old entries are pruned each year by default
- **Simulation mode for Ledger**: Added `simulation_mode=True` flag that skips `entries.append()` entirely, only maintaining the `_balances` cache — eliminates unbounded list growth in MC workers
- **`__slots__` on LedgerEntry**: `@dataclass(slots=True)` reduces per-object memory overhead for entries that are still created

## Details
The Monte Carlo worker creates thousands of fresh manufacturers, each running multi-year simulations. Previously, every ledger entry was appended to `Ledger.entries`, causing O(n_years × entries_per_year) memory growth per simulation. With `simulation_mode=True`, the worker's ledger only tracks running balances (which is all the MC path needs), while the entry list stays empty.

The `simulation_mode` flag is threaded through `WidgetManufacturer.__init__` → `create_fresh` → `reset` → `Ledger()` so it's preserved across the full lifecycle.

### Files changed
| File | Change |
|---|---|
| `monte_carlo.py` | `enable_ledger_pruning` default `False` → `True` |
| `ledger.py` | `@dataclass(slots=True)` on `LedgerEntry`; `simulation_mode` param on `Ledger.__init__`; skip append in `record()`; copy flag in `__deepcopy__` |
| `manufacturer.py` | Thread `simulation_mode` through `__init__`, `create_fresh`, `reset` |
| `monte_carlo_worker.py` | Pass `simulation_mode=True` to `create_fresh` |
| `tests/test_monte_carlo_coverage.py` | Update default assertion from `False` to `True` |

## Test plan
- [x] `test_ledger.py` — 79 passed
- [x] `test_monte_carlo.py` — 49 passed
- [x] `test_monte_carlo_worker_config.py` — 22 passed
- [x] `test_monte_carlo_coverage.py` — 69 passed
- [x] `test_ledger_coverage.py` — 19 passed
- [x] `test_execution_semantics.py` — 20 passed
- [x] `test_claim_reestimation_ledger.py`, `test_dividend_ledger_entries.py`, `test_accrual_integration.py` — 41 passed
- [x] `test_monte_carlo_parallel.py` — 14 passed
- [x] Integration tests (extended, parallel worker, simulation pipeline) — 29 passed
- [x] All pre-commit hooks pass (black, isort, mypy, pylint)

Closes #1146