### PR TITLE
fix: include insurance_receivables in current assets for going concern and Z-prime (#1316)

### DIFF
--- a/ergodic_insurance/manufacturer_solvency.py
+++ b/ergodic_insurance/manufacturer_solvency.py
@@ -135,7 +135,11 @@ class SolvencyMixin:
         # 1. Current Ratio = Current Assets / Current Liabilities
         reported_cash = max(self.cash, to_decimal(0))
         current_assets = (
-            reported_cash + self.accounts_receivable + self.inventory + self.prepaid_insurance
+            reported_cash
+            + self.accounts_receivable
+            + self.inventory
+            + self.prepaid_insurance
+            + self.insurance_receivables  # Issue #1316: ASC 210-10-45
         )
         # Current liabilities = total_liabilities - long-term claims - DTL
         claim_total = sum(
@@ -271,7 +275,11 @@ class SolvencyMixin:
         # Current assets and current liabilities for working capital
         reported_cash = max(self.cash, to_decimal(0))
         current_assets = (
-            reported_cash + self.accounts_receivable + self.inventory + self.prepaid_insurance
+            reported_cash
+            + self.accounts_receivable
+            + self.inventory
+            + self.prepaid_insurance
+            + self.insurance_receivables  # Issue #1316: ASC 210-10-45
         )
         claim_total = sum(
             (liability.remaining_amount for liability in self.claim_liabilities), to_decimal(0)

--- a/ergodic_insurance/tests/test_equity_consistency.py
+++ b/ergodic_insurance/tests/test_equity_consistency.py
@@ -106,6 +106,7 @@ class TestEquityConsistencyAcrossAssessments:
             + manufacturer.accounts_receivable
             + manufacturer.inventory
             + manufacturer.prepaid_insurance
+            + manufacturer.insurance_receivables  # Issue #1316: ASC 210-10-45
         )
         claim_total = sum(
             (cl.remaining_amount for cl in manufacturer.claim_liabilities), to_decimal(0)


### PR DESCRIPTION
## Summary
- Add `self.insurance_receivables` to the `current_assets` calculation in `_assess_going_concern_indicators()` and `compute_z_prime_score()` in `manufacturer_solvency.py`, consistent with the balance sheet's `total_assets` property which already includes them per ASC 210-10-45 / ASC 310-10-45
- Update `test_equity_consistency.py` manual Z-prime recomputation to include insurance receivables
- Add new test `test_current_ratio_includes_insurance_receivables` verifying the current ratio reflects insurance receivables

Closes #1316

## Test plan
- [x] All 47 going concern tests pass (including new test)
- [x] All 9 equity consistency tests pass
- [x] All 145 tests across related test files pass (going concern, equity consistency, manufacturer methods, recovery accounting, financial statements)
- [x] All pre-commit hooks pass (black, isort, mypy, pylint, conventional commit)