### PR TITLE
fix: rename coverage_limit to limit in run_analysis() and unify parameter naming (#1296)

### DIFF
--- a/ergodic_insurance/__init__.py
+++ b/ergodic_insurance/__init__.py
@@ -36,7 +36,7 @@ Examples:
             loss_frequency=2.5,
             loss_severity_mean=1_000_000,
             deductible=500_000,
-            coverage_limit=10_000_000,
+            limit=10_000_000,
             premium_rate=0.025,
         )
         print(results.summary())

--- a/ergodic_insurance/tests/integration/test_critical_integrations.py
+++ b/ergodic_insurance/tests/integration/test_critical_integrations.py
@@ -449,7 +449,7 @@ class TestOptimizationWorkflow:
         # Create optimization constraints
         constraints = DecisionOptimizationConstraints(
             max_premium_budget=500_000,
-            min_coverage_limit=2_000_000,
+            min_total_coverage=2_000_000,
             max_bankruptcy_probability=0.02,  # 2% ruin probability
         )
 

--- a/ergodic_insurance/tests/test_decision_engine.py
+++ b/ergodic_insurance/tests/test_decision_engine.py
@@ -28,8 +28,8 @@ class TestDecisionOptimizationConstraints:
         constraints = DecisionOptimizationConstraints()
 
         assert constraints.max_premium_budget == 1_000_000
-        assert constraints.min_coverage_limit == 5_000_000
-        assert constraints.max_coverage_limit == 100_000_000
+        assert constraints.min_total_coverage == 5_000_000
+        assert constraints.max_total_coverage == 100_000_000
         assert constraints.max_bankruptcy_probability == 0.01
         assert constraints.min_retained_limit == 100_000
         assert constraints.max_retained_limit == 10_000_000
@@ -41,12 +41,12 @@ class TestDecisionOptimizationConstraints:
         """Test custom constraint values."""
         constraints = DecisionOptimizationConstraints(
             max_premium_budget=2_000_000,
-            min_coverage_limit=10_000_000,
+            min_total_coverage=10_000_000,
             max_bankruptcy_probability=0.005,
         )
 
         assert constraints.max_premium_budget == 2_000_000
-        assert constraints.min_coverage_limit == 10_000_000
+        assert constraints.min_total_coverage == 10_000_000
         assert constraints.max_bankruptcy_probability == 0.005
 
     def test_enhanced_constraints(self):
@@ -552,8 +552,8 @@ class TestInsuranceDecisionEngine:
         """Test optimization using SLSQP method."""
         constraints = DecisionOptimizationConstraints(
             max_premium_budget=500_000,
-            min_coverage_limit=5_000_000,
-            max_coverage_limit=50_000_000,
+            min_total_coverage=5_000_000,
+            max_total_coverage=50_000_000,
         )
 
         decision = engine.optimize_insurance_decision(constraints, method=OptimizationMethod.SLSQP)
@@ -568,7 +568,7 @@ class TestInsuranceDecisionEngine:
         """Test optimization using differential evolution."""
         constraints = DecisionOptimizationConstraints(
             max_premium_budget=300_000,
-            min_coverage_limit=5_000_000,
+            min_total_coverage=5_000_000,
             max_layers=3,
         )
 
@@ -589,7 +589,7 @@ class TestInsuranceDecisionEngine:
         decision = engine.optimize_insurance_decision(constraints, weights=weights)
 
         assert isinstance(decision, InsuranceDecision)
-        assert decision.total_coverage >= constraints.min_coverage_limit
+        assert decision.total_coverage >= constraints.min_total_coverage
 
     def test_decision_caching(self, engine):
         """Test that decisions are cached."""
@@ -778,8 +778,8 @@ class TestInsuranceDecisionEngine:
         """Test decision validation against constraints."""
         constraints = DecisionOptimizationConstraints(
             max_premium_budget=50_000,
-            min_coverage_limit=5_000_000,
-            max_coverage_limit=20_000_000,
+            min_total_coverage=5_000_000,
+            max_total_coverage=20_000_000,
         )
 
         # Valid decision
@@ -914,8 +914,8 @@ class TestIntegration:
         # Define constraints
         constraints = DecisionOptimizationConstraints(
             max_premium_budget=500_000,
-            min_coverage_limit=5_000_000,
-            max_coverage_limit=50_000_000,
+            min_total_coverage=5_000_000,
+            max_total_coverage=50_000_000,
             max_bankruptcy_probability=0.01,
         )
 
@@ -939,7 +939,7 @@ class TestIntegration:
 
         # Verify decision quality
         assert decision.total_premium <= constraints.max_premium_budget
-        assert decision.total_coverage >= constraints.min_coverage_limit
+        assert decision.total_coverage >= constraints.min_total_coverage
         assert metrics.bankruptcy_probability <= constraints.max_bankruptcy_probability
 
     @pytest.mark.slow
@@ -962,7 +962,7 @@ class TestIntegration:
 
         constraints = DecisionOptimizationConstraints(
             max_premium_budget=400_000,
-            min_coverage_limit=5_000_000,
+            min_total_coverage=5_000_000,
         )
 
         decisions = {}
@@ -1034,8 +1034,8 @@ class TestEnhancedOptimizationMethods:
         """Test enhanced SLSQP optimization method."""
         constraints = DecisionOptimizationConstraints(
             max_premium_budget=500_000,
-            min_coverage_limit=5_000_000,
-            max_coverage_limit=20_000_000,
+            min_total_coverage=5_000_000,
+            max_total_coverage=20_000_000,
             max_layers=3,
         )
 
@@ -1047,9 +1047,9 @@ class TestEnhancedOptimizationMethods:
         assert decision.optimization_method == "enhanced_slsqp"
         assert decision.total_premium <= constraints.max_premium_budget
         assert (
-            constraints.min_coverage_limit
+            constraints.min_total_coverage
             <= decision.total_coverage
-            <= constraints.max_coverage_limit
+            <= constraints.max_total_coverage
         )
         assert len(decision.layers) <= constraints.max_layers
 
@@ -1058,8 +1058,8 @@ class TestEnhancedOptimizationMethods:
         """Test trust-region optimization method."""
         constraints = DecisionOptimizationConstraints(
             max_premium_budget=400_000,
-            min_coverage_limit=5_000_000,
-            max_coverage_limit=15_000_000,
+            min_total_coverage=5_000_000,
+            max_total_coverage=15_000_000,
             max_layers=2,
         )
 
@@ -1071,17 +1071,17 @@ class TestEnhancedOptimizationMethods:
         assert decision.optimization_method == "trust_region"
         assert decision.total_premium <= constraints.max_premium_budget
         assert (
-            constraints.min_coverage_limit
+            constraints.min_total_coverage
             <= decision.total_coverage
-            <= constraints.max_coverage_limit
+            <= constraints.max_total_coverage
         )
 
     def test_penalty_method_optimization(self, engine):
         """Test penalty method optimization."""
         constraints = DecisionOptimizationConstraints(
             max_premium_budget=300_000,
-            min_coverage_limit=4_000_000,
-            max_coverage_limit=12_000_000,
+            min_total_coverage=4_000_000,
+            max_total_coverage=12_000_000,
             max_bankruptcy_probability=0.02,
         )
 
@@ -1093,17 +1093,17 @@ class TestEnhancedOptimizationMethods:
         assert decision.optimization_method == "penalty_method"
         assert decision.total_premium <= constraints.max_premium_budget
         assert (
-            constraints.min_coverage_limit
+            constraints.min_total_coverage
             <= decision.total_coverage
-            <= constraints.max_coverage_limit
+            <= constraints.max_total_coverage
         )
 
     def test_augmented_lagrangian_optimization(self, engine):
         """Test augmented Lagrangian optimization."""
         constraints = DecisionOptimizationConstraints(
             max_premium_budget=450_000,
-            min_coverage_limit=6_000_000,
-            max_coverage_limit=18_000_000,
+            min_total_coverage=6_000_000,
+            max_total_coverage=18_000_000,
             max_layers=3,
         )
 
@@ -1115,17 +1115,17 @@ class TestEnhancedOptimizationMethods:
         assert decision.optimization_method == "augmented_lagrangian"
         assert decision.total_premium <= constraints.max_premium_budget
         assert (
-            constraints.min_coverage_limit
+            constraints.min_total_coverage
             <= decision.total_coverage
-            <= constraints.max_coverage_limit
+            <= constraints.max_total_coverage
         )
 
     def test_multi_start_optimization(self, engine):
         """Test multi-start global optimization."""
         constraints = DecisionOptimizationConstraints(
             max_premium_budget=500_000,
-            min_coverage_limit=5_000_000,
-            max_coverage_limit=20_000_000,
+            min_total_coverage=5_000_000,
+            max_total_coverage=20_000_000,
             max_layers=4,
         )
 
@@ -1137,17 +1137,17 @@ class TestEnhancedOptimizationMethods:
         assert decision.optimization_method == "multi_start"
         assert decision.total_premium <= constraints.max_premium_budget
         assert (
-            constraints.min_coverage_limit
+            constraints.min_total_coverage
             <= decision.total_coverage
-            <= constraints.max_coverage_limit
+            <= constraints.max_total_coverage
         )
 
     def test_enhanced_constraint_handling(self, engine):
         """Test the enhanced constraints (debt-to-equity, insurance cost ceiling, etc.)."""
         constraints = DecisionOptimizationConstraints(
             max_premium_budget=600_000,
-            min_coverage_limit=5_000_000,
-            max_coverage_limit=25_000_000,
+            min_total_coverage=5_000_000,
+            max_total_coverage=25_000_000,
             max_debt_to_equity=1.5,
             max_insurance_cost_ratio=0.025,  # 2.5% of revenue
             min_coverage_requirement=3_000_000,
@@ -1174,8 +1174,8 @@ class TestEnhancedOptimizationMethods:
         """Test that optimization methods provide convergence information."""
         constraints = DecisionOptimizationConstraints(
             max_premium_budget=400_000,
-            min_coverage_limit=5_000_000,
-            max_coverage_limit=15_000_000,
+            min_total_coverage=5_000_000,
+            max_total_coverage=15_000_000,
         )
 
         # Test with enhanced SLSQP (which should have convergence info)
@@ -1195,8 +1195,8 @@ class TestEnhancedOptimizationMethods:
         # Create moderately restrictive constraints
         constraints = DecisionOptimizationConstraints(
             max_premium_budget=100_000,  # Low but not impossible budget
-            min_coverage_limit=10_000_000,  # High coverage requirement
-            max_coverage_limit=20_000_000,
+            min_total_coverage=10_000_000,  # High coverage requirement
+            max_total_coverage=20_000_000,
             max_bankruptcy_probability=0.01,  # Strict but achievable risk constraint
         )
 
@@ -1978,10 +1978,10 @@ class TestOptimizeConvenience:
 
             engine.optimize(
                 max_premium=500_000,
-                min_coverage_limit=10_000_000,
+                min_total_coverage=10_000_000,
                 max_layers=3,
             )
 
             constraints = mock_opt.call_args[0][0]
-            assert constraints.min_coverage_limit == 10_000_000
+            assert constraints.min_total_coverage == 10_000_000
             assert constraints.max_layers == 3

--- a/ergodic_insurance/tests/test_decision_engine_edge_cases.py
+++ b/ergodic_insurance/tests/test_decision_engine_edge_cases.py
@@ -143,8 +143,8 @@ class TestWeightedSumOptimization:
         """Test explicit WEIGHTED_SUM optimization method."""
         constraints = DecisionOptimizationConstraints(
             max_premium_budget=400_000,
-            min_coverage_limit=5_000_000,
-            max_coverage_limit=15_000_000,
+            min_total_coverage=5_000_000,
+            max_total_coverage=15_000_000,
             max_layers=3,
         )
 
@@ -159,9 +159,9 @@ class TestWeightedSumOptimization:
         ]  # Uses SLSQP or weighted_sum
         assert decision.total_premium <= constraints.max_premium_budget
         assert (
-            constraints.min_coverage_limit
+            constraints.min_total_coverage
             <= decision.total_coverage
-            <= constraints.max_coverage_limit
+            <= constraints.max_total_coverage
         )
 
 
@@ -391,8 +391,8 @@ class TestDecisionValidationFailures:
     def test_validation_failure_coverage_below_minimum(self, engine):
         """Test validation when coverage is below minimum."""
         constraints = DecisionOptimizationConstraints(
-            min_coverage_limit=10_000_000,
-            max_coverage_limit=20_000_000,
+            min_total_coverage=10_000_000,
+            max_total_coverage=20_000_000,
         )
 
         decision = InsuranceDecision(
@@ -409,8 +409,8 @@ class TestDecisionValidationFailures:
     def test_validation_failure_coverage_above_maximum(self, engine):
         """Test validation when coverage exceeds maximum."""
         constraints = DecisionOptimizationConstraints(
-            min_coverage_limit=5_000_000,
-            max_coverage_limit=10_000_000,
+            min_total_coverage=5_000_000,
+            max_total_coverage=10_000_000,
         )
 
         decision = InsuranceDecision(
@@ -974,8 +974,8 @@ class TestDifferentialEvolutionPenalties:
     def test_differential_evolution_coverage_max_penalty(self, engine):
         """Test penalty when coverage exceeds maximum in differential evolution."""
         constraints = DecisionOptimizationConstraints(
-            max_coverage_limit=10_000_000,
-            min_coverage_limit=5_000_000,
+            max_total_coverage=10_000_000,
+            min_total_coverage=5_000_000,
             max_premium_budget=500_000,
         )
 
@@ -986,8 +986,8 @@ class TestDifferentialEvolutionPenalties:
         def track_objective(x, weights):
             calls_made.append(x.copy())
             # Force high coverage to trigger penalty
-            if len(x) > 0 and sum(x) > constraints.max_coverage_limit:
-                return 1000 * (sum(x) - constraints.max_coverage_limit)
+            if len(x) > 0 and sum(x) > constraints.max_total_coverage:
+                return 1000 * (sum(x) - constraints.max_total_coverage)
             return original_objective(x, weights)
 
         with patch.object(engine, "_calculate_objective", side_effect=track_objective):

--- a/ergodic_insurance/tests/test_decision_engine_scenarios.py
+++ b/ergodic_insurance/tests/test_decision_engine_scenarios.py
@@ -48,8 +48,8 @@ class TestRealWorldScenarios:
         # Startup constraints: limited budget, need basic coverage
         constraints = DecisionOptimizationConstraints(
             max_premium_budget=50_000,  # Limited budget
-            min_coverage_limit=500_000,  # Minimum viable coverage
-            max_coverage_limit=2_000_000,  # Don't over-insure
+            min_total_coverage=500_000,  # Minimum viable coverage
+            max_total_coverage=2_000_000,  # Don't over-insure
             max_bankruptcy_probability=0.05,  # Higher risk tolerance
             min_retained_limit=50_000,  # Low retention capability
             max_retained_limit=200_000,
@@ -67,7 +67,7 @@ class TestRealWorldScenarios:
 
         # Verify appropriate for startup
         assert decision.total_premium <= constraints.max_premium_budget
-        assert decision.total_coverage >= constraints.min_coverage_limit
+        assert decision.total_coverage >= constraints.min_total_coverage
         assert len(decision.layers) <= 2  # Simple structure
         assert metrics.bankruptcy_probability <= 0.05
         assert metrics.capital_efficiency > 0  # Should add value
@@ -98,8 +98,8 @@ class TestRealWorldScenarios:
         # Corporation constraints: comprehensive coverage, low risk
         constraints = DecisionOptimizationConstraints(
             max_premium_budget=5_000_000,  # Substantial budget
-            min_coverage_limit=50_000_000,  # High coverage needs
-            max_coverage_limit=200_000_000,
+            min_total_coverage=50_000_000,  # High coverage needs
+            max_total_coverage=200_000_000,
             max_bankruptcy_probability=0.001,  # Very low risk tolerance
             min_retained_limit=1_000_000,  # Can retain more
             max_retained_limit=10_000_000,
@@ -146,8 +146,8 @@ class TestRealWorldScenarios:
         # High-risk constraints: need extensive coverage
         constraints = DecisionOptimizationConstraints(
             max_premium_budget=2_000_000,  # Higher budget needed
-            min_coverage_limit=20_000_000,  # Regulatory requirements
-            max_coverage_limit=100_000_000,
+            min_total_coverage=20_000_000,  # Regulatory requirements
+            max_total_coverage=100_000_000,
             max_bankruptcy_probability=0.005,  # Slightly higher tolerance
             min_retained_limit=500_000,
             max_retained_limit=5_000_000,
@@ -197,8 +197,8 @@ class TestRealWorldScenarios:
         # Downturn constraints: limited budget, essential coverage only
         constraints = DecisionOptimizationConstraints(
             max_premium_budget=200_000,  # Tight budget
-            min_coverage_limit=5_000_000,  # Minimum essential coverage
-            max_coverage_limit=20_000_000,
+            min_total_coverage=5_000_000,  # Minimum essential coverage
+            max_total_coverage=20_000_000,
             max_bankruptcy_probability=0.02,  # Accept higher risk
             min_retained_limit=200_000,
             max_retained_limit=2_000_000,
@@ -263,8 +263,8 @@ class TestMultiYearOptimizationScenarios:
             # Adjust constraints as company grows
             constraints = DecisionOptimizationConstraints(
                 max_premium_budget=100_000 * (year + 1),  # Increasing budget
-                min_coverage_limit=2_000_000 * (year + 1),  # Increasing coverage needs
-                max_coverage_limit=10_000_000 * (year + 1),
+                min_total_coverage=2_000_000 * (year + 1),  # Increasing coverage needs
+                max_total_coverage=10_000_000 * (year + 1),
                 max_bankruptcy_probability=0.01,
                 min_retained_limit=100_000 * (year + 1),
                 max_retained_limit=1_000_000 * (year + 1),
@@ -300,8 +300,8 @@ class TestMultiYearOptimizationScenarios:
         # Same constraints for comparison
         constraints = DecisionOptimizationConstraints(
             max_premium_budget=500_000,
-            min_coverage_limit=10_000_000,
-            max_coverage_limit=30_000_000,
+            min_total_coverage=10_000_000,
+            max_total_coverage=30_000_000,
             max_bankruptcy_probability=0.01,
         )
 
@@ -357,8 +357,8 @@ class TestRegulatoryComplianceScenarios:
         # Regulatory requirements
         constraints = DecisionOptimizationConstraints(
             max_premium_budget=400_000,
-            min_coverage_limit=15_000_000,  # Total minimum
-            max_coverage_limit=50_000_000,
+            min_total_coverage=15_000_000,  # Total minimum
+            max_total_coverage=50_000_000,
             max_bankruptcy_probability=0.01,
             min_coverage_requirement=10_000_000,  # Minimum from insurance (not retention)
             max_retention_limit=2_000_000,  # Regulatory cap on retention
@@ -372,7 +372,7 @@ class TestRegulatoryComplianceScenarios:
         assert decision.retained_limit <= constraints.max_retention_limit
         coverage_from_insurance = sum(layer.limit for layer in decision.layers)
         assert coverage_from_insurance >= constraints.min_coverage_requirement
-        assert decision.total_coverage >= constraints.min_coverage_limit
+        assert decision.total_coverage >= constraints.min_total_coverage
 
     @pytest.mark.filterwarnings("ignore:delta_grad == 0.0:UserWarning")
     def test_debt_covenant_compliance(self):
@@ -398,8 +398,8 @@ class TestRegulatoryComplianceScenarios:
         # Debt covenant requirements
         constraints = DecisionOptimizationConstraints(
             max_premium_budget=600_000,
-            min_coverage_limit=20_000_000,
-            max_coverage_limit=60_000_000,
+            min_total_coverage=20_000_000,
+            max_total_coverage=60_000_000,
             max_bankruptcy_probability=0.005,  # Lender requirement
             max_debt_to_equity=1.2,  # Debt covenant
             max_insurance_cost_ratio=0.025,  # Cost limitation
@@ -454,8 +454,8 @@ class TestCatastrophicEventScenarios:
         # Focus on catastrophic protection
         constraints = DecisionOptimizationConstraints(
             max_premium_budget=1_000_000,
-            min_coverage_limit=30_000_000,  # High limit for catastrophes
-            max_coverage_limit=100_000_000,
+            min_total_coverage=30_000_000,  # High limit for catastrophes
+            max_total_coverage=100_000_000,
             max_bankruptcy_probability=0.002,  # Very low tolerance
             min_retained_limit=1_000_000,  # Retain frequency losses
             max_retained_limit=5_000_000,
@@ -501,8 +501,8 @@ class TestCatastrophicEventScenarios:
         # Business interruption considerations
         constraints = DecisionOptimizationConstraints(
             max_premium_budget=800_000,
-            min_coverage_limit=25_000_000,  # Include BI coverage
-            max_coverage_limit=75_000_000,
+            min_total_coverage=25_000_000,  # Include BI coverage
+            max_total_coverage=75_000_000,
             max_bankruptcy_probability=0.005,
             min_retained_limit=500_000,
             max_retained_limit=3_000_000,
@@ -558,8 +558,8 @@ class TestPortfolioOptimizationScenarios:
         # Portfolio optimization constraints
         constraints = DecisionOptimizationConstraints(
             max_premium_budget=1_500_000,
-            min_coverage_limit=40_000_000,
-            max_coverage_limit=150_000_000,
+            min_total_coverage=40_000_000,
+            max_total_coverage=150_000_000,
             max_bankruptcy_probability=0.003,
             min_retained_limit=2_000_000,  # Benefit from diversification
             max_retained_limit=10_000_000,
@@ -602,8 +602,8 @@ class TestSensitivityAnalysisScenarios:
         # Base decision
         constraints = DecisionOptimizationConstraints(
             max_premium_budget=500_000,
-            min_coverage_limit=10_000_000,
-            max_coverage_limit=30_000_000,
+            min_total_coverage=10_000_000,
+            max_total_coverage=30_000_000,
         )
 
         base_decision = engine.optimize_insurance_decision(constraints)


### PR DESCRIPTION
## Summary
- Renames `coverage_limit` to `limit` in `run_analysis()` to match `InsuranceProgram.simple(limit=...)`, eliminating naming confusion across the quick-start API
- Renames `min_coverage_limit`/`max_coverage_limit` to `min_total_coverage`/`max_total_coverage` in `DecisionOptimizationConstraints` to distinguish total program coverage bounds from per-occurrence layer limits
- Old parameter names emit `DeprecationWarning` and continue to work as aliases

## Test plan
- [x] All 51 `test_run_analysis.py` tests pass (including 3 new deprecation tests)
- [x] All 80 `test_decision_engine.py` tests pass
- [x] All 34 `test_decision_engine_edge_cases.py` tests pass
- [x] All 12 `test_decision_engine_scenarios.py` tests pass
- [x] 29/31 integration tests pass (2 pre-existing perf timeout failures unrelated to this PR)
- [x] Pre-commit hooks pass (black, isort, mypy, pylint, conventional commit)

Closes #1296