### PR TITLE
fix: use standard penalty increase criterion in ALM optimizer (#1313)

### DIFF
--- a/ergodic_insurance/optimization.py
+++ b/ergodic_insurance/optimization.py
@@ -626,12 +626,15 @@ class AugmentedLagrangianOptimizer:
                 logger.info(f"Converged after {outer_iter + 1} outer iterations")
                 break
 
-            # Update penalty parameter
+            # Update penalty parameter.
+            # Increase rho when constraint violation has not decreased
+            # sufficiently (by factor 0.25) since the previous iteration
+            # (Bertsekas & Tsitsiklis, 1997, p. 319).
             should_increase_penalty = True
             if len(self.convergence_monitor.constraint_violation_history) > 1:
                 should_increase_penalty = (
                     constraint_violation
-                    > 0.5 * self.convergence_monitor.constraint_violation_history[-2]
+                    > 0.25 * self.convergence_monitor.constraint_violation_history[-2]
                 )
             if should_increase_penalty:
                 rho = min(rho * 2, rho_max)


### PR DESCRIPTION
## Summary

- Replace the arbitrary 0.5 penalty increase factor in `AugmentedLagrangianOptimizer` with the standard 0.25 factor per Bertsekas & Tsitsiklis (1997, p. 319)
- Add reference documentation for the penalty increase criterion
- Add a 2-D constrained-quadratic convergence test verifying correct multiplier trajectory (primal convergence, dual convergence, and monotonicity)

## Details

The penalty increase threshold determined whether `rho` should be doubled between outer iterations. The previous factor of 0.5 (suppress rho growth when violation decreases by 50%) had no theoretical backing. The standard criterion from Bertsekas & Tsitsiklis requires violation to decrease by 75% (factor 0.25) before suppressing rho growth. This more aggressive criterion leads to faster convergence for constrained problems.

The code ordering (inner solve → multiplier update → rho update) was already correct per the standard ALM algorithm (Bertsekas, 1999, Algorithm 4.2.1).

## Test plan

- [x] All 11 `TestAugmentedLagrangianOptimizer` unit tests pass
- [x] New `test_constrained_quadratic_multiplier_trajectory` verifies x → (0.5, 0.5), λ → 1.0, monotone trajectory
- [x] Existing penalty precedence tests updated for 0.25 threshold

Closes #1313