### PR TITLE
fix: guard dividends against negative net income (ASC 505-20-45) (#1304)

### DIFF
--- a/ergodic_insurance/tests/test_retention_calculation.py
+++ b/ergodic_insurance/tests/test_retention_calculation.py
@@ -237,8 +237,8 @@ class TestRetentionCalculation:
         expected_taxes = to_decimal(0)
         expected_net_loss = income_before_tax  # Negative value
 
-        # Loss retention (reduces equity)
-        expected_retained_loss = expected_net_loss * to_decimal(manufacturer.retention_ratio)
+        # Issue #1304: 100% of losses absorbed — no negative dividends
+        expected_retained_loss = expected_net_loss  # full loss, not partial
 
         # Run actual calculation
         actual_net_income = manufacturer.calculate_net_income(operating_income, collateral_costs)
@@ -251,7 +251,7 @@ class TestRetentionCalculation:
         manufacturer.update_balance_sheet(actual_net_income)
         equity_change = manufacturer.equity - initial_equity
 
-        # Equity should decrease by retained portion of loss
+        # Equity should decrease by full loss (ASC 505-20-45)
         assert equity_change < 0, "Equity should decrease with losses"
         assert abs(float(equity_change) - float(expected_retained_loss)) < 0.01
 


### PR DESCRIPTION
## Summary
- Guard dividend calculation so dividends are zero when net income is negative (ASC 505-20-45)
- Ensure 100% of losses are absorbed by retained earnings in loss years, not just `retention_ratio` fraction
- Add `TestNegativeDividendGuard` test class with 3 targeted tests covering loss-year dividends, ledger entries, and `_last_dividends_paid` invariant
- Update `test_negative_income_retention` to expect full loss absorption instead of partial

Closes #1304

## Test plan
- [x] `test_loss_year_dividends_zero_with_partial_retention` — dividends = 0 and full equity drop on loss
- [x] `test_loss_year_no_dividend_ledger_entries` — no DIVIDEND transactions in ledger for loss year
- [x] `test_last_dividends_paid_never_negative` — parametric over retention ratios 0.0–1.0
- [x] All 24 `test_dividend_phantom_payments.py` tests pass
- [x] All 9 `test_retention_calculation.py` tests pass (including updated assertion)
- [x] All 113 balance sheet / manufacturer / cash flow / financial statement tests pass