### PR TITLE
fix: add __repr__, __str__, and convenience properties to result dataclasses (#1307)

### DIFF
--- a/ergodic_insurance/tests/test_run_analysis.py
+++ b/ergodic_insurance/tests/test_run_analysis.py
@@ -248,6 +248,54 @@ class TestSummary:
         assert "Ergodic Advantage" not in s
 
 
+class TestRepr:
+    """Tests for AnalysisResults __repr__, __str__, and convenience properties (#1307)."""
+
+    def test_repr_with_comparison(self, sample_results):
+        r = repr(sample_results)
+        assert "AnalysisResults(" in r
+        assert "n_simulations=10" in r
+        assert "survival_rate=" in r
+        assert "ergodic_advantage=" in r
+
+    def test_repr_without_comparison(self):
+        results = run_analysis(
+            n_simulations=3,
+            time_horizon=3,
+            seed=0,
+            compare_uninsured=False,
+        )
+        r = repr(results)
+        assert "AnalysisResults(" in r
+        assert "ergodic_advantage=" not in r
+
+    def test_str_delegates_to_summary(self, sample_results):
+        assert str(sample_results) == sample_results.summary()
+
+    def test_survival_rate_property(self, sample_results):
+        sr = sample_results.survival_rate
+        assert 0.0 <= sr <= 1.0
+
+    def test_ergodic_advantage_gain_property(self, sample_results):
+        gain = sample_results.ergodic_advantage_gain
+        assert isinstance(gain, float)
+
+    def test_ergodic_advantage_gain_none_without_comparison(self):
+        results = run_analysis(
+            n_simulations=3,
+            time_horizon=3,
+            seed=0,
+            compare_uninsured=False,
+        )
+        assert results.ergodic_advantage_gain is None
+
+    def test_repr_html(self, sample_results):
+        html = sample_results._repr_html_()
+        assert "<div" in html
+        assert "AnalysisResults" in html
+        assert "Survival Rate" in html
+
+
 class TestToDataFrame:
     """Tests for AnalysisResults.to_dataframe()."""
 


### PR DESCRIPTION
## Summary

- **SimulationResults** now has `__repr__`, `__str__`, `_repr_html_`, and convenience properties (`survived`, `mean_roe`, `final_equity`, `final_assets`, `total_claims`, `n_years`) so actuaries can inspect results interactively without calling `summary_stats()`
- **AnalysisResults** now has `__repr__`, `__str__` (delegates to `summary()`), `_repr_html_`, and convenience properties (`survival_rate`, `ergodic_advantage_gain`)
- **StrategyComparisonResult** now has `__repr__` and `__str__` showing strategy names and summary DataFrame

Closes #1307

## Test plan

- [x] 16 new tests for `SimulationResults` repr, str, html, and all 6 convenience properties (survived/insolvent, NaN edge case)
- [x] 2 new tests for `StrategyComparisonResult` repr and str
- [x] 7 new tests for `AnalysisResults` repr, str, html, and convenience properties (with/without comparison)
- [x] All 84 existing tests in `test_simulation.py` and `test_run_analysis.py` still pass (1 pre-existing perf test flake excluded)