### PR TITLE
fix: accept MonteCarloResults in compare_scenarios() (#1312)

### DIFF
--- a/ergodic_insurance/ergodic_analyzer.py
+++ b/ergodic_insurance/ergodic_analyzer.py
@@ -47,6 +47,7 @@ from .simulation import SimulationResults
 if TYPE_CHECKING:
     from .insurance_program import InsuranceProgram
     from .loss_distributions import LossData
+    from .monte_carlo import MonteCarloResults
 
 logger = logging.getLogger(__name__)
 
@@ -329,8 +330,8 @@ class ErgodicAnalyzer:
 
     def compare_scenarios(
         self,
-        insured_results: Union[List[SimulationResults], np.ndarray],
-        uninsured_results: Union[List[SimulationResults], np.ndarray],
+        insured_results: Union[List[SimulationResults], np.ndarray, "MonteCarloResults"],
+        uninsured_results: Union[List[SimulationResults], np.ndarray, "MonteCarloResults"],
         metric: str = "equity",
     ) -> ScenarioComparison:
         """Compare insured vs uninsured scenarios using ergodic analysis.
@@ -339,14 +340,31 @@ class ErgodicAnalyzer:
         `Advanced Scenarios tutorial <https://docs.mostlyoptimal.com/tutorials/06_advanced_scenarios.html>`_.
 
         Args:
-            insured_results: Simulation results from insured scenarios.
-            uninsured_results: Simulation results from uninsured scenarios.
+            insured_results: Simulation results from insured scenarios —
+                list of :class:`SimulationResults`, 2-D array, or
+                :class:`~ergodic_insurance.monte_carlo.MonteCarloResults`.
+            uninsured_results: Simulation results from uninsured scenarios
+                (same format as *insured_results*; types may differ).
             metric: Financial metric to analyze (default ``"equity"``).
+                Ignored when a :class:`MonteCarloResults` is passed.
 
         Returns:
             :class:`ScenarioComparison` with ``insured``, ``uninsured``,
             and ``ergodic_advantage`` fields.  Supports dict-style access
             for backward compatibility (with deprecation warnings).
+
+        Example:
+            Using :class:`MonteCarloResults` directly::
+
+                from ergodic_insurance import ErgodicAnalyzer
+                from ergodic_insurance.monte_carlo import MonteCarloEngine
+
+                engine = MonteCarloEngine(manufacturer, config)
+                insured_mc = engine.run(insurance_program=program)
+                uninsured_mc = engine.run(insurance_program=None)
+
+                analyzer = ErgodicAnalyzer()
+                comparison = analyzer.compare_scenarios(insured_mc, uninsured_mc)
         """
         from . import scenario_analysis
 


### PR DESCRIPTION
## Summary

- `compare_scenarios()` now accepts `MonteCarloResults` directly, closing the usability gap where users had to reconstruct trajectories from MC output
- Each side dispatches independently by type, so mixed inputs (e.g. `MonteCarloResults` insured + `List[SimulationResults]` uninsured) work seamlessly
- Ruined paths (final_assets <= 0) are converted from the MC engine's `0.0` convention to `-inf`, consistent with `calculate_time_average_growth()` behavior

## Test plan

- [x] `test_compare_scenarios_with_monte_carlo_results` — two MC results (insured/uninsured), verifies output structure, survival rates, growth values, and positive ergodic advantage
- [x] `test_compare_scenarios_with_mixed_types` — MC for insured + `List[SimulationResults]` for uninsured, verifies finite results
- [x] All 18 existing `test_ergodic_analyzer.py` tests pass (no regressions)
- [x] All 30 `test_scenario_batch.py` tests pass (no regressions)
- [x] Import smoke test: `from ergodic_insurance import ErgodicAnalyzer; from ergodic_insurance.monte_carlo import MonteCarloResults`
- [x] Pre-commit hooks pass (black, isort, mypy, pylint, conventional commit)

Closes #1312