### PR TITLE
fix: use exact OU transition in MeanRevertingProcess discretization (#1328)

### DIFF
--- a/ergodic_insurance/tests/test_stochastic.py
+++ b/ergodic_insurance/tests/test_stochastic.py
@@ -132,6 +132,122 @@ class TestStochasticProcesses:
             abs(stds[0] - stds[1]) / stds[0] < 0.05
         ), f"Volatility should be state-independent: std@0.5={stds[0]:.4f}, std@50={stds[1]:.4f}"
 
+    def test_mean_reverting_stationary_distribution(self):
+        """Verify stationary distribution matches N(log(mu), sigma^2/(2*theta)).
+
+        Simulate 100,000 independent OU paths long enough to reach stationarity,
+        then check that the empirical distribution of log(X) matches the
+        theoretical stationary distribution within 3 standard errors.
+        """
+        theta = 1.0
+        sigma = 0.3
+        mu = 2.0
+        dt = 1.0
+        n_paths = 100_000
+        burn_in = 50  # steps to reach stationarity
+
+        config = StochasticConfig(volatility=sigma, drift=0.0, random_seed=12345, time_step=dt)
+        process = MeanRevertingProcess(config, mean_level=mu, reversion_speed=theta)
+
+        # Run all paths from the same starting point, collecting final values
+        final_log_values = np.empty(n_paths)
+        current = 1.0  # starting far from mu to stress burn-in
+        for i in range(n_paths):
+            x = current
+            for _ in range(burn_in):
+                x = x * process.generate_shock(x)
+            final_log_values[i] = np.log(x)
+
+        # Theoretical stationary distribution: N(log(mu), sigma^2 / (2*theta))
+        expected_mean = np.log(mu)
+        expected_var = sigma**2 / (2 * theta)
+        expected_std = np.sqrt(expected_var)
+
+        sample_mean = np.mean(final_log_values)
+        sample_var = np.var(final_log_values)
+        se_mean = expected_std / np.sqrt(n_paths)
+
+        assert abs(sample_mean - expected_mean) < 3 * se_mean, (
+            f"Stationary mean mismatch: sample={sample_mean:.4f}, "
+            f"expected={expected_mean:.4f}, 3*SE={3*se_mean:.4f}"
+        )
+        # Variance check (chi-squared): SE of sample variance ≈ expected_var * sqrt(2/n)
+        se_var = expected_var * np.sqrt(2 / n_paths)
+        assert abs(sample_var - expected_var) < 3 * se_var, (
+            f"Stationary variance mismatch: sample={sample_var:.6f}, "
+            f"expected={expected_var:.6f}, 3*SE={3*se_var:.6f}"
+        )
+
+    def test_mean_reverting_long_run_variance(self):
+        """Verify that the long-run variance of log(X) equals sigma^2 / (2*theta)."""
+        theta = 0.5
+        sigma = 0.2
+        mu = 1.0
+        dt = 1.0
+        n_paths = 50_000
+        n_steps = 100  # long enough for convergence
+
+        config = StochasticConfig(volatility=sigma, drift=0.0, random_seed=999, time_step=dt)
+        process = MeanRevertingProcess(config, mean_level=mu, reversion_speed=theta)
+
+        final_log_values = np.empty(n_paths)
+        for i in range(n_paths):
+            x = mu  # start at mean
+            for _ in range(n_steps):
+                x = x * process.generate_shock(x)
+            final_log_values[i] = np.log(x)
+
+        expected_var = sigma**2 / (2 * theta)
+        sample_var = np.var(final_log_values)
+        se_var = expected_var * np.sqrt(2 / n_paths)
+
+        assert abs(sample_var - expected_var) < 3 * se_var, (
+            f"Long-run variance: sample={sample_var:.6f}, "
+            f"expected={expected_var:.6f}, 3*SE={3*se_var:.6f}"
+        )
+
+    def test_mean_reverting_theta_zero_reduces_to_gbm(self):
+        """For theta -> 0, the shock reduces to pure GBM (no mean reversion)."""
+        sigma = 0.2
+        dt = 1.0
+        n_samples = 10_000
+        current = 5.0  # arbitrary starting point
+
+        # MeanRevertingProcess with theta ≈ 0
+        config = StochasticConfig(volatility=sigma, drift=0.0, random_seed=42, time_step=dt)
+        process = MeanRevertingProcess(config, mean_level=1.0, reversion_speed=1e-12)
+
+        log_shocks = np.array([np.log(process.generate_shock(current)) for _ in range(n_samples)])
+
+        # With theta=0, log_shock should be N(0, sigma^2 * dt)
+        # (no mean reversion, pure diffusion)
+        assert abs(np.mean(log_shocks)) < 3 * sigma * np.sqrt(dt) / np.sqrt(n_samples)
+        assert abs(np.std(log_shocks) - sigma * np.sqrt(dt)) < 0.02
+
+    def test_mean_reverting_large_theta_jumps_to_mean(self):
+        """For theta -> infinity, the shock immediately jumps to the mean level."""
+        sigma = 0.2
+        dt = 1.0
+        mu = 3.0
+        theta = 50.0
+        n_samples = 200
+
+        config = StochasticConfig(volatility=sigma, drift=0.0, random_seed=42, time_step=dt)
+        process = MeanRevertingProcess(config, mean_level=mu, reversion_speed=theta)
+
+        # With theta=50, conditional_std = sigma*sqrt(1/(2*theta)) ≈ 0.02.
+        # Average over many draws to verify the mean converges to mu.
+        for current in [0.5, 1.0, 5.0, 20.0]:
+            next_values = np.array(
+                [current * process.generate_shock(current) for _ in range(n_samples)]
+            )
+            mean_next = np.mean(next_values)
+            # conditional_std in log-space ≈ 0.02, so SE of mean ≈ 0.02/sqrt(n)
+            se = sigma * np.sqrt(1 / (2 * theta)) / np.sqrt(n_samples)
+            assert abs(np.log(mean_next) - np.log(mu)) < 3 * se, (
+                f"Large theta: mean(next)={mean_next:.4f}, expected≈{mu}, " f"3*SE={3*se:.4f}"
+            )
+
     def test_mean_reverting_rejects_nonpositive_mean(self):
         """Test that MeanRevertingProcess rejects non-positive mean_level."""
         config = StochasticConfig(volatility=0.1, drift=0.0, random_seed=42)


### PR DESCRIPTION
## Summary

- Replace the Euler-Maruyama discretization in `MeanRevertingProcess.generate_shock()` with the **exact discrete-time OU conditional distribution**, eliminating O(dt) bias
- At the default annual time step (`theta*dt ≈ 1`), the Euler scheme over-reverted by ~58% and overestimated noise by ~27% — the exact transition is unbiased for any dt
- Handle the `theta → 0` limit via L'Hôpital fallback to pure lognormal diffusion

## Test plan

- [x] **Stationary distribution** (100k paths): empirical mean and variance of log(X) match theoretical `N(log(μ), σ²/(2θ))` within 3 SE
- [x] **Long-run variance** (50k paths): sample variance of log(X) matches `σ²/(2θ)` within 3 SE
- [x] **θ → 0 limit**: shock reduces to pure GBM (zero mean, correct std)
- [x] **θ → ∞ limit**: next value converges to μ regardless of starting point
- [x] All 20 existing + new tests in `test_stochastic.py` pass
- [x] All pre-commit hooks pass (black, isort, mypy, pylint)

Closes #1328