### PR TITLE
fix: replace print() with logging in production modules (#1310)

### DIFF
--- a/ergodic_insurance/bootstrap_analysis.py
+++ b/ergodic_insurance/bootstrap_analysis.py
@@ -30,12 +30,15 @@ Attributes:
 
 from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass
+import logging
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import warnings
 
 import numpy as np
 from scipy import stats
 from tqdm import tqdm
+
+logger = logging.getLogger(__name__)
 
 
 def _bootstrap_worker(args: Tuple[np.ndarray, Any, int, int, Optional[int]]) -> List[float]:
@@ -233,8 +236,7 @@ class BootstrapAnalyzer:
                 bootstrap_dist = self._parallel_bootstrap(data, statistic)
             except (ValueError, RuntimeError, TypeError) as e:
                 # Fall back to sequential if parallel fails
-                if self.show_progress:
-                    print(f"Parallel bootstrap failed: {e}. Falling back to sequential.")
+                logger.warning("Parallel bootstrap failed: %s. Falling back to sequential.", e)
                 bootstrap_dist = self._sequential_bootstrap(data, statistic)
         else:
             bootstrap_dist = self._sequential_bootstrap(data, statistic)

--- a/ergodic_insurance/tests/test_print_warnings_382.py
+++ b/ergodic_insurance/tests/test_print_warnings_382.py
@@ -1,15 +1,20 @@
-"""Tests for issue #382: replace print() warnings with logging/warnings module.
+"""Tests for issue #382 and #1310: replace print() with logging/warnings module.
 
 Verifies that:
 - Custom warning classes exist and have the correct hierarchy.
 - Modules that previously used print() for warnings now use logging.warning().
 - No bare print("Warning: ...") calls remain in the package source.
+- Production modules (progress_monitor, batch_processor, trajectory_storage,
+  bootstrap_analysis) use logging instead of print() (#1310).
 """
 
+import ast
 import logging
-from unittest.mock import MagicMock
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 import warnings
 
+import numpy as np
 import pytest
 
 from ergodic_insurance._warnings import (
@@ -200,8 +205,265 @@ class TestExportLogging:
 
 
 # ---------------------------------------------------------------------------
+# progress_monitor.py — logging instead of print (#1310)
+# ---------------------------------------------------------------------------
+
+
+class TestProgressMonitorLogging:
+    """progress_monitor.py uses logging instead of print()."""
+
+    def test_module_has_logger(self):
+        """Module defines a module-level logger."""
+        from ergodic_insurance import progress_monitor
+
+        assert hasattr(progress_monitor, "logger")
+        assert isinstance(progress_monitor.logger, logging.Logger)
+
+    def test_convergence_message_logged(self, caplog):
+        """Convergence achievement is logged, not printed."""
+        from ergodic_insurance.progress_monitor import ProgressMonitor
+
+        monitor = ProgressMonitor(total_iterations=100_000, show_console=True)
+        with caplog.at_level(logging.INFO, logger="ergodic_insurance.progress_monitor"):
+            monitor._print_convergence_message(50_000, 1.05)
+
+        assert any("Convergence achieved" in r.message for r in caplog.records)
+        assert any("[OK]" in r.message for r in caplog.records)
+
+    def test_finalize_logs_summary(self, caplog):
+        """finalize() logs summary via logger, not print()."""
+        import time
+
+        from ergodic_insurance.progress_monitor import ProgressMonitor
+
+        monitor = ProgressMonitor(total_iterations=1000, show_console=True)
+        monitor.current_iteration = 1000
+        # Ensure non-zero elapsed time to avoid division by zero
+        monitor.start_time = time.time() - 1.0
+
+        with caplog.at_level(logging.INFO, logger="ergodic_insurance.progress_monitor"):
+            monitor.finalize()
+
+        assert any("Simulation Complete" in r.message for r in caplog.records)
+
+    def test_finalize_uses_ascii_markers(self, caplog):
+        """finalize() uses ASCII [OK]/[FAIL] instead of Unicode emoji."""
+        import time
+
+        from ergodic_insurance.progress_monitor import ProgressMonitor
+
+        monitor = ProgressMonitor(total_iterations=1000, show_console=True)
+        monitor.current_iteration = 1000
+        monitor.converged = True
+        monitor.converged_at = 500
+        # Ensure non-zero elapsed time to avoid division by zero
+        monitor.start_time = time.time() - 1.0
+
+        with caplog.at_level(logging.INFO, logger="ergodic_insurance.progress_monitor"):
+            monitor.finalize()
+
+        log_text = " ".join(r.message for r in caplog.records)
+        assert "[OK]" in log_text
+        # No Unicode checkmark or cross
+        assert "\u2713" not in log_text
+        assert "\u2717" not in log_text
+
+    def test_console_update_uses_debug(self, caplog):
+        """_update_console logs at DEBUG level."""
+        import time
+
+        from ergodic_insurance.progress_monitor import ProgressMonitor
+
+        monitor = ProgressMonitor(total_iterations=1000, show_console=True)
+        monitor.current_iteration = 500
+
+        with caplog.at_level(logging.DEBUG, logger="ergodic_insurance.progress_monitor"):
+            monitor._update_console(time.time())
+
+        assert any(r.levelno == logging.DEBUG for r in caplog.records)
+
+    def test_no_print_in_source(self):
+        """progress_monitor.py has zero print() calls in executable code."""
+        from ergodic_insurance import progress_monitor
+
+        source_path = Path(progress_monitor.__file__)
+        _assert_no_print_calls(source_path)
+
+
+# ---------------------------------------------------------------------------
+# batch_processor.py — logging instead of print (#1310)
+# ---------------------------------------------------------------------------
+
+
+class TestBatchProcessorLogging:
+    """batch_processor.py uses logging instead of print()."""
+
+    def test_module_has_logger(self):
+        """Module defines a module-level logger."""
+        from ergodic_insurance import batch_processor
+
+        assert hasattr(batch_processor, "logger")
+        assert isinstance(batch_processor.logger, logging.Logger)
+
+    def test_all_completed_logs_info(self, caplog):
+        """'All scenarios already completed' is logged, not printed."""
+        from ergodic_insurance.batch_processor import BatchProcessor
+
+        processor = BatchProcessor.__new__(BatchProcessor)
+        processor.completed_scenarios = {"s1"}
+        processor.failed_scenarios = set()
+        processor.batch_results = []
+        processor.checkpoint_dir = Path("/tmp/test_checkpoints")
+        processor.use_parallel = False
+        processor.progress_bar = False
+
+        mock_scenario = MagicMock()
+        mock_scenario.scenario_id = "s1"
+        mock_scenario.priority = 1
+
+        with (
+            patch.object(processor, "_aggregate_results", return_value=MagicMock()),
+            patch.object(processor, "_load_checkpoint"),
+            caplog.at_level(logging.INFO, logger="ergodic_insurance.batch_processor"),
+        ):
+            processor.process_batch([mock_scenario], resume_from_checkpoint=False)
+
+        assert any("All scenarios already completed" in r.message for r in caplog.records)
+
+    def test_no_print_in_source(self):
+        """batch_processor.py has zero print() calls in executable code."""
+        from ergodic_insurance import batch_processor
+
+        source_path = Path(batch_processor.__file__)
+        _assert_no_print_calls(source_path)
+
+
+# ---------------------------------------------------------------------------
+# trajectory_storage.py — logging instead of print (#1310)
+# ---------------------------------------------------------------------------
+
+
+class TestTrajectoryStorageLogging:
+    """trajectory_storage.py uses logging instead of print()."""
+
+    def test_module_has_logger(self):
+        """Module defines a module-level logger."""
+        from ergodic_insurance import trajectory_storage
+
+        assert hasattr(trajectory_storage, "logger")
+        assert isinstance(trajectory_storage.logger, logging.Logger)
+
+    def test_export_csv_logs_info(self, caplog, tmp_path):
+        """export_summaries_csv logs export count via logger."""
+        from ergodic_insurance.trajectory_storage import (
+            SimulationSummary,
+            StorageConfig,
+            TrajectoryStorage,
+        )
+
+        config = StorageConfig(storage_dir=str(tmp_path / "storage"), backend="memmap")
+        storage = TrajectoryStorage(config)
+
+        # Add a summary directly
+        storage._summaries[0] = SimulationSummary(
+            sim_id=0,
+            final_assets=100.0,
+            total_losses=10.0,
+            total_recoveries=5.0,
+            mean_annual_loss=1.0,
+            max_annual_loss=3.0,
+            min_annual_loss=0.1,
+            growth_rate=0.05,
+            ruin_occurred=False,
+        )
+
+        output_csv = str(tmp_path / "summaries.csv")
+        with caplog.at_level(logging.INFO, logger="ergodic_insurance.trajectory_storage"):
+            storage.export_summaries_csv(output_csv)
+
+        assert any("Exported" in r.message for r in caplog.records)
+
+    def test_no_print_in_source(self):
+        """trajectory_storage.py has zero print() calls in executable code."""
+        from ergodic_insurance import trajectory_storage
+
+        source_path = Path(trajectory_storage.__file__)
+        _assert_no_print_calls(source_path)
+
+
+# ---------------------------------------------------------------------------
+# bootstrap_analysis.py — logging instead of print (#1310)
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrapAnalysisLogging:
+    """bootstrap_analysis.py uses logging instead of print()."""
+
+    def test_module_has_logger(self):
+        """Module defines a module-level logger."""
+        from ergodic_insurance import bootstrap_analysis
+
+        assert hasattr(bootstrap_analysis, "logger")
+        assert isinstance(bootstrap_analysis.logger, logging.Logger)
+
+    def test_parallel_fallback_logs_warning(self, caplog):
+        """Parallel bootstrap fallback logs a warning, not a print."""
+        from ergodic_insurance.bootstrap_analysis import BootstrapAnalyzer
+
+        analyzer = BootstrapAnalyzer(n_bootstrap=100, seed=42, show_progress=False)
+
+        # Make _parallel_bootstrap always fail
+        with (
+            patch.object(
+                analyzer,
+                "_parallel_bootstrap",
+                side_effect=RuntimeError("pool error"),
+            ),
+            caplog.at_level(logging.WARNING, logger="ergodic_insurance.bootstrap_analysis"),
+        ):
+            result = analyzer.confidence_interval(
+                np.random.default_rng(42).normal(0, 1, 100),
+                np.mean,
+                parallel=True,
+            )
+
+        assert any("Parallel bootstrap failed" in r.message for r in caplog.records)
+        assert any(
+            r.levelno == logging.WARNING
+            for r in caplog.records
+            if "Parallel bootstrap failed" in r.message
+        )
+
+    def test_no_print_in_source(self):
+        """bootstrap_analysis.py has zero print() calls in executable code."""
+        from ergodic_insurance import bootstrap_analysis
+
+        source_path = Path(bootstrap_analysis.__file__)
+        _assert_no_print_calls(source_path)
+
+
+# ---------------------------------------------------------------------------
 # No remaining print("Warning: …") in package source
 # ---------------------------------------------------------------------------
+
+
+def _assert_no_print_calls(source_path: Path) -> None:
+    """Assert that a Python source file has zero print() calls in executable code.
+
+    Uses AST parsing to distinguish real print() calls from those in
+    docstrings and comments.
+    """
+    source = source_path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    violations = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
+            func = node.value.func
+            if isinstance(func, ast.Name) and func.id == "print":
+                violations.append(f"  line {node.lineno}: print() call")
+
+    assert violations == [], f"Found print() calls in {source_path.name}:\n" + "\n".join(violations)
 
 
 class TestNoBareWarningPrints:
@@ -209,7 +471,6 @@ class TestNoBareWarningPrints:
 
     def test_no_print_warnings_in_source(self):
         """Scan all .py source files for print('Warning: ...')."""
-        from pathlib import Path
         import re
 
         pkg_root = Path(__file__).resolve().parent.parent
@@ -229,3 +490,24 @@ class TestNoBareWarningPrints:
         assert violations == [], "Found bare print() warnings in package source:\n" + "\n".join(
             violations
         )
+
+    def test_no_print_in_issue_1310_modules(self):
+        """Modules listed in issue #1310 have zero print() calls."""
+        from ergodic_insurance import (
+            batch_processor,
+            bootstrap_analysis,
+            progress_monitor,
+            sensitivity,
+            trajectory_storage,
+        )
+
+        for module in (
+            progress_monitor,
+            batch_processor,
+            trajectory_storage,
+            sensitivity,
+            bootstrap_analysis,
+        ):
+            assert module.__file__ is not None
+            source_path = Path(module.__file__)
+            _assert_no_print_calls(source_path)

--- a/ergodic_insurance/trajectory_storage.py
+++ b/ergodic_insurance/trajectory_storage.py
@@ -35,6 +35,7 @@ Example:
 from dataclasses import dataclass
 import gc
 import json
+import logging
 from pathlib import Path
 import shutil
 from typing import Any, Dict, List, Optional
@@ -43,6 +44,8 @@ import warnings
 import h5py
 import numpy as np
 import pandas as pd
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -517,7 +520,7 @@ class TrajectoryStorage:
         if all_summaries:
             df = pd.DataFrame([s.to_dict() for s in all_summaries])
             df.to_csv(output_path, index=False)
-            print(f"Exported {len(all_summaries)} summaries to {output_path}")
+            logger.info("Exported %d summaries to %s", len(all_summaries), output_path)
 
     def export_summaries_json(self, output_path: str) -> None:
         """Export all summary statistics to JSON.
@@ -544,7 +547,7 @@ class TrajectoryStorage:
         # Write to JSON
         with open(output_path, "w") as f:
             json.dump(all_summaries, f, indent=2)
-        print(f"Exported {len(all_summaries)} summaries to {output_path}")
+        logger.info("Exported %d summaries to %s", len(all_summaries), output_path)
 
     def _persist_summaries(self) -> None:
         """Persist in-memory summaries to disk."""


### PR DESCRIPTION
## Summary
- Replace all print() calls with proper logging framework usage in progress_monitor.py, batch_processor.py, trajectory_storage.py, and bootstrap_analysis.py (sensitivity.py was already migrated)
- Add module-level loggers (logging.getLogger(__name__)) to all four affected modules
- Replace Unicode emoji characters (checkmark/cross) with ASCII-safe [OK]/[FAIL] alternatives
- Update all existing tests that captured stdout/patched builtins.print to use caplog log record assertions instead
- Add comprehensive logging compliance tests and an AST-based no-print scanner for all issue #1310 modules

### Logging level mapping
- Progress bar updates (frequent) -> logger.debug()
- Status/info messages (batch start, checkpoint, export) -> logger.info()
- Failure limit reached, parallel fallback -> logger.warning()
- Report generation errors -> logger.error()

### Files changed (production)
- progress_monitor.py: 13 print() calls removed
- batch_processor.py: 8 print() calls removed
- trajectory_storage.py: 2 print() calls removed
- bootstrap_analysis.py: 1 print() call removed

### Files changed (tests)
- tests/test_print_warnings_382.py: expanded with 4 new test classes + no-print scanner
- tests/test_progress_monitor.py: migrated stdout captures to caplog
- tests/test_progress_monitor_coverage.py: migrated builtins.print patches to caplog
- tests/test_bootstrap_analysis_coverage.py: migrated builtins.print patch to caplog

Closes #1310

## Test plan
- [x] All 30 tests in test_print_warnings_382.py pass (including new compliance tests)
- [x] All 286 related tests pass (progress_monitor, batch_processor, trajectory_storage, bootstrap keyword filter)
- [x] AST-based scanner confirms zero print() calls in all 5 issue #1310 modules
- [x] Pre-commit hooks pass (black, isort, mypy, pylint, conventional commit)
- [ ] CI pipeline passes