### PR TITLE
fix: use per-cohort tax depreciation in DTL calculation (#1321)

### DIFF
--- a/ergodic_insurance/config/manufacturer.py
+++ b/ergodic_insurance/config/manufacturer.py
@@ -358,6 +358,15 @@ class ManufacturerConfig(BaseModel):
         "Noise shrinks proportionally to claim maturity.",
     )
 
+    # PP&E useful life for book depreciation (Issue #1321)
+    ppe_useful_life_years: float = Field(
+        default=10,
+        gt=0,
+        le=50,
+        description="Average useful life of PP&E in years for book depreciation "
+        "(straight-line). Used in both record_depreciation() and DTL calculation.",
+    )
+
     # Accelerated tax depreciation configuration (Issue #367, ASC 740)
     tax_depreciation_life_years: Optional[float] = Field(
         default=None,

--- a/ergodic_insurance/manufacturer_balance_sheet.py
+++ b/ergodic_insurance/manufacturer_balance_sheet.py
@@ -1129,6 +1129,12 @@ class BalanceSheetMixin:
             month=self.current_month,
         )
 
+        # Track vintage cohort for accurate DTL calculation (Issue #1321)
+        if hasattr(self, "_ppe_cohorts"):
+            from ergodic_insurance.manufacturer import _PPECohort
+
+            self._ppe_cohorts.append(_PPECohort(amount=actual_capex))
+
         logger.debug(
             f"Recorded capex: ${actual_capex:,.2f}, "
             f"Gross PP&E: ${self.gross_ppe:,.2f}, "


### PR DESCRIPTION
## Summary

- **Fixes #1321**: `_record_dtl_from_depreciation()` previously computed tax depreciation on the entire `gross_ppe` pool, causing fully-depreciated cohorts to still contribute to tax depreciation and overstating the DTL unboundedly over multi-year simulations with ongoing capex.
- Introduces `_PPECohort` vintage-year tracking so each cohort's tax depreciation is capped at its own remaining basis (per ASC 740-10-25-20).
- Parameterizes book useful life via `ManufacturerConfig.ppe_useful_life_years` (default=10), replacing the hardcoded value.

### Files changed
| File | Change |
|---|---|
| `config/manufacturer.py` | Add `ppe_useful_life_years` field to `ManufacturerConfig` |
| `manufacturer.py` | Add `_PPECohort` dataclass; init/reset cohort tracking; rewrite `_record_dtl_from_depreciation()` to iterate cohorts; use parameterized book life in `step()` |
| `manufacturer_balance_sheet.py` | Append new cohort in `record_capex()` |
| `tests/test_dta_dtl_and_capex.py` | Add `TestDTLVintageCohorts` class with 7 new tests |

## Test plan
- [x] All 27 existing DTL/DTA/capex tests pass
- [x] All 19 depreciation tracking tests pass
- [x] All 24 capex tests pass
- [x] All 7 closing entry depreciation tests pass
- [x] All 15 balance sheet cash depreciation tests pass
- [x] All 43 config validation tests pass
- [x] 7 new cohort-specific tests pass:
  - DTL stabilizes with ongoing capex (does not grow unboundedly)
  - Fully-depreciated cohort contributes zero tax depreciation
  - Each cohort's tax accumulated depreciation capped at cost
  - TaxHandler aggregate stays in sync with cohort sum
  - Capex creates new cohort
  - Book life is parameterized from config
  - Accounting equation holds over 15 years with cohorts
- [x] Pre-commit hooks pass (black, isort, mypy, pylint)