### PR TITLE
fix: make Config.apply_module() and apply_preset() return new instances (#1295)

### DIFF
--- a/ergodic_insurance/config_manager.py
+++ b/ergodic_insurance/config_manager.py
@@ -283,12 +283,12 @@ class ConfigManager:
         # Apply includes (modules)
         if config.profile and config.profile.includes:
             for module_name in config.profile.includes:
-                self._apply_module(config, module_name)
+                config = self._apply_module(config, module_name)
 
         # Apply presets
         if config.profile and config.profile.presets:
             for preset_type, preset_name in config.profile.presets.items():
-                self._apply_preset(config, preset_type, preset_name)
+                config = self._apply_preset(config, preset_type, preset_name)
 
         # Apply runtime overrides
         if overrides:
@@ -357,58 +357,37 @@ class ConfigManager:
 
         return Config(**data)
 
-    def _apply_module(self, config: Config, module_name: str) -> None:
-        """Apply a configuration module to a config.
+    def _apply_module(self, config: Config, module_name: str) -> Config:
+        """Apply a configuration module, returning a new Config.
 
         Args:
-            config: Configuration to modify.
+            config: Base configuration (not mutated).
             module_name: Name of the module to apply.
+
+        Returns:
+            New Config with the module applied, or the original config
+            unchanged if the module file is not found.
         """
         self._validate_name(module_name)
         module_path = self.modules_dir / f"{module_name}.yaml"
         self._validate_path_containment(module_path, self.modules_dir)
         if not module_path.exists():
             warnings.warn(f"Module '{module_name}' not found")
-            return
+            return config
 
-        with open(module_path, "r") as f:
-            module_data = yaml.safe_load(f)
+        return config.with_module(module_path)
 
-        # Apply module data to config
-        for key, value in module_data.items():
-            if hasattr(config, key):
-                if isinstance(value, dict):
-                    current = getattr(config, key)
-                    if current is None:
-                        # Create new instance if field is None
-                        from ergodic_insurance.config import InsuranceConfig, LossDistributionConfig
-
-                        # Map key names to config classes
-                        field_mapping = {
-                            "insurance": InsuranceConfig,
-                            "losses": LossDistributionConfig,
-                        }
-
-                        if key in field_mapping:
-                            field_class = field_mapping[key]
-                            setattr(config, key, field_class(**value))
-                    elif hasattr(current, "model_dump"):
-                        # Update Pydantic model
-                        updated = current.model_dump()
-                        updated = self._deep_merge(updated, value)
-                        setattr(config, key, type(current)(**updated))
-                    else:
-                        setattr(config, key, value)
-                else:
-                    setattr(config, key, value)
-
-    def _apply_preset(self, config: Config, preset_type: str, preset_name: str) -> None:
-        """Apply a preset to a configuration.
+    def _apply_preset(self, config: Config, preset_type: str, preset_name: str) -> Config:
+        """Apply a preset, returning a new Config.
 
         Args:
-            config: Configuration to modify.
+            config: Base configuration (not mutated).
             preset_type: Type of preset (e.g., 'market', 'layers').
             preset_name: Name of the specific preset.
+
+        Returns:
+            New Config with the preset applied, or the original config
+            unchanged if the preset library/name is not found.
         """
         self._validate_name(preset_type)
 
@@ -424,7 +403,7 @@ class ConfigManager:
 
             if not preset_file.exists():
                 warnings.warn(f"Preset library '{preset_type}' not found")
-                return
+                return config
 
             with open(preset_file, "r") as f:
                 library_data = yaml.safe_load(f)
@@ -439,31 +418,25 @@ class ConfigManager:
                 f"Preset '{preset_name}' not found in {preset_type}. "
                 f"Available: {', '.join(available)}"
             )
-            return
+            return config
 
         preset_data = library_data[preset_name]
 
-        # Apply preset data
-        config.apply_preset(f"{preset_type}:{preset_name}", preset_data)
+        # Apply preset data — return new instance
+        return config.with_preset(f"{preset_type}:{preset_name}", preset_data)
 
     def with_preset(self, config: Config, preset_type: str, preset_name: str) -> Config:
         """Create a new configuration with a preset applied.
 
         Args:
-            config: Base configuration.
+            config: Base configuration (not mutated).
             preset_type: Type of preset.
             preset_name: Name of the preset.
 
         Returns:
             New Config instance with preset applied.
         """
-        # Create a copy
-        new_config = Config(**config.model_dump())
-
-        # Apply the preset
-        self._apply_preset(new_config, preset_type, preset_name)
-
-        return new_config
+        return self._apply_preset(config, preset_type, preset_name)
 
     def with_overrides(self, config: Config, overrides: Dict[str, Any]) -> Config:
         """Create a new configuration with runtime overrides.

--- a/ergodic_insurance/tests/test_config_v2_integration.py
+++ b/ergodic_insurance/tests/test_config_v2_integration.py
@@ -100,12 +100,12 @@ class TestIntegration:
         issues = config.validate_completeness()
         assert len(issues) == 0
 
-        # Apply preset
+        # Apply preset (returns new instance)
         preset_data = {
             "growth": {"volatility": 0.25},
             "losses": {"tail_alpha": 3.0},
         }
-        config.apply_preset("high_volatility", preset_data)
+        config = config.with_preset("high_volatility", preset_data)
         assert config.growth.volatility == 0.25
         assert config.losses is not None and config.losses.tail_alpha == 3.0
         assert "high_volatility" in config.applied_presets


### PR DESCRIPTION
## Summary

- **Renamed** `Config.apply_module()` to `Config.with_module()` and `Config.apply_preset()` to `Config.with_preset()`, both now return **new Config instances** without mutating the original
- **Removed** all `object.__setattr__()` bypasses from Config
- **Added** deprecated aliases `apply_module()` / `apply_preset()` that emit `DeprecationWarning` and delegate to the new methods
- **Updated** `ConfigManager._apply_module()` / `_apply_preset()` to return `Config` instead of mutating in-place
- **Simplified** `ConfigManager.with_preset()` to delegate directly
- **Updated** `ConfigManager.load_profile()` to chain return values from module/preset application
- **Updated** all tests across 4 test files to verify immutability (original Config unchanged after operation)

## Motivation

Closes #1295. `apply_module()` and `apply_preset()` used `object.__setattr__()` to bypass Pydantic frozen-model protection and mutate Config in-place. This was inconsistent with `override()` and `with_overrides()` which already return new instances. The mutation pattern made it impossible to safely share or cache Config instances.

## Test plan

- [x] All tests in `test_config_v2.py` pass (47 tests)
- [x] All tests in `test_config_v2_integration.py` pass (1 test)
- [x] All tests in `test_coverage_gaps_batch3.py` pass (45 tests)
- [x] All tests in `test_config_manager.py` pass (32 tests)
- [x] All tests in `test_config_manager_coverage.py` pass (21 tests)
- [x] All tests in `test_config.py` pass (45 tests)
- [x] New tests verify `with_module()` / `with_preset()` immutability
- [x] New tests verify deprecated aliases emit `DeprecationWarning`
- [x] All pre-commit hooks pass (black, isort, mypy, pylint)
