### PR TITLE
fix: replace deprecated dict-style access in AnalysisResults.summary() (#1305)

### DIFF
--- a/ergodic_insurance/_run_analysis.py
+++ b/ergodic_insurance/_run_analysis.py
@@ -200,18 +200,12 @@ class AnalysisResults:
 
         # --- Ergodic advantage ---
         if self.comparison is not None:
-            adv = self.comparison.get("ergodic_advantage", {})
+            adv = self.comparison.ergodic_advantage
             lines.append("")
             lines.append("--- Ergodic Advantage (Insured - Uninsured) ---")
-            ta_gain = adv.get("time_average_gain")
-            if ta_gain is not None:
-                lines.append(f"Time-Average Growth Gain: {ta_gain:+.2%}")
-            surv_gain = adv.get("survival_gain")
-            if surv_gain is not None:
-                lines.append(f"Survival Rate Gain: {surv_gain:+.1%}")
-            sig = adv.get("significant")
-            if sig is not None:
-                lines.append(f"Statistically Significant: {'Yes' if sig else 'No'}")
+            lines.append(f"Time-Average Growth Gain: {adv.time_average_gain:+.2%}")
+            lines.append(f"Survival Rate Gain: {adv.survival_gain:+.1%}")
+            lines.append(f"Statistically Significant: {'Yes' if adv.significant else 'No'}")
 
         lines.append("=" * 60)
         text = "\n".join(lines)


### PR DESCRIPTION
## Summary
- Replaced .get() dict-style access on ScenarioComparison and ErgodicAdvantage dataclasses with direct attribute access in AnalysisResults.summary()
- This eliminates DeprecationWarnings emitted by the library's own primary entry point (run_analysis().summary())
- Added two new tests: one verifying no deprecation warnings are emitted, and one covering the comparison=None path

Closes #1305

## Test plan
- [x] test_summary_no_deprecation_warnings -- calls summary() with warnings.catch_warnings(record=True) and asserts zero DeprecationWarnings
- [x] test_summary_without_comparison -- verifies summary() works when compare_uninsured=False
- [x] All 41 existing tests in test_run_analysis.py pass
- [x] All pre-commit hooks pass (black, isort, mypy, pylint)