### PR TITLE
fix(ci): skip unknown commits in changelog templates to prevent ParseError crash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,6 +243,11 @@ changelog_file = "CHANGELOG.md"
 template_dir = "templates"
 mode = "update"
 insertion_flag = "<!-- next-version -->"
+exclude_commit_patterns = [
+    '''Merge pull request .*''',
+    '''Merge branch .*''',
+    '''chore\(release\).*''',
+]
 
 [tool.semantic_release.remote]
 type = "github"

--- a/templates/.release_notes.md.j2
+++ b/templates/.release_notes.md.j2
@@ -3,7 +3,8 @@
   Keep a Changelog style with PSR v9 LONG_TYPE_NAMES.
 #}{%- set ns = namespace(added=[], changed=[], fixed=[])
 %}{%  for type, commits in release["elements"].items()
-%}{%    if type == "features"
+%}{%    if type == "unknown"
+%}{%    elif type == "features"
 %}{%      set ns.added = ns.added + commits
 %}{%    elif type == "bug fixes"
 %}{%      set ns.fixed = ns.fixed + commits

--- a/templates/CHANGELOG.md.j2
+++ b/templates/CHANGELOG.md.j2
@@ -9,7 +9,8 @@
 #}{%- macro render_sections(release)
 %}{%  set ns = namespace(added=[], changed=[], fixed=[])
 %}{%  for type, commits in release["elements"].items()
-%}{%    if type == "features"
+%}{%    if type == "unknown"
+%}{%    elif type == "features"
 %}{%      set ns.added = ns.added + commits
 %}{%    elif type == "bug fixes"
 %}{%      set ns.fixed = ns.fixed + commits


### PR DESCRIPTION
## Summary
- Skip `"unknown"` type commits in changelog/release-notes templates to avoid accessing `.descriptions` on `ParseError` objects
- Add `exclude_commit_patterns` to filter merge commits and release commits from changelog context

## Root cause
The regular merge from develop exposed the full git history (including early non-conventional commits like `docs`, `Merge branch...`) to semantic-release. The custom changelog templates tried to access `.descriptions` on `ParseError` objects from these unparseable commits, crashing the release.

Ref: [python-semantic-release#1019](https://github.com/python-semantic-release/python-semantic-release/issues/1019)

## Important: Merge Strategy
**Use "Create a merge commit" — do NOT squash.**

## Test plan
- [ ] Verify release workflow completes without ParseError
- [ ] Verify publish job succeeds and package appears on PyPI